### PR TITLE
test(web): add #21 regression for settings-page theme persistence

### DIFF
--- a/.agent-shared/handoffs/chat-log.md
+++ b/.agent-shared/handoffs/chat-log.md
@@ -30,3 +30,16 @@ plus 3 rows of `zombieTwerk` whose name was never seeded into
 146/146 unit + 29/29 E2E green. See
 `implementation-reports/2026-05-02-1730-phase-27-items-1-through-6.md`
 for the full report. Next agent: either.
+
+## 2026-05-03T17:06Z — claude-code
+Issue #21 (Settings menu theme persistence) — verified the Phase 27
+FOUC guard in `apps/web/hooks/use-theme.ts` already fixes it. Added a
+Playwright regression in `e2e/ui-regressions.spec.ts` that seeds
+`localStorage.theme=dark`, navigates to `/settings`, reloads, and
+asserts via `MutationObserver` that `data-theme` only ever holds
+`"dark"` (no FOUC flash to light). Sensitivity-checked by removing
+the guard, rebuilding `web`, watching it fail, then restoring. All
+4 ui-regressions pass; 9/9 web unit pass; typecheck clean. Branch
+`fix/issue-21-settings-theme`, report at
+`implementation-reports/2026-05-03-1706-issue-21-settings-theme.md`.
+Next agent: either.

--- a/.agent-shared/handoffs/current-plan.md
+++ b/.agent-shared/handoffs/current-plan.md
@@ -1,9 +1,19 @@
 ---
 created_by: claude-code
-last_updated: 2026-05-02
+last_updated: 2026-05-03T17:06:00Z
 next_agent: either
 status: complete
 ---
+
+> **Note (2026-05-03):** Issue #21 (Settings menu theme persistence)
+> verified fixed on the current build. The Phase 27 FOUC guard
+> (`fe54478`) already addresses it; this turn added a Playwright
+> regression test that exercises the literal repro (seed
+> `localStorage.theme=dark`, navigate to `/settings`, reload, assert no
+> flash to light) so the path stays covered. Branch
+> `fix/issue-21-settings-theme`, report at
+> `implementation-reports/2026-05-03-1706-issue-21-settings-theme.md`.
+> No active plan is in flight.
 
 > **Note (2026-05-02):** Phase 27 merged via PR #37 (`edfb91e`). A
 > follow-up fix for Issue #22 (Discord Bridge OAuth scroll/state

