### PR TITLE
Scaffold Phases 1–3: workspace, Discord OIDC auth, and Matrix provisioning

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,24 @@
+# Shared defaults
+NEXT_PUBLIC_CONTROL_PLANE_URL=http://localhost:4000
+APP_BASE_URL=http://localhost:4000
+WEB_BASE_URL=http://localhost:3000
+
+# Control-plane persistence
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/escapehatch
+SESSION_SECRET=replace-me
+
+# Discord OIDC (primary provider)
+OIDC_DISCORD_CLIENT_ID=
+OIDC_DISCORD_CLIENT_SECRET=
+OIDC_DISCORD_AUTHORIZE_URL=https://discord.com/api/oauth2/authorize
+OIDC_DISCORD_TOKEN_URL=https://discord.com/api/oauth2/token
+OIDC_DISCORD_USERINFO_URL=https://discord.com/api/users/@me
+
+# Optional Keycloak broker (future expansion)
+OIDC_KEYCLOAK_ISSUER=http://localhost:8080/realms/escapehatch
+OIDC_KEYCLOAK_CLIENT_ID=escapehatch-web
+OIDC_KEYCLOAK_CLIENT_SECRET=
+
+# Synapse provisioning
+SYNAPSE_BASE_URL=http://localhost:8008
+SYNAPSE_ACCESS_TOKEN=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm lint
+      - run: pnpm typecheck
+      - run: pnpm build

--- a/README.md
+++ b/README.md
@@ -1,108 +1,42 @@
 # EscapeHatch
 
-EscapeHatch is the bootstrap monorepo for the **Creator Co-Op Hub Chat Platform**: a Matrix-based, Discord-like community product for creator collectives.
+EscapeHatch is the monorepo for the **Creator Co-Op Hub Chat Platform**: a Matrix-based, Discord-like community product for creator collectives.
 
-This repository turns the root spec into a runnable foundation with:
-- a hosted web client shell,
-- a control-plane API scaffold,
-- shared domain contracts,
-- local infrastructure composition for Matrix + voice + identity primitives.
+## Phase progress snapshot
 
-## Spec-first goals
-
-The architecture target comes from:
-- `creator_co_op_hub_chat_platform_project_spec_reference_architecture.md`
-
-Current scaffolding is designed to support the first milestones:
-1. Hub bootstrap,
-2. Discord semantics mapping,
-3. Moderation and voice integration foundations.
+This repository now includes sequential scaffolding for **Phases 1–3** from `TODO.md`:
+- **Phase 1:** hardened workspace scripts, env templates, package architecture docs, CI workflow, and smoke tests.
+- **Phase 2:** Discord-first OIDC auth flow scaffolding, control-plane auth middleware, identity mapping model, and session lifecycle endpoints.
+- **Phase 3:** versioned provisioning APIs (`/v1/servers`, `/v1/channels`), PostgreSQL persistence, Matrix adapter hooks, idempotency, and retries.
 
 ## Repository layout
 
 ```text
 .
 ├── apps/
-│   ├── control-plane/      # Fastify + TypeScript control-plane API scaffold
+│   ├── control-plane/      # Fastify control-plane API + provisioning/auth workflows
 │   └── web/                # Next.js hosted client shell
 ├── packages/
-│   └── shared/             # Shared platform contracts/types
-├── docker/
-│   └── synapse/            # Synapse data/config mount point
+│   └── shared/             # Shared auth + domain contracts
+├── .github/workflows/ci.yml
 ├── docker-compose.yml      # Local infra: Postgres, Synapse, Keycloak, LiveKit, coturn
-├── AGENTS.md               # Contributor/agent instructions
 └── creator_co_op_hub_chat_platform_project_spec_reference_architecture.md
 ```
 
-## Framework instantiations
-
-### Web client (`apps/web`)
-- **Next.js 14 + React 18**
-- Initial Discord-like layout shell:
-  - server rail,
-  - channel rail,
-  - main timeline panel.
-- Dependencies included for Matrix SDK integration.
-
-### Control plane (`apps/control-plane`)
-- **Fastify 5 + TypeScript + Zod**
-- Bootstrap endpoints:
-  - `GET /health`
-  - `GET /bootstrap/default-server`
-  - `POST /bootstrap/channel`
-- Uses shared contracts from `@escapehatch/shared`.
-
-### Shared contracts (`packages/shared`)
-- Core role/channel typing
-- Default server blueprint contract used by control-plane
-
-### Infra composition (`docker-compose.yml`)
-- **PostgreSQL**
-- **Synapse**
-- **Keycloak**
-- **LiveKit**
-- **coturn**
-
-This is a pragmatic local bootstrap, not a production deployment profile.
-
 ## Quick start
-
-### 1) Install dependencies
 
 ```bash
 pnpm install
-```
-
-### 2) Start app development services
-
-```bash
+cp .env.example .env
 pnpm dev
 ```
 
 - Web: http://localhost:3000
 - Control plane: http://localhost:4000/health
 
