### PR TITLE
fix(web): repair New DM modal — fallback name, JSON header, self-exclude

### DIFF
--- a/.agent-shared/handoffs/chat-log.md
+++ b/.agent-shared/handoffs/chat-log.md
@@ -30,3 +30,23 @@ plus 3 rows of `zombieTwerk` whose name was never seeded into
 146/146 unit + 29/29 E2E green. See
 `implementation-reports/2026-05-02-1730-phase-27-items-1-through-6.md`
 for the full report. Next agent: either.
+
+## 2026-05-03 19:48 — claude-code
+
+Started Sprint 1 (Skerry MVP) with concurrency analysis: identified 3 safe
+parallel lanes — A: #21 (settings theme), B: #39 (New DM modal), C
+(sequential): #35 → #40 → #41 → #45. Lane A landed via worktree agent
+(`fix/issue-21-settings-theme`, commit `a029071`): no production change
+needed — verified Phase 27's FOUC guard already handles refresh, added
+Playwright regression that fails without the guard. Lane B agent hit
+sandbox permission denials in the worktree but produced a clean diagnosis;
+I picked Lane B up in the main tree on `fix/issue-39-new-dm-modal`. Two
+real bugs fixed: (1) modal display-name fallback (`displayName ??
+preferredUsername ?? matrixLocalpart`), and (2) `createDirectMessage`
+missing `Content-Type: application/json`, which was the actual click-error
+root cause (Fastify couldn't parse the body, zod 400'd). Bonus:
+`searchIdentities` now self-excludes the requester. Tests: 1 new E2E +
+1 control-plane assertion block extension. Suite: 121/121 control-plane,
+9/9 web unit, 16/16 shared, 4/4 ui-regressions E2E, typecheck clean.
+Lane C (#35/#40/#41/#45) still pending — separate session. Next agent:
+either.

--- a/.agent-shared/handoffs/implementation-reports/2026-05-03-1948-issue-39-new-dm-modal.md
+++ b/.agent-shared/handoffs/implementation-reports/2026-05-03-1948-issue-39-new-dm-modal.md
@@ -1,0 +1,55 @@
+---
+date: 2026-05-03 19:48
+agent: claude-code
+issue: 39
+branch: fix/issue-39-new-dm-modal
+sprint: Sprint 1 (MVP)
+verification_machine: localhost (development)
+---
+
+# Issue #39 — New DM Modal Dialog Issues
+
+Reported symptoms (from pangolin test server):
+1. Search results in the New DM modal do not render user names.
+2. Clicking any entry produces an error.
+
+## Root Causes
+
+Two independent bugs, both reproduced locally:
+
+### 1. Display name fallback missing
+`apps/web/components/dm-picker-modal.tsx` rendered `user.displayName ?? "Unknown User"`, but the dev/OIDC login paths and onboarding only populate `preferred_username` — `display_name` stays NULL for freshly-onboarded users. So every search hit displayed as "Unknown User".
+
+### 2. Missing `Content-Type` header on DM creation
+`createDirectMessage` in `apps/web/lib/control-plane.ts` POSTed `JSON.stringify({ userIds })` without `Content-Type: application/json`. Fastify therefore couldn't parse the body, leaving `request.body` undefined, and the route's zod schema `{ userIds: z.array(z.string().min(1)).min(1).max(10) }` rejected the request with a 400. The web client surfaced that as a "Failed to start conversation." error and the modal stayed open — exactly the "clicking produces an error" symptom.
+
+A bonus fix: `searchIdentities` now self-excludes the requester. Pre-fix, the admin appeared in their own results; clicking themselves would route through `getOrCreateDMChannel` with a 1-member self-DM, an untested edge case. Self-exclusion eliminates the path entirely. (Catching the click error from #2 above also prevented the self-DM follow-on; both fixes are now in place.)
+
+## Files Changed
+
+- `apps/web/components/dm-picker-modal.tsx` — fallback chain `displayName ?? preferredUsername ?? matrixLocalpart ?? "Unknown User"`, applied to both the rendered name and the avatar initial.
+- `apps/web/lib/control-plane.ts` — added `Content-Type: application/json` to `createDirectMessage`.
+- `apps/control-plane/src/services/identity-service.ts` — `searchIdentities` accepts `{ excludingProductUserId }` and filters via SQL.
+- `apps/control-plane/src/routes/user-routes.ts` — passes `request.auth!.productUserId` into `searchIdentities`.
+- `apps/control-plane/src/test/identity-service.test.ts` — extended lifecycle test with self-exclusion assertion.
+- `apps/web/e2e/ui-regressions.spec.ts` — added `#39` Playwright regression: spawns alice in a second context, opens New DM modal as admin, asserts alice's preferred-username renders (no "Unknown User"), asserts admin doesn't appear in own results, clicks alice and asserts the modal closes with no DM-creation console errors.
+
+## Tests
+
+- New: 1 Playwright E2E (#39 in `ui-regressions.spec.ts`) and 1 assertion block extension in `identity-service.test.ts` (case 9: self-exclusion).
+- Failing-then-passing: pre-fix the new E2E hit "Request validation failed (400)" on the DM POST; post-fix all 4 ui-regressions tests pass.
+- Suite results on localhost:
+  - `pnpm --filter @skerry/control-plane test` — 121/121 pass.
+  - `pnpm --filter @skerry/web test` — 9/9 pass.
+  - `pnpm --filter @skerry/shared test` — 16/16 pass.
+  - `pnpm --filter @skerry/web exec playwright test e2e/ui-regressions.spec.ts` — 4/4 pass.
+  - `pnpm typecheck` — clean.
+  - `pnpm lint` — only pre-existing unrelated warnings.
+
+## Open Issues / Follow-ups
+
+None blocking. Note: the `Content-Type` omission is a one-off; spot-checked the rest of `control-plane.ts` and the other JSON POSTs in that file already set the header. If a similar bug surfaces elsewhere later, a centralized helper would prevent the class — out of scope here.
+
+## Verification
+
+All test runs above were on localhost (development machine). Pangolin not directly verified; the failing-then-passing E2E run on the locally-rebuilt test stack is the regression evidence.

--- a/apps/control-plane/src/routes/user-routes.ts
+++ b/apps/control-plane/src/routes/user-routes.ts
@@ -24,7 +24,11 @@ export async function registerUserRoutes(app: FastifyInstance): Promise<void> {
 
   app.get("/v1/users/search", initializedAuthHandlers, async (request) => {
     const query = z.object({ q: z.string().min(1) }).parse(request.query);
-    return { items: await searchIdentities(query.q) };
+    return {
+      items: await searchIdentities(query.q, {
+        excludingProductUserId: request.auth!.productUserId
+      })
+    };
   });
 
   app.get("/v1/users/:userId", initializedAuthHandlers, async (request, reply) => {

--- a/apps/control-plane/src/services/identity-service.ts
+++ b/apps/control-plane/src/services/identity-service.ts
@@ -278,16 +278,20 @@ export async function isPreferredUsernameTaken(input: {
   });
 }
 
-export async function searchIdentities(query: string): Promise<IdentityMapping[]> {
+export async function searchIdentities(
+  query: string,
+  options: { excludingProductUserId?: string } = {}
+): Promise<IdentityMapping[]> {
   const normalizedQuery = `%${query.trim().toLowerCase()}%`;
   return withDb(async (db) => {
     const rows = await db.query<IdentityRow>(
       `select distinct on (product_user_id) *
        from identity_mappings
        where (lower(preferred_username) like $1 or lower(email) like $1)
+         and ($2::text is null or product_user_id <> $2)
        order by product_user_id, (preferred_username is not null) desc, updated_at desc
        limit 10`,
-      [normalizedQuery]
+      [normalizedQuery, options.excludingProductUserId ?? null]
     );
     return rows.rows.map(mapRow);
   });

--- a/apps/control-plane/src/test/identity-service.test.ts
+++ b/apps/control-plane/src/test/identity-service.test.ts
@@ -85,4 +85,17 @@ test("identity service lifecycle", async (t) => {
   const searchResults2 = await searchIdentities("some");
   assert.equal(searchResults2.length, 1);
   assert.equal(searchResults2[0]?.productUserId, identity2.productUserId);
+
+  // 9. Self-exclusion: passing excludingProductUserId filters that user out
+  // (regression for #39: opening "New DM" was returning the requester among
+  // their own search results, and clicking themselves errored out downstream).
+  const broadResults = await searchIdentities("e");
+  const broadIds = broadResults.map((r) => r.productUserId).sort();
+  assert.deepEqual(broadIds, [identity1.productUserId, identity2.productUserId].sort());
+
+  const excludedResults = await searchIdentities("e", {
+    excludingProductUserId: identity1.productUserId
+  });
+  assert.equal(excludedResults.length, 1);
+  assert.equal(excludedResults[0]?.productUserId, identity2.productUserId);
 });

--- a/apps/web/components/dm-picker-modal.tsx
+++ b/apps/web/components/dm-picker-modal.tsx
@@ -87,21 +87,26 @@ export function DMPickerModal() {
                     {error && <div className="error-message">{error}</div>}
 
                     <ul className="user-results-list">
-                        {results.map((user) => (
-                            <li key={user.productUserId} className="user-result-item" onClick={() => handleSelectUser(user)}>
-                                <div className="user-avatar-placeholder">
-                                    {user.avatarUrl ? (
-                                        <img src={user.avatarUrl} alt="" />
-                                    ) : (
-                                        (user.displayName ?? "U").charAt(0).toUpperCase()
-                                    )}
-                                </div>
-                                <div className="user-info">
-                                    <span className="display-name">{user.displayName ?? "Unknown User"}</span>
-                                    {user.matrixUserId && <span className="matrix-id">{user.matrixUserId}</span>}
-                                </div>
-                            </li>
-                        ))}
+                        {results.map((user) => {
+                            const matrixLocalpart = user.matrixUserId?.replace(/^@/, "").split(":")[0] ?? null;
+                            const renderedName =
+                                user.displayName ?? user.preferredUsername ?? matrixLocalpart ?? "Unknown User";
+                            return (
+                                <li key={user.productUserId} className="user-result-item" onClick={() => handleSelectUser(user)}>
+                                    <div className="user-avatar-placeholder">
+                                        {user.avatarUrl ? (
+                                            <img src={user.avatarUrl} alt="" />
+                                        ) : (
+                                            renderedName.charAt(0).toUpperCase()
+                                        )}
+                                    </div>
+                                    <div className="user-info">
+                                        <span className="display-name">{renderedName}</span>
+                                        {user.matrixUserId && <span className="matrix-id">{user.matrixUserId}</span>}
+                                    </div>
+                                </li>
+                            );
+                        })}
                         {!loading && query && results.length === 0 && (
                             <li className="no-results">No users found for &quot;{query}&quot;</li>
                         )}

--- a/apps/web/e2e/ui-regressions.spec.ts
+++ b/apps/web/e2e/ui-regressions.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { resetPlatform, bootstrapAdmin } from './helpers';
+import { resetPlatform, bootstrapAdmin, loginAndOnboard } from './helpers';
 
 // Regression tests for UI bugs:
 // - Bug 1 (Phase 27): theme toggle button now flips data-theme on the document
@@ -64,6 +64,64 @@ test.describe('UI regressions', () => {
       line.includes('useChatHandlers must be used within a ChatHandlersProvider')
     );
     expect(providerError, providerError).toBeUndefined();
+  });
+
+  test('#39: New DM modal renders preferred-username fallback and excludes self', async ({ page, browser }) => {
+    // Seed a second identity in the DB by completing onboarding in a separate
+    // context. Alice never joins the hub — she just needs an `identity_mappings`
+    // row so that admin's user-search hits her. Onboarding sets only
+    // preferred_username (display_name stays NULL), which is exactly the
+    // situation that produced "Unknown User" rows in the modal pre-fix.
+    const aliceContext = await browser.newContext();
+    try {
+      const alicePage = await aliceContext.newPage();
+      await alicePage.goto('/');
+      await loginAndOnboard(alicePage, 'alice-dev', 'alice');
+      await alicePage.close();
+
+      const consoleErrors: string[] = [];
+      page.on('console', (msg) => {
+        if (msg.type() === 'error') consoleErrors.push(msg.text());
+      });
+
+      await page.getByTestId('back-to-servers').click();
+      await page.getByRole('button', { name: 'New Message' }).click();
+      await expect(page.getByRole('heading', { name: 'New Direct Message' })).toBeVisible({
+        timeout: 5000,
+      });
+
+      // Type a query that matches BOTH alice and the admin (both have an "a"
+      // in their preferred_username). Pre-fix, the admin would appear in their
+      // own results and clicking would create a self-DM that errored downstream.
+      await page.getByPlaceholder('Type a username...').fill('a');
+
+      const aliceRow = page.locator('.user-result-item', { hasText: 'alice' });
+      await expect(aliceRow).toBeVisible({ timeout: 5000 });
+
+      // Self-exclusion: admin's own preferred_username ('admin') must not appear.
+      await expect(page.locator('.user-result-item', { hasText: /^admin$/ })).toHaveCount(0);
+
+      // Display-name fallback: alice has display_name=NULL, but the modal must
+      // render her preferred_username, never the literal string "Unknown User".
+      await expect(page.locator('.user-result-item', { hasText: 'Unknown User' })).toHaveCount(0);
+
+      await aliceRow.click();
+
+      // Modal closes and the DM is created. The sidebar's DMs section gets
+      // populated with the new conversation. We don't assert specific UI here
+      // beyond modal-dismissal + no console errors, since the surrounding DM
+      // list reactivity is the subject of #35/#40.
+      await expect(page.getByRole('heading', { name: 'New Direct Message' })).toBeHidden({
+        timeout: 10000,
+      });
+
+      const dmFailures = consoleErrors.filter((line) =>
+        /Failed to create DM|TypeError|Cannot read|undefined is not/.test(line)
+      );
+      expect(dmFailures, dmFailures.join('\n')).toEqual([]);
+    } finally {
+      await aliceContext.close();
+    }
   });
 
   test('#22: OAuth return scrolls the BridgeManager into view', async ({ page }) => {

--- a/apps/web/lib/control-plane.ts
+++ b/apps/web/lib/control-plane.ts
@@ -335,6 +335,7 @@ export async function searchUsers(query: string): Promise<IdentityMapping[]> {
 export async function createDirectMessage(hubId: string, userIds: string[]): Promise<Channel> {
   return apiFetch<Channel>(`/v1/hubs/${encodeURIComponent(hubId)}/dms`, {
     method: "POST",
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ userIds })
   });
 }


### PR DESCRIPTION
- dm-picker-modal: fall back to preferredUsername / matrix localpart so freshly-onboarded users (display_name=NULL) no longer render as "Unknown User".
- control-plane.ts: createDirectMessage was POSTing JSON without a Content-Type, so Fastify left request.body undefined and zod 400'd every click. Add the header.
- identity-service.searchIdentities: accept excludingProductUserId and filter via SQL; user-routes passes the requester's id so admins don't appear in their own search results.

Adds 1 Playwright E2E (#39 in ui-regressions.spec.ts) covering both the fallback rendering and self-exclusion, and extends the identity-service lifecycle test with a self-exclusion case.

Fixes #39