--- a/.agent-shared/handoffs/implementation-reports/2026-05-03-1706-issue-21-settings-theme.md
+++ b/.agent-shared/handoffs/implementation-reports/2026-05-03-1706-issue-21-settings-theme.md
@@ -1,0 +1,80 @@
+# Issue #21 — Settings Menu Does Not Maintain Theme
+
+## What changed
+
+- `apps/web/e2e/ui-regressions.spec.ts` — added a new Playwright regression
+  test, `#21: theme persists when refreshing the settings page`, and a
+  matching entry in the file's docblock.
+- No production source changes. The underlying defect was already addressed
+  by the FOUC guard introduced in `fe54478` (Phase 27 Item 1) in
+  `apps/web/hooks/use-theme.ts`. Verified by removing the guard, rebuilding
+  the test stack, and watching the new test fail with
+  `data-theme transitions: ["dark","light","dark"]` — then re-adding the
+  guard and watching it pass.
+
+## Why
+
+Issue #21 reported that refreshing inside `/settings` reverted the page to
+light mode regardless of the user's preference. The owner flagged
+`fe54478` as a likely fix candidate but asked for confirmation via the
+original repro path before closing.
+
+## Root-cause recap
+
+`useTheme` runs through the root layout's `<AppInitializer>`, which mounts
+on every route including `/settings`. Without the FOUC guard, Effect 2 fires
+on first render with the reducer's default `theme="light"` — overwriting the
+DOM's correctly-applied `data-theme="dark"` (set by `<ThemeScript>`) and
+clobbering `localStorage` to `"light"` in the same tick. The viewer's
+identity-level preference eventually rehydrates the dark state, but the user
+sees a flash and, in cases where the DB has no theme persisted, the choice
+is lost permanently.
+
+The `if (!hasAppliedRef.current) { ...skip if DOM already non-light... }`
+block in `apps/web/hooks/use-theme.ts:41-46` blocks that initial
+overwrite and lets Effect 1 dispatch the correct state before Effect 2
+applies it.
+
+## Tests
+
+- **Added:** Playwright E2E test seeds `localStorage.theme = 'dark'` via
+  `addInitScript` (mirrors a real browser carrying the preference across a
+  reload), navigates to `/settings`, attaches a `MutationObserver` to track
+  every `data-theme` transition, then reloads. Asserts:
+  - `data-theme === 'dark'` after navigation and after reload
+  - `__themeFlashes` records exactly `['dark']` (no transient `'light'`)
+  - `localStorage.theme === 'dark'` after reload
+- **Verification of test sensitivity:** temporarily removed the FOUC guard
+  in `use-theme.ts`, rebuilt the `web` container, ran the test — it failed
+  with the captured flash sequence `["dark","light","dark"]`. Restored the
+  guard, rebuilt, ran again — passed.
+
+### Suite results
+
+- `pnpm --filter @skerry/web test:e2e -- ui-regressions.spec.ts` — 4/4 pass
+  (Bug 1, #21, Bug 5, #22).
+- `pnpm --filter @skerry/web test` — 9/9 pass.
+- `pnpm typecheck` — clean across `@skerry/shared`, `@skerry/control-plane`,
+  `@skerry/web`.
+- `pnpm lint` — only pre-existing `<img>` and `react-hooks/exhaustive-deps`
+  warnings. No new diagnostics from this change.
+
+## Open issues / follow-ups
+
+- The bug doesn't reproduce on the current `main` build for users whose
+  identity-level theme is persisted, because the eventual `viewer` fetch
+  rehydrates the correct state. The new test specifically pins the
+  no-DB-preference flash path (the original failure mode) so we don't
+  silently regress when the FOUC guard is touched again.
+- Pre-existing lint warnings (`@next/next/no-img-element`,
+  `react-hooks/exhaustive-deps`) are unrelated and out of scope for #21.
+
+## Verification
+
+- Verified on **localhost** (the development machine — see CONTEXT.md). The
+  Skerry test stack was rebuilt twice (broken-fix, restored-fix) via
+  `docker compose -f docker-compose-test.yml up -d --build web` against
+  `http://localhost:8080`.
+- Did **not** reproduce on `pangolin` directly. The failing-then-passing
+  cycle on the local stack is sufficient evidence that the test catches
+  the regression and the fix prevents it.

--- a/apps/web/e2e/ui-regressions.spec.ts
+++ b/apps/web/e2e/ui-regressions.spec.ts
@@ -7,6 +7,9 @@ import { resetPlatform, bootstrapAdmin } from './helpers';
 //   on every render and overwrote the user's choice with stale localStorage).
 // - Bug 5 (Phase 27): "+" New Direct Message button opens the picker modal
 //   instead of crashing on `useChatHandlers must be used within a ChatHandlersProvider`.
+// - #21: refreshing the page while inside the settings menu must preserve the
+//   user's chosen theme (prior bug: settings layout/refresh path reverted to
+//   light mode regardless of the saved preference).
 // - #22 (Phase 25): when the Discord OAuth flow redirects back to the space
 //   settings page with `?discordPendingSelection=…`, the BridgeManager section
 //   scrolls itself into view so the freshly-rendered guild picker is visible
@@ -41,6 +44,97 @@ test.describe('UI regressions', () => {
         { timeout: 5000 }
       )
       .toBe(initial);
+  });
+
+  test('#21: theme persists when refreshing the settings page', async ({ page, context }) => {
+    // Reproduce the original #21 repro path: a user whose theme preference
+    // lives ONLY in localStorage (not yet persisted to identity.theme on
+    // the control plane) refreshes inside /settings and the page must not
+    // revert to light. This is the failure mode that the FOUC guard in
+    // hooks/use-theme.ts (Phase 27 fe54478) was added to protect against —
+    // without the guard, Effect 2 fires on first render with the reducer's
+    // default theme="light", overwrites the DOM's correctly-applied "dark"
+    // and clobbers localStorage in the process, so even after viewer loads
+    // there's no "dark" preference left to recover from.
+    //
+    // We seed localStorage via addInitScript so the value is present BEFORE
+    // ThemeScript runs — exactly as it would be on a real browser refresh.
+    await context.addInitScript(() => {
+      try {
+        window.localStorage.setItem('theme', 'dark');
+      } catch (e) {
+        // ignore — not all contexts have localStorage on init
+      }
+    });
+
+    await page.goto('/settings');
+    await expect(page.getByRole('heading', { name: 'User Settings' })).toBeVisible({
+      timeout: 15000,
+    });
+
+    // ThemeScript must apply data-theme="dark" before paint, AND the React
+    // hydration path must NOT subsequently overwrite it.
+    await expect
+      .poll(
+        async () => page.evaluate(() => document.documentElement.getAttribute('data-theme')),
+        { timeout: 5000 }
+      )
+      .toBe('dark');
+
+    // Hold across a full reload — this is the literal #21 repro.
+    // We attach a MutationObserver via init script BEFORE the reload so it
+    // catches even a transient "light" flash during hydration. The original
+    // bug surfaced as React's initial-mount Effect 2 firing with the
+    // reducer's default theme="light" and overwriting the DOM the
+    // ThemeScript had correctly set to "dark"; that flash is the
+    // user-visible failure, even if the value eventually self-heals.
+    await context.addInitScript(() => {
+      (window as unknown as { __themeFlashes: string[] }).__themeFlashes = [];
+      const record = (val: string | null) => {
+        const flashes = (window as unknown as { __themeFlashes: string[] })
+          .__themeFlashes;
+        if (val && flashes[flashes.length - 1] !== val) flashes.push(val);
+      };
+      // Capture the value as soon as the html element exists.
+      const interval = setInterval(() => {
+        if (document.documentElement) {
+          record(document.documentElement.getAttribute('data-theme'));
+          const observer = new MutationObserver(() => {
+            record(document.documentElement.getAttribute('data-theme'));
+          });
+          observer.observe(document.documentElement, {
+            attributes: true,
+            attributeFilter: ['data-theme'],
+          });
+          clearInterval(interval);
+        }
+      }, 1);
+    });
+
+    await page.reload();
+    await expect(page.getByRole('heading', { name: 'User Settings' })).toBeVisible({
+      timeout: 15000,
+    });
+    await expect
+      .poll(
+        async () => page.evaluate(() => document.documentElement.getAttribute('data-theme')),
+        { timeout: 5000 }
+      )
+      .toBe('dark');
+
+    // The MutationObserver should have seen `data-theme` set to "dark" by
+    // ThemeScript and never anything else. A flash to "light" indicates
+    // the FOUC guard regressed.
+    const flashes = await page.evaluate(
+      () => (window as unknown as { __themeFlashes: string[] }).__themeFlashes
+    );
+    expect(flashes, `data-theme transitions: ${JSON.stringify(flashes)}`).toEqual(['dark']);
+
+    // Final guard: localStorage must still be "dark" — without the FOUC
+    // guard the initial-mount Effect 2 would have written "light" here,
+    // making the regression sticky across subsequent navigations.
+    const persisted = await page.evaluate(() => localStorage.getItem('theme'));
+    expect(persisted).toBe('dark');
   });
 
   test('Bug 5: "New Message" button opens the DM picker without a context error', async ({ page }) => {


### PR DESCRIPTION
Issue #21 reported that refreshing inside the settings menu reverted the page to light mode regardless of the user's preference. The underlying defect was already addressed by the Phase 27 FOUC guard in apps/web/hooks/use-theme.ts (fe54478), but the literal repro path was never directly exercised by an E2E.

Add a Playwright regression to e2e/ui-regressions.spec.ts that seeds localStorage.theme=dark via addInitScript (mirrors a real browser carrying the preference across a reload), navigates to /settings, reloads, and asserts via MutationObserver that data-theme only ever holds "dark" — catching even a transient flash to light during hydration. Sensitivity-checked by removing the guard, rebuilding the web container, watching the test fail with the captured flash sequence ["dark","light","dark"], then restoring the guard and watching it pass.

Verified on localhost: 4/4 ui-regressions pass, 9/9 web unit pass, typecheck clean across all workspaces.

Fixes #21