-### 3) (Optional) Start platform infrastructure
+## Validation commands
 
 ```bash
-docker compose up -d
-```
-
-## Next glue-up targets
-
-Near-term implementation tasks:
-- Wire OIDC login flow between web client, Keycloak, and Synapse.
-- Add control-plane persistence (PostgreSQL) and mapping tables for server/channel ↔ Matrix IDs.
-- Add Matrix room/space provisioning adapters behind control-plane routes.
-- Add SFU token issuance flow and voice channel binding to `sfu_room_id`.
-- Begin creator-scoped moderation action APIs and audit logging.
-
-## Development commands
-
-At repo root:
-
-```bash
-pnpm dev
 pnpm lint
 pnpm typecheck
 pnpm build

--- a/apps/control-plane/.env.example
+++ b/apps/control-plane/.env.example
@@ -1,0 +1,15 @@
+PORT=4000
+APP_BASE_URL=http://localhost:4000
+WEB_BASE_URL=http://localhost:3000
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/escapehatch
+SESSION_SECRET=replace-me
+OIDC_DISCORD_CLIENT_ID=
+OIDC_DISCORD_CLIENT_SECRET=
+OIDC_DISCORD_AUTHORIZE_URL=https://discord.com/api/oauth2/authorize
+OIDC_DISCORD_TOKEN_URL=https://discord.com/api/oauth2/token
+OIDC_DISCORD_USERINFO_URL=https://discord.com/api/users/@me
+OIDC_KEYCLOAK_ISSUER=http://localhost:8080/realms/escapehatch
+OIDC_KEYCLOAK_CLIENT_ID=escapehatch-web
+OIDC_KEYCLOAK_CLIENT_SECRET=
+SYNAPSE_BASE_URL=http://localhost:8008
+SYNAPSE_ACCESS_TOKEN=

--- a/apps/control-plane/README.md
+++ b/apps/control-plane/README.md
@@ -1,0 +1,17 @@
+# Control Plane Architecture
+
+## Ownership boundary
+- Policy gate for privileged hub/server/channel operations.
+- Identity/session source for web client auth context.
+- Provisioning orchestrator for Matrix entities (space/room mappings).
+
+## Extension points
+- `src/routes`: HTTP surface (versioned domain APIs).
+- `src/services`: workflow logic, retries, idempotency handling.
+- `src/matrix`: Synapse integration adapter.
+- `src/auth`: OIDC/session middleware and auth lifecycle.
+- `src/db`: persistence bootstrapping and storage access.
+
+## Milestone alignment
+- Milestone 0: Discord-first OIDC auth scaffolding + identity mapping.
+- Milestone 1: server/channel provisioning through `/v1/servers` + `/v1/channels`.

--- a/apps/control-plane/package.json
+++ b/apps/control-plane/package.json
@@ -7,20 +7,22 @@
     "dev": "tsx watch src/index.ts",
     "build": "tsc --project tsconfig.json",
     "start": "node dist/index.js",
-    "lint": "echo \"No control-plane lint config yet\"",
+    "lint": "tsc --project tsconfig.json --noEmit",
     "typecheck": "tsc --project tsconfig.json --noEmit",
-    "test": "echo \"No control-plane tests yet\""
+    "test": "tsx --test src/test/*.test.ts"
   },
   "dependencies": {
     "@escapehatch/shared": "workspace:*",
     "@fastify/cors": "^10.0.2",
     "@fastify/sensible": "^6.0.2",
     "fastify": "^5.1.0",
-    "zod": "^3.24.1"
+    "zod": "^3.24.1",
+    "pg": "^8.13.1"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",
     "tsx": "^4.19.2",
-    "typescript": "^5.7.2"
+    "typescript": "^5.7.2",
+    "@types/pg": "^8.11.10"
   }
 }

--- a/apps/control-plane/src/app.ts
+++ b/apps/control-plane/src/app.ts
@@ -1,0 +1,14 @@
+import Fastify from "fastify";
+import cors from "@fastify/cors";
+import sensible from "@fastify/sensible";
+import { registerAuthRoutes } from "./routes/auth-routes.js";
+import { registerDomainRoutes } from "./routes/domain-routes.js";
+
+export async function buildApp() {
+  const app = Fastify({ logger: false });
+  await app.register(cors, { origin: true, credentials: true });
+  await app.register(sensible);
+  await registerAuthRoutes(app);
+  await registerDomainRoutes(app);
+  return app;
+}

--- a/apps/control-plane/src/auth/middleware.ts
+++ b/apps/control-plane/src/auth/middleware.ts
@@ -1,0 +1,28 @@
+import type { FastifyReply, FastifyRequest } from "fastify";
+import { getSession } from "./session.js";
+
+export interface ScopedAuthContext {
+  productUserId: string;
+  provider: string;
+  oidcSubject: string;
+}
+
+declare module "fastify" {
+  interface FastifyRequest {
+    auth?: ScopedAuthContext;
+  }
+}
+
+export async function requireAuth(request: FastifyRequest, reply: FastifyReply): Promise<void> {
+  const session = getSession(request);
+  if (!session) {
+    reply.code(401).send({ message: "Unauthorized" });
+    return;
+  }
+
+  request.auth = {
+    productUserId: session.productUserId,
+    provider: session.provider,
+    oidcSubject: session.oidcSubject
+  };
+}

--- a/apps/control-plane/src/auth/oidc.ts
+++ b/apps/control-plane/src/auth/oidc.ts
@@ -1,0 +1,90 @@
+import crypto from "node:crypto";
+import { config } from "../config.js";
+import type { IdentityProvider } from "@escapehatch/shared";
+
+const inMemoryState = new Map<string, { provider: IdentityProvider; verifier: string }>();
+
+export function createAuthorizationRedirect(provider: IdentityProvider): string {
+  if (provider !== "discord") {
+    throw new Error("Only Discord provider is enabled in current milestone.");
+  }
+
+  if (!config.oidc.discordClientId) {
+    throw new Error("OIDC_DISCORD_CLIENT_ID is not set.");
+  }
+
+  const state = crypto.randomBytes(16).toString("hex");
+  const verifier = crypto.randomBytes(32).toString("base64url");
+  const challenge = crypto.createHash("sha256").update(verifier).digest("base64url");
+
+  inMemoryState.set(state, { provider, verifier });
+
+  const redirectUri = `${config.appBaseUrl}/auth/callback/discord`;
+  const query = new URLSearchParams({
+    client_id: config.oidc.discordClientId,
+    redirect_uri: redirectUri,
+    response_type: "code",
+    scope: "identify email",
+    state,
+    code_challenge: challenge,
+    code_challenge_method: "S256",
+    prompt: "consent"
+  });
+
+  return `${config.oidc.discordAuthorizeUrl}?${query.toString()}`;
+}
+
+interface ExchangeTokenInput {
+  code: string;
+  state: string;
+}
+
+interface DiscordProfile {
+  id: string;
+  email?: string;
+  username?: string;
+  avatar?: string;
+}
+
+export async function exchangeDiscordCode({ code, state }: ExchangeTokenInput): Promise<DiscordProfile> {
+  const stateEntry = inMemoryState.get(state);
+  if (!stateEntry) {
+    throw new Error("Invalid OIDC state.");
+  }
+
+  inMemoryState.delete(state);
+
+  if (!config.oidc.discordClientId || !config.oidc.discordClientSecret) {
+    throw new Error("Discord OIDC client credentials are missing.");
+  }
+
+  const redirectUri = `${config.appBaseUrl}/auth/callback/discord`;
+
+  const tokenResponse = await fetch(config.oidc.discordTokenUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      client_id: config.oidc.discordClientId,
+      client_secret: config.oidc.discordClientSecret,
+      grant_type: "authorization_code",
+      code,
+      redirect_uri: redirectUri,
+      code_verifier: stateEntry.verifier
+    })
+  });
+
+  if (!tokenResponse.ok) {
+    throw new Error(`Token exchange failed with status ${tokenResponse.status}`);
+  }
+
+  const tokenJson = (await tokenResponse.json()) as { access_token: string };
+  const userResponse = await fetch(config.oidc.discordUserInfoUrl, {
+    headers: { Authorization: `Bearer ${tokenJson.access_token}` }
+  });
+
+  if (!userResponse.ok) {
+    throw new Error(`Unable to load Discord profile (${userResponse.status})`);
+  }
+
+  return (await userResponse.json()) as DiscordProfile;
+}

--- a/apps/control-plane/src/auth/session.ts
+++ b/apps/control-plane/src/auth/session.ts
@@ -1,0 +1,73 @@
+import crypto from "node:crypto";
+import type { FastifyReply, FastifyRequest } from "fastify";
+import { config } from "../config.js";
+
+interface SessionPayload {
+  productUserId: string;
+  provider: string;
+  oidcSubject: string;
+  expiresAt: number;
+}
+
+function sign(payload: SessionPayload): string {
+  const encoded = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  const signature = crypto
+    .createHmac("sha256", config.sessionSecret)
+    .update(encoded)
+    .digest("base64url");
+  return `${encoded}.${signature}`;
+}
+
+function verify(token: string): SessionPayload | null {
+  const [encoded, signature] = token.split(".");
+  if (!encoded || !signature) {
+    return null;
+  }
+
+  const expected = crypto
+    .createHmac("sha256", config.sessionSecret)
+    .update(encoded)
+    .digest("base64url");
+
+  if (expected !== signature) {
+    return null;
+  }
+
+  const decoded = JSON.parse(Buffer.from(encoded, "base64url").toString("utf8")) as SessionPayload;
+  if (Date.now() > decoded.expiresAt) {
+    return null;
+  }
+
+  return decoded;
+}
+
+export function setSessionCookie(reply: FastifyReply, payload: Omit<SessionPayload, "expiresAt">): void {
+  const expiresAt = Date.now() + 1000 * 60 * 60;
+  const token = sign({ ...payload, expiresAt });
+  reply.header(
+    "Set-Cookie",
+    `escapehatch_session=${token}; Path=/; HttpOnly; SameSite=Lax; Max-Age=3600`
+  );
+}
+
+export function clearSessionCookie(reply: FastifyReply): void {
+  reply.header("Set-Cookie", "escapehatch_session=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0");
+}
+
+export function getSession(request: FastifyRequest): SessionPayload | null {
+  const cookieHeader = request.headers.cookie;
+  if (!cookieHeader) {
+    return null;
+  }
+
+  const raw = cookieHeader
+    .split(";")
+    .map((part) => part.trim())
+    .find((part) => part.startsWith("escapehatch_session="));
+
+  if (!raw) {
+    return null;
+  }
+
+  return verify(raw.replace("escapehatch_session=", ""));
+}

--- a/apps/control-plane/src/config.ts
+++ b/apps/control-plane/src/config.ts
@@ -1,0 +1,22 @@
+export const config = {
+  port: Number(process.env.PORT ?? "4000"),
+  appBaseUrl: process.env.APP_BASE_URL ?? "http://localhost:4000",
+  webBaseUrl: process.env.WEB_BASE_URL ?? "http://localhost:3000",
+  databaseUrl: process.env.DATABASE_URL,
+  sessionSecret: process.env.SESSION_SECRET ?? "dev-insecure-session-secret",
+  oidc: {
+    keycloakIssuer: process.env.OIDC_KEYCLOAK_ISSUER,
+    keycloakClientId: process.env.OIDC_KEYCLOAK_CLIENT_ID,
+    keycloakClientSecret: process.env.OIDC_KEYCLOAK_CLIENT_SECRET,
+    discordClientId: process.env.OIDC_DISCORD_CLIENT_ID,
+    discordClientSecret: process.env.OIDC_DISCORD_CLIENT_SECRET,
+    discordAuthorizeUrl:
+      process.env.OIDC_DISCORD_AUTHORIZE_URL ?? "https://discord.com/api/oauth2/authorize",
+    discordTokenUrl: process.env.OIDC_DISCORD_TOKEN_URL ?? "https://discord.com/api/oauth2/token",
+    discordUserInfoUrl: process.env.OIDC_DISCORD_USERINFO_URL ?? "https://discord.com/api/users/@me"
+  },
+  synapse: {
+    baseUrl: process.env.SYNAPSE_BASE_URL,
+    accessToken: process.env.SYNAPSE_ACCESS_TOKEN
+  }
+};

--- a/apps/control-plane/src/db/client.ts
+++ b/apps/control-plane/src/db/client.ts
@@ -1,0 +1,77 @@
+import { Pool } from "pg";
+import { config } from "../config.js";
+
+export const pool = config.databaseUrl
+  ? new Pool({ connectionString: config.databaseUrl })
+  : null;
+
+export async function withDb<T>(fn: (db: Pool) => Promise<T>): Promise<T> {
+  if (!pool) {
+    throw new Error("DATABASE_URL must be configured for persistence-backed APIs.");
+  }
+
+  return fn(pool);
+}
+
+export async function initDb(): Promise<void> {
+  if (!pool) {
+    return;
+  }
+
+  await pool.query(`
+    create table if not exists identity_mappings (
+      id text primary key,
+      provider text not null,
+      oidc_subject text not null,
+      email text,
+      preferred_username text,
+      avatar_url text,
+      matrix_user_id text,
+      product_user_id text not null,
+      created_at timestamptz not null default now(),
+      updated_at timestamptz not null default now(),
+      unique(provider, oidc_subject)
+    );
+
+    create table if not exists hubs (
+      id text primary key,
+      name text not null,
+      owner_user_id text not null,
+      created_at timestamptz not null default now()
+    );
+
+    create table if not exists servers (
+      id text primary key,
+      hub_id text not null references hubs(id),
+      name text not null,
+      matrix_space_id text,
+      created_by_user_id text not null,
+      created_at timestamptz not null default now()
+    );
+
+    create table if not exists categories (
+      id text primary key,
+      server_id text not null references servers(id),
+      name text not null,
+      matrix_subspace_id text,
+      created_at timestamptz not null default now()
+    );
+
+    create table if not exists channels (
+      id text primary key,
+      server_id text not null references servers(id),
+      category_id text references categories(id),
+      name text not null,
+      type text not null,
+      matrix_room_id text,
+      created_at timestamptz not null default now()
+    );
+
+    create table if not exists idempotency_keys (
+      idempotency_key text primary key,
+      request_hash text not null,
+      response_json jsonb not null,
+      created_at timestamptz not null default now()
+    );
+  `);
+}

--- a/apps/control-plane/src/index.ts
+++ b/apps/control-plane/src/index.ts
@@ -1,42 +1,11 @@
-import Fastify from "fastify";
-import cors from "@fastify/cors";
-import sensible from "@fastify/sensible";
-import { z } from "zod";
-import { DEFAULT_SERVER_BLUEPRINT } from "@escapehatch/shared";
+import { buildApp } from "./app.js";
+import { config } from "./config.js";
+import { initDb } from "./db/client.js";
 
-const app = Fastify({ logger: true });
+const app = await buildApp();
+await initDb();
 
-await app.register(cors, { origin: true });
-await app.register(sensible);
-
-app.get("/health", async () => {
-  return { status: "ok", service: "control-plane" };
-});
-
-app.get("/bootstrap/default-server", async () => {
-  return DEFAULT_SERVER_BLUEPRINT;
-});
-
-app.post("/bootstrap/channel", async (request, reply) => {
-  const schema = z.object({
-    serverId: z.string().min(1),
-    channelName: z.string().min(1),
-    type: z.enum(["text", "voice", "announcement"])
-  });
-
-  const payload = schema.parse(request.body);
-
-  reply.status(201);
-  return {
-    id: `ch_${Date.now()}`,
-    ...payload,
-    provisionStatus: "queued"
-  };
-});
-
-const port = Number(process.env.PORT ?? "4000");
-
-app.listen({ port, host: "0.0.0.0" }).catch((error) => {
+app.listen({ port: config.port, host: "0.0.0.0" }).catch((error) => {
   app.log.error(error);
   process.exit(1);
 });

--- a/apps/control-plane/src/matrix/synapse-adapter.ts
+++ b/apps/control-plane/src/matrix/synapse-adapter.ts
@@ -1,0 +1,101 @@
+import { config } from "../config.js";
+import type { ChannelType } from "@escapehatch/shared";
+
+interface CreateSpaceInput {
+  name: string;
+}
+
+interface CreateRoomInput {
+  name: string;
+  type: ChannelType;
+}
+
+async function synapseRequest<T>(path: string, body: Record<string, unknown>): Promise<T | null> {
+  if (!config.synapse.baseUrl || !config.synapse.accessToken) {
+    return null;
+  }
+
+  const response = await fetch(`${config.synapse.baseUrl}${path}`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${config.synapse.accessToken}`,
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify(body)
+  });
+
+  if (!response.ok) {
+    throw new Error(`Synapse request failed: ${response.status}`);
+  }
+
+  return (await response.json()) as T;
+}
+
+export async function createSpace(input: CreateSpaceInput): Promise<string | null> {
+  const response = await synapseRequest<{ room_id: string }>("/_matrix/client/v3/createRoom", {
+    name: input.name,
+    creation_content: { type: "m.space" },
+    preset: "private_chat",
+    power_level_content_override: { users_default: 0 },
+    initial_state: [
+      {
+        type: "m.room.history_visibility",
+        state_key: "",
+        content: { history_visibility: "joined" }
+      },
+      {
+        type: "m.room.join_rules",
+        state_key: "",
+        content: { join_rule: "invite" }
+      }
+    ]
+  });
+
+  return response?.room_id ?? null;
+}
+
+export async function createChannelRoom(input: CreateRoomInput): Promise<string | null> {
+  const response = await synapseRequest<{ room_id: string }>("/_matrix/client/v3/createRoom", {
+    name: input.name,
+    topic: `${input.type} channel provisioned by control-plane`,
+    preset: "private_chat",
+    initial_state: [
+      {
+        type: "m.room.history_visibility",
+        state_key: "",
+        content: { history_visibility: "joined" }
+      },
+      {
+        type: "m.room.join_rules",
+        state_key: "",
+        content: { join_rule: "invite" }
+      }
+    ]
+  });
+
+  return response?.room_id ?? null;
+}
+
+export async function attachChildRoom(spaceId: string, childRoomId: string): Promise<void> {
+  if (!config.synapse.baseUrl || !config.synapse.accessToken) {
+    return;
+  }
+
+  const response = await fetch(
+    `${config.synapse.baseUrl}/_matrix/client/v3/rooms/${encodeURIComponent(
+      spaceId
+    )}/state/m.space.child/${encodeURIComponent(childRoomId)}`,
+    {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${config.synapse.accessToken}`,
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({ via: [new URL(config.synapse.baseUrl).hostname] })
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(`Failed to attach child room to space (${response.status})`);
+  }
+}

--- a/apps/control-plane/src/routes/auth-routes.ts
+++ b/apps/control-plane/src/routes/auth-routes.ts
@@ -1,0 +1,92 @@
+import type { FastifyInstance } from "fastify";
+import { z } from "zod";
+import { createAuthorizationRedirect, exchangeDiscordCode } from "../auth/oidc.js";
+import { clearSessionCookie, setSessionCookie } from "../auth/session.js";
+import { getIdentityByProductUserId, upsertIdentityMapping } from "../services/identity-service.js";
+import { requireAuth } from "../auth/middleware.js";
+import type { AccountLinkingRequirement, IdentityProvider } from "@escapehatch/shared";
+import { config } from "../config.js";
+
+const providerSchema = z.enum(["discord", "keycloak", "google", "github"]);
+
+export async function registerAuthRoutes(app: FastifyInstance): Promise<void> {
+  app.get("/auth/providers", async () => {
+    const providers: AccountLinkingRequirement[] = [
+      {
+        provider: "discord",
+        displayName: "Discord",
+        isEnabled: Boolean(config.oidc.discordClientId),
+        requiresReauthentication: false
+      },
+      {
+        provider: "google",
+        displayName: "Google",
+        isEnabled: false,
+        requiresReauthentication: true
+      },
+      {
+        provider: "github",
+        displayName: "GitHub",
+        isEnabled: false,
+        requiresReauthentication: true
+      }
+    ];
+    return { primaryProvider: "discord", providers };
+  });
+
+  app.get("/auth/login/:provider", async (request, reply) => {
+    const { provider } = z.object({ provider: providerSchema }).parse(request.params);
+    const redirect = createAuthorizationRedirect(provider as IdentityProvider);
+    reply.redirect(redirect, 302);
+  });
+
+  app.get("/auth/callback/discord", async (request, reply) => {
+    const query = z.object({ code: z.string(), state: z.string() }).parse(request.query);
+    const profile = await exchangeDiscordCode(query);
+
+    const identity = await upsertIdentityMapping({
+      provider: "discord",
+      oidcSubject: profile.id,
+      email: profile.email ?? null,
+      preferredUsername: profile.username ?? null,
+      avatarUrl: profile.avatar
+        ? `https://cdn.discordapp.com/avatars/${profile.id}/${profile.avatar}.png`
+        : null
+    });
+
+    setSessionCookie(reply, {
+      productUserId: identity.productUserId,
+      provider: identity.provider,
+      oidcSubject: identity.oidcSubject
+    });
+
+    reply.redirect(`${config.webBaseUrl}?auth=success`, 302);
+  });
+
+  app.get("/auth/session/me", { preHandler: requireAuth }, async (request) => {
+    const auth = request.auth;
+    if (!auth) {
+      throw new Error("Auth context missing");
+    }
+
+    const identity = await getIdentityByProductUserId(auth.productUserId);
+    return {
+      productUserId: auth.productUserId,
+      identity: identity
+        ? {
+            provider: identity.provider,
+            oidcSubject: identity.oidcSubject,
+            email: identity.email,
+            preferredUsername: identity.preferredUsername,
+            avatarUrl: identity.avatarUrl,
+            matrixUserId: identity.matrixUserId
+          }
+        : null
+    };
+  });
+
+  app.post("/auth/logout", async (_, reply) => {
+    clearSessionCookie(reply);
+    reply.code(204).send();
+  });
+}

--- a/apps/control-plane/src/routes/domain-routes.ts
+++ b/apps/control-plane/src/routes/domain-routes.ts
@@ -1,0 +1,54 @@
+import type { FastifyInstance } from "fastify";
+import { z } from "zod";
+import { requireAuth } from "../auth/middleware.js";
+import { createChannelWorkflow, createServerWorkflow } from "../services/provisioning-service.js";
+import { DEFAULT_SERVER_BLUEPRINT } from "@escapehatch/shared";
+
+export async function registerDomainRoutes(app: FastifyInstance): Promise<void> {
+  app.get("/health", async () => {
+    return { status: "ok", service: "control-plane" };
+  });
+
+  app.get("/bootstrap/default-server", async () => {
+    return DEFAULT_SERVER_BLUEPRINT;
+  });
+
+  app.post("/v1/servers", { preHandler: requireAuth }, async (request, reply) => {
+    const payload = z
+      .object({
+        hubId: z.string().min(1),
+        name: z.string().min(2).max(80)
+      })
+      .parse(request.body);
+
+    const idempotencyKey = request.headers["idempotency-key"];
+    const server = await createServerWorkflow({
+      ...payload,
+      productUserId: request.auth!.productUserId,
+      idempotencyKey: typeof idempotencyKey === "string" ? idempotencyKey : undefined
+    });
+
+    reply.code(201);
+    return server;
+  });
+
+  app.post("/v1/channels", { preHandler: requireAuth }, async (request, reply) => {
+    const payload = z
+      .object({
+        serverId: z.string().min(1),
+        categoryId: z.string().optional(),
+        name: z.string().min(2).max(80),
+        type: z.enum(["text", "voice", "announcement"])
+      })
+      .parse(request.body);
+
+    const idempotencyKey = request.headers["idempotency-key"];
+    const channel = await createChannelWorkflow({
+      ...payload,
+      idempotencyKey: typeof idempotencyKey === "string" ? idempotencyKey : undefined
+    });
+
+    reply.code(201);
+    return channel;
+  });
+}

--- a/apps/control-plane/src/services/identity-service.ts
+++ b/apps/control-plane/src/services/identity-service.ts
@@ -1,0 +1,110 @@
+import crypto from "node:crypto";
+import type { IdentityMapping } from "@escapehatch/shared";
+import { withDb } from "../db/client.js";
+
+function randomId(prefix: string): string {
+  return `${prefix}_${crypto.randomUUID().replaceAll("-", "")}`;
+}
+
+function mapRow(result: {
+  id: string;
+  provider: IdentityMapping["provider"];
+  oidc_subject: string;
+  email: string | null;
+  preferred_username: string | null;
+  avatar_url: string | null;
+  matrix_user_id: string | null;
+  product_user_id: string;
+  created_at: string;
+  updated_at: string;
+}): IdentityMapping {
+  return {
+    id: result.id,
+    provider: result.provider,
+    oidcSubject: result.oidc_subject,
+    email: result.email,
+    preferredUsername: result.preferred_username,
+    avatarUrl: result.avatar_url,
+    matrixUserId: result.matrix_user_id,
+    productUserId: result.product_user_id,
+    createdAt: result.created_at,
+    updatedAt: result.updated_at
+  };
+}
+
+export async function upsertIdentityMapping(input: {
+  provider: IdentityMapping["provider"];
+  oidcSubject: string;
+  email: string | null;
+  preferredUsername: string | null;
+  avatarUrl: string | null;
+}): Promise<IdentityMapping> {
+  return withDb(async (db) => {
+    const existing = await db.query<{ id: string; product_user_id: string }>(
+      "select id, product_user_id from identity_mappings where provider = $1 and oidc_subject = $2 limit 1",
+      [input.provider, input.oidcSubject]
+    );
+
+    const existingRow = existing.rows[0];
+    const id = existingRow?.id ?? randomId("idm");
+    const productUserId = existingRow?.product_user_id ?? randomId("usr");
+
+    await db.query(
+      `insert into identity_mappings
+      (id, provider, oidc_subject, email, preferred_username, avatar_url, matrix_user_id, product_user_id)
+      values ($1,$2,$3,$4,$5,$6,$7,$8)
+      on conflict (provider, oidc_subject)
+      do update set
+        email = excluded.email,
+        preferred_username = excluded.preferred_username,
+        avatar_url = excluded.avatar_url,
+        updated_at = now()`,
+      [id, input.provider, input.oidcSubject, input.email, input.preferredUsername, input.avatarUrl, null, productUserId]
+    );
+
+    const row = await db.query<{
+      id: string;
+      provider: IdentityMapping["provider"];
+      oidc_subject: string;
+      email: string | null;
+      preferred_username: string | null;
+      avatar_url: string | null;
+      matrix_user_id: string | null;
+      product_user_id: string;
+      created_at: string;
+      updated_at: string;
+    }>("select * from identity_mappings where provider = $1 and oidc_subject = $2", [
+      input.provider,
+      input.oidcSubject
+    ]);
+
+    const result = row.rows[0];
+    if (!result) {
+      throw new Error("Identity mapping upsert failed.");
+    }
+
+    return mapRow(result);
+  });
+}
+
+export async function getIdentityByProductUserId(productUserId: string): Promise<IdentityMapping | null> {
+  return withDb(async (db) => {
+    const row = await db.query<{
+      id: string;
+      provider: IdentityMapping["provider"];
+      oidc_subject: string;
+      email: string | null;
+      preferred_username: string | null;
+      avatar_url: string | null;
+      matrix_user_id: string | null;
+      product_user_id: string;
+      created_at: string;
+      updated_at: string;
+    }>("select * from identity_mappings where product_user_id = $1 order by created_at asc limit 1", [
+      productUserId
+    ]);
+
+    const result = row.rows[0];
+    return result ? mapRow(result) : null;
+  });
+}

--- a/apps/control-plane/src/services/provisioning-service.ts
+++ b/apps/control-plane/src/services/provisioning-service.ts
@@ -1,0 +1,168 @@
+import crypto from "node:crypto";
+import type { Channel, ChannelType, Server } from "@escapehatch/shared";
+import { withDb } from "../db/client.js";
+import { attachChildRoom, createChannelRoom, createSpace } from "../matrix/synapse-adapter.js";
+import { withRetry } from "./retry.js";
+
+function randomId(prefix: string): string {
+  return `${prefix}_${crypto.randomUUID().replaceAll("-", "")}`;
+}
+
+function hashRequest(payload: unknown): string {
+  return crypto.createHash("sha256").update(JSON.stringify(payload)).digest("hex");
+}
+
+async function checkIdempotency<T>(
+  idempotencyKey: string | undefined,
+  payload: unknown
+): Promise<T | null> {
+  if (!idempotencyKey) {
+    return null;
+  }
+
+  return withDb(async (db) => {
+    const requestHash = hashRequest(payload);
+    const row = await db.query<{ request_hash: string; response_json: T }>(
+      "select request_hash, response_json from idempotency_keys where idempotency_key = $1 limit 1",
+      [idempotencyKey]
+    );
+
+    const existing = row.rows[0];
+    if (!existing) {
+      return null;
+    }
+
+    if (existing.request_hash !== requestHash) {
+      throw new Error("Idempotency key reuse with different payload is not allowed.");
+    }
+
+    return existing.response_json;
+  });
+}
+
+async function storeIdempotency<T>(idempotencyKey: string | undefined, payload: unknown, response: T): Promise<void> {
+  if (!idempotencyKey) {
+    return;
+  }
+
+  await withDb(async (db) => {
+    await db.query(
+      "insert into idempotency_keys (idempotency_key, request_hash, response_json) values ($1, $2, $3) on conflict (idempotency_key) do nothing",
+      [idempotencyKey, hashRequest(payload), JSON.stringify(response)]
+    );
+  });
+}
+
+export async function createServerWorkflow(input: {
+  hubId: string;
+  name: string;
+  productUserId: string;
+  idempotencyKey?: string;
+}): Promise<Server> {
+  const cached = await checkIdempotency<Server>(input.idempotencyKey, input);
+  if (cached) {
+    return cached;
+  }
+
+  const matrixSpaceId = await withRetry(() => createSpace({ name: input.name }));
+
+  const server = await withDb(async (db) => {
+    const id = randomId("srv");
+    const row = await db.query<{
+      id: string;
+      hub_id: string;
+      name: string;
+      matrix_space_id: string | null;
+      created_by_user_id: string;
+      created_at: string;
+    }>(
+      `insert into servers (id, hub_id, name, matrix_space_id, created_by_user_id)
+       values ($1, $2, $3, $4, $5)
+       returning *`,
+      [id, input.hubId, input.name, matrixSpaceId, input.productUserId]
+    );
+
+    const value = row.rows[0];
+    if (!value) {
+      throw new Error("Server creation failed.");
+    }
+
+    return {
+      id: value.id,
+      hubId: value.hub_id,
+      name: value.name,
+      matrixSpaceId: value.matrix_space_id,
+      createdByUserId: value.created_by_user_id,
+      createdAt: value.created_at
+    };
+  });
+
+  await storeIdempotency(input.idempotencyKey, input, server);
+  return server;
+}
+
+export async function createChannelWorkflow(input: {
+  serverId: string;
+  categoryId?: string;
+  name: string;
+  type: ChannelType;
+  idempotencyKey?: string;
+}): Promise<Channel> {
+  const cached = await checkIdempotency<Channel>(input.idempotencyKey, input);
+  if (cached) {
+    return cached;
+  }
+
+  const matrixRoomId = await withRetry(() => createChannelRoom({ name: input.name, type: input.type }));
+
+  const channel = await withDb(async (db) => {
+    const row = await db.query<{ matrix_space_id: string | null }>(
+      "select matrix_space_id from servers where id = $1 limit 1",
+      [input.serverId]
+    );
+
+    const server = row.rows[0];
+    if (!server) {
+      throw new Error("Server not found.");
+    }
+
+    const id = randomId("chn");
+    const created = await db.query<{
+      id: string;
+      server_id: string;
+      category_id: string | null;
+      name: string;
+      type: ChannelType;
+      matrix_room_id: string | null;
+      created_at: string;
+    }>(
+      `insert into channels (id, server_id, category_id, name, type, matrix_room_id)
+       values ($1, $2, $3, $4, $5, $6)
+       returning *`,
+      [id, input.serverId, input.categoryId ?? null, input.name, input.type, matrixRoomId]
+    );
+
+    const value = created.rows[0];
+    if (!value) {
+      throw new Error("Channel creation failed.");
+    }
+
+    const matrixSpaceId = server.matrix_space_id;
+    if (matrixSpaceId && matrixRoomId) {
+      await withRetry(() => attachChildRoom(matrixSpaceId, matrixRoomId));
+    }
+
+    return {
+      id: value.id,
+      serverId: value.server_id,
+      categoryId: value.category_id,
+      name: value.name,
+      type: value.type,
+      matrixRoomId: value.matrix_room_id,
+      createdAt: value.created_at
+    };
+  });
+
+  await storeIdempotency(input.idempotencyKey, input, channel);
+  return channel;
+}

--- a/apps/control-plane/src/services/retry.ts
+++ b/apps/control-plane/src/services/retry.ts
@@ -1,0 +1,16 @@
+export async function withRetry<T>(fn: () => Promise<T>, retries = 2): Promise<T> {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= retries; attempt += 1) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+      if (attempt < retries) {
+        await new Promise((resolve) => setTimeout(resolve, 200 * (attempt + 1)));
+      }
+    }
+  }
+
+  throw lastError;
+}

--- a/apps/control-plane/src/test/smoke.test.ts
+++ b/apps/control-plane/src/test/smoke.test.ts
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { buildApp } from "../app.js";
+
+test("health endpoint returns ok", async () => {
+  const app = await buildApp();
+  const response = await app.inject({ method: "GET", url: "/health" });
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(response.json(), { status: "ok", service: "control-plane" });
+  await app.close();
+});
+
+test("providers endpoint exposes discord as primary", async () => {
+  const app = await buildApp();
+  const response = await app.inject({ method: "GET", url: "/auth/providers" });
+  assert.equal(response.statusCode, 200);
+  const json = response.json();
+  assert.equal(json.primaryProvider, "discord");
+  await app.close();
+});

--- a/apps/control-plane/tsconfig.json
+++ b/apps/control-plane/tsconfig.json
@@ -2,7 +2,12 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "types": [
+      "node"
+    ]
   },
-  "include": ["src/**/*.ts"]
+  "include": [
+    "src/**/*.ts"
+  ]
 }

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_CONTROL_PLANE_URL=http://localhost:4000

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,0 +1,15 @@
+# Web App Architecture
+
+## Ownership boundary
+- Hosted product shell and UX for creator co-op collaboration.
+- Presents auth entrypoints and viewer session state from control-plane.
+- Remains free of privileged direct Synapse admin operations.
+
+## Extension points
+- `app/`: route-level composition and data loading.
+- `components/`: Discord-like shell, future timeline/moderation widgets.
+- `lib/`: control-plane API client helpers and typed DTO adapters.
+
+## Milestone alignment
+- Milestone 0: social-login-first UX (`Sign in with Discord`).
+- Milestone 1: consume server/channel domain APIs when channel management UI lands.

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,5 +1,7 @@
 import { AppShell } from "../components/app-shell";
+import { discordLoginUrl, fetchViewerSession } from "../lib/control-plane";
 
-export default function HomePage() {
-  return <AppShell />;
+export default async function HomePage() {
+  const viewer = await fetchViewerSession();
+  return <AppShell viewer={viewer} loginUrl={discordLoginUrl()} />;
 }

--- a/apps/web/components/app-shell.tsx
+++ b/apps/web/components/app-shell.tsx
@@ -1,7 +1,17 @@
+import Link from "next/link";
+import type { ViewerSession } from "../lib/control-plane";
+
 const creatorServers = ["Creator HQ", "Art Guild", "Mod Room"];
 const channels = ["#announcements", "#general", "#voice-lounge"];
 
-export function AppShell() {
+interface AppShellProps {
+  viewer: ViewerSession | null;
+  loginUrl: string;
+}
+
+export function AppShell({ viewer, loginUrl }: AppShellProps) {
+  const username = viewer?.identity?.preferredUsername ?? "Guest";
+
   return (
     <main className="shell">
       <aside className="server-rail">
@@ -22,10 +32,12 @@ export function AppShell() {
       </aside>
       <section className="timeline">
         <h1>EscapeHatch Boilerplate Ready</h1>
-        <p>
-          This shell gives us a Discord-style layout to begin integrating Matrix timelines,
-          role-aware moderation controls, and SFU voice presence.
-        </p>
+        <p>Signed in as: {username}</p>
+        {!viewer ? (
+          <Link href={loginUrl}>Sign in with Discord</Link>
+        ) : (
+          <p>Session established with control-plane identity mapping.</p>
+        )}
       </section>
     </main>
   );

--- a/apps/web/lib/control-plane.ts
+++ b/apps/web/lib/control-plane.ts
@@ -1,0 +1,31 @@
+const controlPlaneBaseUrl = process.env.NEXT_PUBLIC_CONTROL_PLANE_URL ?? "http://localhost:4000";
+
+export interface ViewerSession {
+  productUserId: string;
+  identity: {
+    provider: string;
+    preferredUsername: string | null;
+    email: string | null;
+  } | null;
+}
+
+export async function fetchViewerSession(): Promise<ViewerSession | null> {
+  try {
+    const response = await fetch(`${controlPlaneBaseUrl}/auth/session/me`, {
+      credentials: "include",
+      cache: "no-store"
+    });
+
+    if (!response.ok) {
+      return null;
+    }
+
+    return (await response.json()) as ViewerSession;
+  } catch {
+    return null;
+  }
+}
+
+export function discordLoginUrl(): string {
+  return `${controlPlaneBaseUrl}/auth/login/discord`;
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --project tsconfig.json --noEmit",
-    "test": "echo \"No web tests yet\""
+    "test": "node --test"
   },
   "dependencies": {
     "@escapehatch/shared": "workspace:*",

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -1,0 +1,13 @@
+# Shared Contracts Architecture
+
+## Ownership boundary
+- Home of cross-app domain contracts and auth/session DTOs.
+- Any entity exchanged across `apps/web` and `apps/control-plane` belongs here.
+
+## Extension points
+- `src/domain`: hub/server/category/channel contracts and provisioning payloads.
+- `src/auth`: identity mapping/session/account-linking contracts.
+
+## Milestone alignment
+- Supports Milestone 0 identity mapping evolution without schema rewrites.
+- Supports Milestone 1 provisioning APIs with stable typed contracts.

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -10,11 +10,13 @@
   },
   "scripts": {
     "build": "tsc --project tsconfig.json",
-    "lint": "echo \"No shared lint config yet\"",
+    "lint": "tsc --project tsconfig.json --noEmit",
     "typecheck": "tsc --project tsconfig.json --noEmit",
-    "test": "echo \"No shared tests yet\""
+    "test": "tsx --test src/test/*.test.ts"
   },
   "devDependencies": {
-    "typescript": "^5.7.2"
+    "typescript": "^5.7.2",
+    "tsx": "^4.19.2",
+    "@types/node": "^22.10.2"
   }
 }

--- a/packages/shared/src/auth/contracts.ts
+++ b/packages/shared/src/auth/contracts.ts
@@ -1,0 +1,36 @@
+export type IdentityProvider = "discord" | "keycloak" | "google" | "github";
+
+export interface IdentityMapping {
+  id: string;
+  provider: IdentityProvider;
+  oidcSubject: string;
+  email: string | null;
+  preferredUsername: string | null;
+  avatarUrl: string | null;
+  matrixUserId: string | null;
+  productUserId: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ProductSession {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: number;
+  provider: IdentityProvider;
+}
+
+export interface AuthenticatedViewer {
+  productUserId: string;
+  identity: Pick<
+    IdentityMapping,
+    "provider" | "oidcSubject" | "email" | "preferredUsername" | "avatarUrl" | "matrixUserId"
+  >;
+}
+
+export interface AccountLinkingRequirement {
+  provider: IdentityProvider;
+  displayName: string;
+  isEnabled: boolean;
+  requiresReauthentication: boolean;
+}

--- a/packages/shared/src/domain/contracts.ts
+++ b/packages/shared/src/domain/contracts.ts
@@ -1,0 +1,73 @@
+export type Role = "hub_operator" | "creator_admin" | "creator_moderator" | "member";
+
+export type ChannelType = "text" | "voice" | "announcement";
+
+export interface ServerBlueprint {
+  serverName: string;
+  defaultChannels: Array<{
+    name: string;
+    type: ChannelType;
+  }>;
+}
+
+export interface Hub {
+  id: string;
+  name: string;
+  ownerUserId: string;
+  createdAt: string;
+}
+
+export interface Server {
+  id: string;
+  hubId: string;
+  name: string;
+  matrixSpaceId: string | null;
+  createdByUserId: string;
+  createdAt: string;
+}
+
+export interface Category {
+  id: string;
+  serverId: string;
+  name: string;
+  matrixSubspaceId: string | null;
+  createdAt: string;
+}
+
+export interface Channel {
+  id: string;
+  serverId: string;
+  categoryId: string | null;
+  name: string;
+  type: ChannelType;
+  matrixRoomId: string | null;
+  createdAt: string;
+}
+
+export interface MatrixProvisioningDefaults {
+  joinRule: "invite" | "public";
+  historyVisibility: "joined" | "invited" | "shared" | "world_readable";
+}
+
+export interface CreateServerRequest {
+  hubId: string;
+  name: string;
+  idempotencyKey?: string;
+}
+
+export interface CreateChannelRequest {
+  serverId: string;
+  categoryId?: string;
+  name: string;
+  type: ChannelType;
+  idempotencyKey?: string;
+}
+
+export const DEFAULT_SERVER_BLUEPRINT: ServerBlueprint = {
+  serverName: "New Creator Server",
+  defaultChannels: [
+    { name: "announcements", type: "announcement" },
+    { name: "general", type: "text" },
+    { name: "voice-lounge", type: "voice" }
+  ]
+};

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,20 +1,2 @@
-export type Role = "hub_operator" | "creator_admin" | "creator_moderator" | "member";
-
-export type ChannelType = "text" | "voice" | "announcement";
-
-export interface ServerBlueprint {
-  serverName: string;
-  defaultChannels: Array<{
-    name: string;
-    type: ChannelType;
-  }>;
-}
-
-export const DEFAULT_SERVER_BLUEPRINT: ServerBlueprint = {
-  serverName: "New Creator Server",
-  defaultChannels: [
-    { name: "announcements", type: "announcement" },
-    { name: "general", type: "text" },
-    { name: "voice-lounge", type: "voice" }
-  ]
-};
+export * from "./domain/contracts.js";
+export * from "./auth/contracts.js";

--- a/packages/shared/src/test/contracts.test.ts
+++ b/packages/shared/src/test/contracts.test.ts
@@ -1,0 +1,8 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { DEFAULT_SERVER_BLUEPRINT } from "../index.js";
+
+test("default server blueprint includes required channels", () => {
+  const names = DEFAULT_SERVER_BLUEPRINT.defaultChannels.map((channel) => channel.name);
+  assert.deepEqual(names, ["announcements", "general", "voice-lounge"]);
+});

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -3,7 +3,12 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "src",
-    "declaration": true
+    "declaration": true,
+    "types": [
+      "node"
+    ]
   },
-  "include": ["src/**/*.ts"]
+  "include": [
+    "src/**/*.ts"
+  ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,9 @@ importers:
       fastify:
         specifier: ^5.1.0
         version: 5.7.4
+      pg:
+        specifier: ^8.13.1
+        version: 8.18.0
       zod:
         specifier: ^3.24.1
         version: 3.25.76
@@ -29,6 +32,9 @@ importers:
       '@types/node':
         specifier: ^22.10.2
         version: 22.19.11
+      '@types/pg':
+        specifier: ^8.11.10
+        version: 8.16.0
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
@@ -78,6 +84,12 @@ importers:
 
   packages/shared:
     devDependencies:
+      '@types/node':
+        specifier: ^22.10.2
+        version: 22.19.11
+      tsx:
+        specifier: ^4.19.2
+        version: 4.21.0
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -429,6 +441,9 @@ packages:
 
   '@types/node@22.19.11':
     resolution: {integrity: sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==}
+
+  '@types/pg@8.16.0':
+    resolution: {integrity: sha512-RmhMd/wD+CF8Dfo+cVIy3RR5cl8CyfXQ0tGgW6XBL8L4LM/UTEbNXYRbLwU6w+CgrKBNbrQWt4FUtTfaU5jSYQ==}
 
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
@@ -1570,6 +1585,40 @@ packages:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
 
+  pg-cloudflare@1.3.0:
+    resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
+
+  pg-connection-string@2.11.0:
+    resolution: {integrity: sha512-kecgoJwhOpxYU21rZjULrmrBJ698U2RxXofKVzOn5UDj61BPj/qMb7diYUR1nLScCDbrztQFl1TaQZT0t1EtzQ==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.11.0:
+    resolution: {integrity: sha512-MJYfvHwtGp870aeusDh+hg9apvOe2zmpZJpyt+BMtzUWlVqbhFmMK6bOBXLBUPd7iRtIF9fZplDc7KrPN3PN7w==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.11.0:
+    resolution: {integrity: sha512-pfsxk2M9M3BuGgDOfuy37VNRRX3jmKgMjcvAcWqNDpZSf4cUmv8HSOl5ViRQFsfARFn0KuUQTgLxVMbNq5NW3g==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.18.0:
+    resolution: {integrity: sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -1594,6 +1643,22 @@ packages:
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -1988,6 +2053,10 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -2261,6 +2330,12 @@ snapshots:
   '@types/node@22.19.11':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/pg@8.16.0':
+    dependencies:
+      '@types/node': 22.19.11
+      pg-protocol: 1.11.0
+      pg-types: 2.2.0
 
   '@types/prop-types@15.7.15': {}
 
@@ -3627,6 +3702,41 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.2
 
+  pg-cloudflare@1.3.0:
+    optional: true
+
+  pg-connection-string@2.11.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.11.0(pg@8.18.0):
+    dependencies:
+      pg: 8.18.0
+
+  pg-protocol@1.11.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.18.0:
+    dependencies:
+      pg-connection-string: 2.11.0
+      pg-pool: 3.11.0(pg@8.18.0)
+      pg-protocol: 1.11.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.3.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
   picocolors@1.1.1: {}
 
   picomatch@4.0.3: {}
@@ -3658,6 +3768,16 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
 
   prelude-ls@1.2.1: {}
 
@@ -4131,6 +4251,8 @@ snapshots:
       strip-ansi: 7.1.2
 
   wrappy@1.0.2: {}
+
+  xtend@4.0.2: {}
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
### Motivation
- Provide an incremental, runnable foundation for Phases 1–3 in the project roadmap so contributors can lint/typecheck/build/test and iterate reliably. 
- Establish an OIDC-first auth surface (Discord primary) and a control-plane identity mapping to enable future provider expansion and Matrix provisioning. 
- Replace bootstrap mock endpoints with versioned domain APIs and add persistence, idempotency, and retry handling to prepare for real Synapse orchestration. 

### Description
- Standardized workspace scripts and CI, added `.env.example` templates, and added per-app README docs and a CI workflow to run `lint`, `typecheck`, and `build`. 
- Added Discord-first OIDC scaffolding including `auth/login` redirect, token exchange, signed session cookie helpers, `requireAuth` middleware, and identity mapping services. 
- Introduced shared domain/auth contracts in `packages/shared`, PostgreSQL persistence initialization and schema (`identity_mappings`, `hubs`, `servers`, `categories`, `channels`, `idempotency_keys`), and a minimal DB client wrapper. 
- Implemented Matrix/Synapse adapter hooks and provisioning workflows with idempotency and `withRetry`, and exposed versioned domain routes `POST /v1/servers` and `POST /v1/channels`. 
- Updated the web shell to surface viewer session state and a `Sign in with Discord` entrypoint, and added initial smoke/unit tests for shared contracts and control-plane endpoints. 

### Testing
- Ran `pnpm lint` and the workspace TypeScript checks which completed successfully. 
- Ran `pnpm typecheck` which completed successfully. 
- Ran `pnpm build` (including Next.js build) which completed successfully. 
- Ran `pnpm test` which executed the new unit/smoke tests for `packages/shared` and `apps/control-plane` and passed. 
- Attempted an automated Playwright screenshot of the web homepage which failed due to a Chromium runtime crash in this environment (SIGSEGV) and produced no artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e60c80b188330abe70e642e44d206)