### PR TITLE
Fix/sprint 1 dm reactivity

### DIFF
--- a/.agent-shared/handoffs/chat-log.md
+++ b/.agent-shared/handoffs/chat-log.md
@@ -62,3 +62,25 @@ root cause (Fastify couldn't parse the body, zod 400'd). Bonus:
 9/9 web unit, 16/16 shared, 4/4 ui-regressions E2E, typecheck clean.
 Lane C (#35/#40/#41/#45) still pending — separate session. Next agent:
 either.
+
+## 2026-05-03 22:30 — claude-code
+
+Sprint 1 Lane C: shipped #35, #40, #41, #45 on a single branch
+(`fix/sprint-1-dm-reactivity`). Root cause for #35/#40 collapsed to one
+fix: backend `getOrCreateDMChannel` now publishes `channel.created` to
+the hub, and `use-chat-realtime.ts` routes DM channel.created events
+through `ADD_DM_CHANNEL` when the viewer is in `participants`. #45
+needed a new endpoint (`DELETE /v1/channels/:id/members/me` →
+`leaveDmChannel`) plus a sidebar context-menu entry guarded by the
+existing confirmation modal; `dm.left` SSE event drives `REMOVE_DM_CHANNEL`
+on the frontend. #41 added a `NotificationsPanel` (bell + dropdown)
+to the topbar, surfacing DMs with unread + channels with @-mentions
+(honoring mute state). Tests: 2 new control-plane (leave + non-DM
+guard), 2 new web reducer (REMOVE_DM_CHANNEL with/without active
+selection), 1 new Playwright E2E covering the full lifecycle. Suite on
+localhost: shared 16/16, web 11/11, control-plane 123/123, E2E 33/33.
+One pre-existing concern surfaced and noted in the report: the hub SSE
+stream is not user-scoped, so DM channel.created payloads are visible
+to all hub members on the wire even though the frontend filters them.
+Per-user fan-out is the proper fix — left as follow-up. No active plan;
+next agent: either.

--- a/.agent-shared/handoffs/current-plan.md
+++ b/.agent-shared/handoffs/current-plan.md
@@ -1,9 +1,21 @@
 ---
 created_by: claude-code
-last_updated: 2026-05-03T17:06:00Z
+last_updated: 2026-05-03T22:30:00Z
 next_agent: either
 status: complete
 ---
+
+> **Note (2026-05-03 22:30):** Sprint 1 Lane C complete — issues #35,
+> #40, #41, #45 all landed on `fix/sprint-1-dm-reactivity` (single
+> branch, four issues bundled). Backend now emits `channel.created` for
+> new DMs and `dm.left` / `channel.deleted` for departures; frontend
+> wires those to `ADD_DM_CHANNEL` / `REMOVE_DM_CHANNEL`, adds a
+> notifications bell + panel in the topbar, and a "Leave Conversation"
+> context-menu item on DM rows. Suite on localhost: shared 16/16,
+> web 11/11, control-plane 123/123, E2E 33/33. Report at
+> `implementation-reports/2026-05-03-2230-sprint-1-dm-reactivity.md`.
+> Open follow-up: per-user SSE fan-out (DM event scoping). No active
+> plan in flight; the user's next request should seed a new one.
 
 > **Note (2026-05-03):** Issue #21 (Settings menu theme persistence)
 > verified fixed on the current build. The Phase 27 FOUC guard

--- a/.agent-shared/handoffs/implementation-reports/2026-05-03-2230-sprint-1-dm-reactivity.md
+++ b/.agent-shared/handoffs/implementation-reports/2026-05-03-2230-sprint-1-dm-reactivity.md
@@ -1,0 +1,149 @@
+---
+date: 2026-05-03 22:30
+agent: claude-code
+issues: [35, 40, 41, 45]
+branch: fix/sprint-1-dm-reactivity
+sprint: Sprint 1 Lane C (MVP)
+verification_machine: localhost (development)
+---
+
+# Sprint 1 Lane C — DM reactivity, notifications, leave-DM
+
+Reported symptoms (default-assumed pangolin per `.agent-shared/CONTEXT.md`,
+not directly verified there):
+
+- **#35** Creating a DM didn't repaint the sidebar — required a refresh.
+- **#40** Receiving a DM didn't update the recipient's UI or notify them.
+- **#41** No in-app notification surface for unread DMs / @-mentions.
+- **#45** Only the DM creator could "delete" the DM; non-creators were stuck.
+
+## Root causes
+
+#35 was already largely addressed in Phase 27 by the `ADD_DM_CHANNEL`
+reducer that prepends to `state.allDmChannels` (the source for the sidebar
+DM list) and to `state.channels` when the DM server is active. The
+remaining gap was that recipients (#40) only learned about a new DM via
+the 60-second poll in `use-dms.ts`, because the backend never published a
+`channel.created` event when a DM was first opened.
+
+#40 had a second gap: even with reactivity, there was no notification
+surface. Document-hidden Web Notifications fire for any new message, but
+when the tab is foregrounded there was no visible queue of pending DMs
+or @-mentions outside the sidebar's per-channel pill, which is hidden
+behind the "back to servers" view.
+
+#45 was a missing endpoint. `getOrCreateDMChannel` happily added members,
+but there was no DELETE route to remove a single member from a DM. The
+server-level `deleteChannel` only worked for owners, and DMs aren't
+"owned" in the same sense as text channels.
+
+## Files changed
+
+### Backend (control-plane)
+
+- `services/chat-realtime.ts` — extended `ChatEvent` type with the
+  `channel.*`, `category.*`, and new `dm.left` events that the web
+  client already listens for at runtime.
+- `services/chat/channel-service.ts`
+  - `getOrCreateDMChannel` now publishes `channel.created` to the hub
+    when a DM channel is first created (not on the idempotent rehit).
+  - New `leaveDmChannel(channelId, productUserId)`: removes the user
+    from `channel_members`, kicks them from the underlying Matrix room
+    if one exists, and tears down the channel + chat history when the
+    last member leaves. Publishes `dm.left` for the leaver and
+    `channel.deleted` when the channel is torn down.
+- `routes/channel-routes.ts` — `DELETE /v1/channels/:channelId/members/me`
+  wraps `leaveDmChannel`. Maps "Channel not found" / "Not a member" to
+  404 and "not a DM" to 400 so non-DM channels can't be silently left.
+
+### Frontend (web)
+
+- `lib/control-plane.ts` — `leaveDmChannel(channelId)` client.
+- `context/chat-context.tsx`
+  - New `REMOVE_DM_CHANNEL` action: drops the channel from
+    `allDmChannels` *and* `channels`, clears `selectedChannelId` /
+    `activeChannelData` / `messages` if it was selected, otherwise
+    leaves selection alone.
+- `hooks/use-chat-realtime.ts`
+  - `channel.created` now branches: DM with viewer in `participants`
+    → `ADD_DM_CHANNEL` + notification-summary refresh; otherwise the
+    pre-existing `UPSERT_CHANNEL` path.
+  - New `dm.left` handler: triggers `REMOVE_DM_CHANNEL` only when the
+    leaver is the viewer (other participants stay).
+  - `channel.deleted` now also calls `REMOVE_DM_CHANNEL` so DM teardown
+    propagates regardless of which server the viewer is currently on.
+- `components/sidebar.tsx` — DM rows get a context menu with **Leave
+  Conversation**, gated through the existing `confirmation` modal.
+- `components/notifications-panel.tsx` (new) — bell icon in the topbar
+  with a dropdown listing channels with mentions and DMs with unread,
+  honoring the existing mute state. Clicking an item navigates via
+  `handleServerChange(serverId, channelId)`.
+- `components/layout/ClientTopbar.tsx` — embeds `NotificationsPanel`
+  next to the search/settings icons.
+- `components/chat-client.tsx` — `ChatHandlersProvider` now wraps the
+  full main return (previously only `ModalManager`), so the
+  topbar-embedded `NotificationsPanel` can call `handleServerChange`.
+
+## Tests
+
+- `apps/control-plane/src/test/dm-messaging.test.ts`
+  - `non-creator can leave a DM and creator's view persists` — covers
+    the multi-step lifecycle (leave → other member sees DM gone, creator
+    sees it kept; final leave deletes; second leave 404s).
+  - `leave-DM endpoint refuses non-DM channels` — guard for the 400
+    branch.
+- `apps/web/test/chat-context-reducer.test.ts`
+  - `REMOVE_DM_CHANNEL drops the entry and clears active chat when
+    selected`
+  - `REMOVE_DM_CHANNEL leaves selection alone when a different DM is
+    removed`
+- `apps/web/e2e/dm-lifecycle.spec.ts` (new) — admin invites bob, opens
+  a DM with him, both sidebars update live (no refresh), the bell shows
+  the panel, bob right-clicks the DM and chooses Leave Conversation,
+  the DM disappears from bob's sidebar while admin still sees it.
+
+Failing-then-passing evidence: the new reducer tests (added before the
+reducer changes) and the dm-messaging leave tests (added before the
+service/route) failed exactly as predicted with `not a function` /
+`404` until the implementations landed. The E2E was authored after the
+implementation but caught one real defect — `useChatHandlers must be
+used within a ChatHandlersProvider` from the topbar, which forced the
+provider-broadening fix in `chat-client.tsx`.
+
+### Suite results on localhost
+
+- `pnpm --filter @skerry/web test` — 11/11 pass (was 9/9 baseline +2).
+- `pnpm --filter @skerry/control-plane test` — 123/123 pass
+  (was 121/121 baseline +2).
+- `pnpm --filter @skerry/shared test` — 16/16 pass (unchanged).
+- `pnpm --filter @skerry/web exec playwright test` — 33/33 pass.
+- `pnpm typecheck` — clean.
+- `pnpm lint` — clean modulo pre-existing unrelated warnings.
+
+## Open issues / follow-ups
+
+- Hub-level SSE leakage (pre-existing, not introduced here): the hub
+  stream broadcasts message and channel events to every subscriber in
+  the hub regardless of DM-membership. The frontend filters in
+  `use-chat-realtime` (only acts on DMs the viewer participates in),
+  but a curious client could read other users' DMs off the wire. The
+  proper fix is per-user fan-out at the SSE layer; tracked separately
+  per the user's "MVP scope" note — call it out in the next sprint.
+- `channel.created` payload includes the full `participants` list with
+  display names. That's necessary for the frontend's "am I in this DM?"
+  check, but it does mean the same hub-stream listeners not in the DM
+  see the participant list. Tightening this depends on the per-user
+  fan-out above.
+- `kickUser` for Matrix room cleanup on leave is best-effort (logged
+  on failure). For pre-MVP this is acceptable; the channel-side state
+  is the source of truth.
+- Two-person DMs: leaving from one side doesn't tell the other side
+  "they left." That's deliberate (Discord-style), but a future polish
+  could add a system message when membership changes.
+
+## Verification
+
+Verification ran on localhost (development machine), the test stack
+rebuilt with `pnpm test:env:up` after each backend change. Pangolin not
+directly exercised — the failing-then-passing E2E on the locally rebuilt
+stack is the regression evidence.

--- a/apps/control-plane/src/routes/channel-routes.ts
+++ b/apps/control-plane/src/routes/channel-routes.ts
@@ -18,6 +18,7 @@ import {
   updateChannel,
   listChannelMembers,
   inviteToChannel,
+  leaveDmChannel,
   moveChannelToCategory
 } from "../services/chat/channel-service.js";
 import {
@@ -416,6 +417,24 @@ export async function registerChannelRoutes(app: FastifyInstance): Promise<void>
 
     await inviteToChannel(params.channelId, payload.productUserId);
     reply.code(204).send();
+  });
+
+  app.delete("/v1/channels/:channelId/members/me", initializedAuthHandlers, async (request, reply) => {
+    const params = z.object({ channelId: z.string().min(1) }).parse(request.params);
+    try {
+      const result = await leaveDmChannel(params.channelId, request.auth!.productUserId);
+      reply.code(200);
+      return result;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to leave DM.";
+      const status = message === "Channel not found." || message === "Not a member of this DM."
+        ? 404
+        : message === "Channel is not a DM."
+          ? 400
+          : 500;
+      reply.code(status).send({ message });
+      return;
+    }
   });
 
   app.patch("/v1/channels/:channelId/category", initializedAuthHandlers, async (request, reply) => {

--- a/apps/control-plane/src/services/chat-realtime.ts
+++ b/apps/control-plane/src/services/chat-realtime.ts
@@ -1,6 +1,21 @@
 import type { ChatMessage } from "@skerry/shared";
 
-type ChatEvent = "message.created" | "message.updated" | "message.deleted" | "typing.start" | "typing.stop" | "presence.update" | "voice.presence.update" | "membership.updated";
+type ChatEvent =
+  | "message.created"
+  | "message.updated"
+  | "message.deleted"
+  | "typing.start"
+  | "typing.stop"
+  | "presence.update"
+  | "voice.presence.update"
+  | "membership.updated"
+  | "channel.created"
+  | "channel.updated"
+  | "channel.deleted"
+  | "category.created"
+  | "category.updated"
+  | "category.deleted"
+  | "dm.left";
 type ChatListener = (event: ChatEvent, payload: any) => void;
 
 const channelListeners = new Map<string, Set<ChatListener>>();

--- a/apps/control-plane/src/services/chat/channel-service.ts
+++ b/apps/control-plane/src/services/chat/channel-service.ts
@@ -1,14 +1,15 @@
 import crypto from "node:crypto";
 import type { Category, Channel } from "@skerry/shared";
 import { withDb } from "../../db/client.js";
-import { 
-  ChannelRow, 
-  CategoryRow, 
-  mapChannel, 
-  mapCategory, 
-  validateChannelStyle 
+import {
+  ChannelRow,
+  CategoryRow,
+  mapChannel,
+  mapCategory,
+  validateChannelStyle
 } from "./mapping-helpers.js";
 import type { ScopedAuthContext } from "../../auth/middleware.js";
+import { publishHubEvent } from "../chat-realtime.js";
 
 export async function listChannels(
   serverId: string, 
@@ -534,7 +535,8 @@ export async function inviteToChannel(channelId: string, productUserId: string):
 }
 
 export async function getOrCreateDMChannel(hubId: string, productUserIds: string[]): Promise<Channel> {
-  return withDb(async (db) => {
+  let createdChannel: Channel | null = null;
+  const result = await withDb(async (db) => {
     const dmSrvRow = await db.query<{ id: string }>(
       "select id from servers where hub_id = $1 and type = 'dm' limit 1",
       [hubId]
@@ -629,6 +631,88 @@ export async function getOrCreateDMChannel(hubId: string, productUserIds: string
       displayName: (r as any).display_name
     }));
 
+    createdChannel = channel;
     return channel;
   });
+
+  if (createdChannel) {
+    // Notify hub subscribers so participants' sidebars update without a refresh.
+    // The payload mirrors the listChannels shape so the frontend can route it
+    // through ADD_DM_CHANNEL when the viewer is in `participants`.
+    publishHubEvent(hubId, "channel.created", createdChannel);
+  }
+
+  return result;
+}
+
+export async function leaveDmChannel(channelId: string, productUserId: string): Promise<{
+  hubId: string | null;
+  channelDeleted: boolean;
+}> {
+  const outcome = await withDb(async (db) => {
+    const chRow = await db.query<{ server_id: string; type: string; matrix_room_id: string | null; hub_id: string | null }>(
+      `select ch.server_id, ch.type, ch.matrix_room_id, s.hub_id
+         from channels ch
+         join servers s on s.id = ch.server_id
+        where ch.id = $1`,
+      [channelId]
+    );
+    const ch = chRow.rows[0];
+    if (!ch) {
+      throw new Error("Channel not found.");
+    }
+    if (ch.type !== "dm") {
+      throw new Error("Channel is not a DM.");
+    }
+
+    const membership = await db.query<{ product_user_id: string }>(
+      "select product_user_id from channel_members where channel_id = $1 and product_user_id = $2",
+      [channelId, productUserId]
+    );
+    if (membership.rowCount === 0) {
+      throw new Error("Not a member of this DM.");
+    }
+
+    await db.query(
+      "delete from channel_members where channel_id = $1 and product_user_id = $2",
+      [channelId, productUserId]
+    );
+
+    const remaining = await db.query<{ count: string }>(
+      "select count(*)::text as count from channel_members where channel_id = $1",
+      [channelId]
+    );
+    const remainingCount = Number(remaining.rows[0]?.count ?? "0");
+    let channelDeleted = false;
+
+    if (remainingCount === 0) {
+      await db.query("delete from chat_messages where channel_id = $1", [channelId]);
+      await db.query("delete from channels where id = $1", [channelId]);
+      channelDeleted = true;
+    }
+
+    return { hubId: ch.hub_id, channelDeleted, matrixRoomId: ch.matrix_room_id };
+  });
+
+  if (outcome.matrixRoomId) {
+    try {
+      const { kickUser } = await import("../../matrix/synapse-adapter.js");
+      const { getIdentityByProductUserId } = await import("../identity-service.js");
+      const identity = await getIdentityByProductUserId(productUserId);
+      if (identity?.matrixUserId) {
+        await kickUser({ roomId: outcome.matrixRoomId, userId: identity.matrixUserId, reason: "User left DM" });
+      }
+    } catch (err) {
+      console.warn(`[leaveDmChannel] matrix kick failed for ${channelId}:`, err);
+    }
+  }
+
+  if (outcome.hubId) {
+    publishHubEvent(outcome.hubId, "dm.left", { channelId, userId: productUserId });
+    if (outcome.channelDeleted) {
+      publishHubEvent(outcome.hubId, "channel.deleted", { id: channelId });
+    }
+  }
+
+  return { hubId: outcome.hubId, channelDeleted: outcome.channelDeleted };
 }

--- a/apps/control-plane/src/test/dm-messaging.test.ts
+++ b/apps/control-plane/src/test/dm-messaging.test.ts
@@ -222,6 +222,127 @@ test("DM creation fails with invalid payload (empty userIds)", async (t) => {
   }
 });
 
+test("non-creator can leave a DM and creator's view persists", async (t) => {
+  // #45 — Before this change there was no leave endpoint at all, so any
+  // non-creator was stuck in the DM. The minimum guarantee: a participant
+  // can DELETE /v1/channels/:id/members/me, the channel survives for
+  // remaining members, and a subsequent leave by the last member tears the
+  // channel down.
+  if (!pool) { t.skip("DATABASE_URL not configured."); return; }
+  if (!config.setupBootstrapToken) { t.skip("SETUP_BOOTSTRAP_TOKEN not configured."); return; }
+
+  const app = await buildApp();
+
+  try {
+    const adminIdentity = await upsertIdentityMapping({
+      provider: "dev", oidcSubject: "dm_leave_admin",
+      email: "dm-leave-admin@dev.local", preferredUsername: "dm-leave-admin", avatarUrl: null
+    });
+    const otherIdentity = await upsertIdentityMapping({
+      provider: "dev", oidcSubject: "dm_leave_other",
+      email: "dm-leave-other@dev.local", preferredUsername: "dm-leave-other", avatarUrl: null
+    });
+    const adminCookie = createAuthCookie({ productUserId: adminIdentity.productUserId, provider: "dev", oidcSubject: "dm_leave_admin" });
+    const otherCookie = createAuthCookie({ productUserId: otherIdentity.productUserId, provider: "dev", oidcSubject: "dm_leave_other" });
+
+    await app.inject({
+      method: "POST", url: "/auth/bootstrap-admin",
+      headers: { cookie: adminCookie },
+      payload: { setupToken: config.setupBootstrapToken, hubName: "Leave Hub" }
+    });
+    const hubId = (await app.inject({ method: "GET", url: "/v1/bootstrap/context", headers: { cookie: adminCookie } })).json().hubId as string;
+
+    const dmRes = await app.inject({
+      method: "POST", url: `/v1/hubs/${hubId}/dms`,
+      headers: { cookie: adminCookie },
+      payload: { userIds: [otherIdentity.productUserId] }
+    });
+    const channelId = dmRes.json().id as string;
+
+    // Non-creator (other) leaves the DM.
+    const leaveRes = await app.inject({
+      method: "DELETE", url: `/v1/channels/${channelId}/members/me`,
+      headers: { cookie: otherCookie }
+    });
+    assert.equal(leaveRes.statusCode, 200, "Non-creator should be allowed to leave");
+    assert.equal(leaveRes.json().channelDeleted, false, "Channel must survive while one member remains");
+
+    // Other can no longer see the DM in their channel listing.
+    const dmServerRow = await pool!.query(
+      "select s.id from servers s join channels ch on ch.server_id = s.id where ch.id = $1",
+      [channelId]
+    );
+    const dmServerId = dmServerRow.rows[0].id;
+    const otherChannelsRes = await app.inject({
+      method: "GET", url: `/v1/servers/${dmServerId}/channels`,
+      headers: { cookie: otherCookie }
+    });
+    const otherChannels = otherChannelsRes.json().items as { id: string }[];
+    assert.equal(otherChannels.find(c => c.id === channelId), undefined, "Leaver's channel listing must not include the DM");
+
+    // Creator still sees it.
+    const adminChannelsRes = await app.inject({
+      method: "GET", url: `/v1/servers/${dmServerId}/channels`,
+      headers: { cookie: adminCookie }
+    });
+    const adminChannels = adminChannelsRes.json().items as { id: string }[];
+    assert.ok(adminChannels.find(c => c.id === channelId), "Creator should still see the DM after other member leaves");
+
+    // Last member leaves → channel is torn down.
+    const finalLeaveRes = await app.inject({
+      method: "DELETE", url: `/v1/channels/${channelId}/members/me`,
+      headers: { cookie: adminCookie }
+    });
+    assert.equal(finalLeaveRes.statusCode, 200);
+    assert.equal(finalLeaveRes.json().channelDeleted, true, "Last leave should delete the channel");
+
+    const postFinalRes = await app.inject({
+      method: "DELETE", url: `/v1/channels/${channelId}/members/me`,
+      headers: { cookie: adminCookie }
+    });
+    assert.equal(postFinalRes.statusCode, 404, "Re-leave on a deleted channel returns 404");
+  } finally {
+    await app.close();
+  }
+});
+
+test("leave-DM endpoint refuses non-DM channels", async (t) => {
+  if (!pool) { t.skip("DATABASE_URL not configured."); return; }
+  if (!config.setupBootstrapToken) { t.skip("SETUP_BOOTSTRAP_TOKEN not configured."); return; }
+
+  const app = await buildApp();
+
+  try {
+    const adminIdentity = await upsertIdentityMapping({
+      provider: "dev", oidcSubject: "dm_leave_guard",
+      email: "dm-leave-guard@dev.local", preferredUsername: "dm-leave-guard", avatarUrl: null
+    });
+    const adminCookie = createAuthCookie({ productUserId: adminIdentity.productUserId, provider: "dev", oidcSubject: "dm_leave_guard" });
+
+    await app.inject({
+      method: "POST", url: "/auth/bootstrap-admin",
+      headers: { cookie: adminCookie },
+      payload: { setupToken: config.setupBootstrapToken, hubName: "Guard Hub" }
+    });
+    const ctx = (await app.inject({ method: "GET", url: "/v1/bootstrap/context", headers: { cookie: adminCookie } })).json();
+    // The bootstrap creates a default text channel; pick the first one.
+    const channels = (await app.inject({
+      method: "GET", url: `/v1/servers/${ctx.defaultServerId}/channels`,
+      headers: { cookie: adminCookie }
+    })).json().items as { id: string; type: string }[];
+    const textChannel = channels.find(c => c.type !== "dm");
+    assert.ok(textChannel, "Expected a default text channel from bootstrap");
+
+    const leaveRes = await app.inject({
+      method: "DELETE", url: `/v1/channels/${textChannel!.id}/members/me`,
+      headers: { cookie: adminCookie }
+    });
+    assert.equal(leaveRes.statusCode, 400, "Leave endpoint should reject non-DM channels");
+  } finally {
+    await app.close();
+  }
+});
+
 test("DM channel listing reflects messages from both participants in order", async (t) => {
   if (!pool) { t.skip("DATABASE_URL not configured."); return; }
   if (!config.setupBootstrapToken) { t.skip("SETUP_BOOTSTRAP_TOKEN not configured."); return; }

--- a/apps/web/components/chat-client.tsx
+++ b/apps/web/components/chat-client.tsx
@@ -698,7 +698,7 @@ export function ChatClient() {
   }
 
   return (
-    <>
+    <ChatHandlersProvider value={{ handleServerChange, handleChannelChange, refreshChatState }}>
       <main className="app">
       <ClientTopbar
         dispatch={dispatch}
@@ -953,9 +953,7 @@ export function ChatClient() {
         </section >
       )}
 
-      <ChatHandlersProvider value={{ handleServerChange, handleChannelChange, refreshChatState }}>
-        <ModalManager />
-      </ChatHandlersProvider>
+      <ModalManager />
       <ClientModals
         {...state}
         activeModal={activeModal}
@@ -1033,6 +1031,6 @@ export function ChatClient() {
 
 </main>
 
-    </>
+    </ChatHandlersProvider>
   );
 }

--- a/apps/web/components/layout/ClientTopbar.tsx
+++ b/apps/web/components/layout/ClientTopbar.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import type { ViewerSession } from "../../lib/control-plane";
+import { NotificationsPanel } from "../notifications-panel";
 
 interface ClientTopbarProps {
   dispatch: (action: any) => void;
@@ -60,6 +61,7 @@ export function ClientTopbar({
           >
             🔍
           </button>
+          <NotificationsPanel />
           <Link href="/settings" className="icon-button" title="User Settings" aria-label="User Settings">
             ⚙️
           </Link>

--- a/apps/web/components/notifications-panel.tsx
+++ b/apps/web/components/notifications-panel.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import React, { useMemo, useState, useRef, useEffect } from "react";
+import { useChat, useChatHandlers } from "../context/chat-context";
+import { getChannelName } from "../lib/channel-utils";
+
+interface NotificationItem {
+    channelId: string;
+    serverId: string;
+    label: string;
+    kind: "dm" | "mention" | "unread";
+    count: number;
+}
+
+export function NotificationsPanel() {
+    const { state, dispatch } = useChat();
+    const { handleServerChange } = useChatHandlers();
+    const [open, setOpen] = useState(false);
+    const ref = useRef<HTMLDivElement | null>(null);
+
+    const items = useMemo<NotificationItem[]>(() => {
+        const result: NotificationItem[] = [];
+        const dmIds = new Set(state.allDmChannels.map((c) => c.id));
+
+        for (const dm of state.allDmChannels) {
+            const unread = state.unreadCountByChannel[dm.id] ?? 0;
+            const mentions = state.mentionCountByChannel[dm.id] ?? 0;
+            if (unread === 0 && mentions === 0) continue;
+            if (state.muteStatusByChannel[dm.id]) continue;
+            result.push({
+                channelId: dm.id,
+                serverId: dm.serverId,
+                label: getChannelName(dm, state.viewer?.productUserId),
+                kind: "dm",
+                count: mentions || unread
+            });
+        }
+
+        for (const [channelId, mentions] of Object.entries(state.mentionCountByChannel)) {
+            if (mentions <= 0) continue;
+            if (dmIds.has(channelId)) continue;
+            if (state.muteStatusByChannel[channelId]) continue;
+            const channel = state.channels.find((c) => c.id === channelId);
+            if (!channel) continue;
+            result.push({
+                channelId,
+                serverId: channel.serverId,
+                label: getChannelName(channel, state.viewer?.productUserId),
+                kind: "mention",
+                count: mentions
+            });
+        }
+
+        return result;
+    }, [
+        state.allDmChannels,
+        state.channels,
+        state.unreadCountByChannel,
+        state.mentionCountByChannel,
+        state.muteStatusByChannel,
+        state.viewer?.productUserId
+    ]);
+
+    const totalCount = items.reduce((sum, n) => sum + n.count, 0);
+
+    useEffect(() => {
+        if (!open) return;
+        const onClick = (e: MouseEvent) => {
+            if (ref.current && !ref.current.contains(e.target as Node)) {
+                setOpen(false);
+            }
+        };
+        document.addEventListener("mousedown", onClick);
+        return () => document.removeEventListener("mousedown", onClick);
+    }, [open]);
+
+    const handleSelect = async (item: NotificationItem) => {
+        setOpen(false);
+        await handleServerChange(item.serverId, item.channelId);
+    };
+
+    return (
+        <div className="notifications-anchor" ref={ref}>
+            <button
+                type="button"
+                className="icon-button"
+                aria-label="Notifications"
+                aria-expanded={open}
+                title={totalCount > 0 ? `${totalCount} unread notification${totalCount === 1 ? "" : "s"}` : "Notifications"}
+                onClick={() => setOpen((v) => !v)}
+                data-testid="notifications-bell"
+            >
+                <span className="bell-glyph">🔔</span>
+                {totalCount > 0 && <span className="notif-badge" data-testid="notifications-badge">{totalCount > 99 ? "99+" : totalCount}</span>}
+            </button>
+
+            {open && (
+                <div className="notifications-panel" role="dialog" aria-label="Notifications" data-testid="notifications-panel">
+                    <header className="notifications-header">
+                        <h3>Notifications</h3>
+                        <button type="button" className="close-button" aria-label="Close notifications" onClick={() => setOpen(false)}>×</button>
+                    </header>
+                    {items.length === 0 ? (
+                        <p className="notifications-empty">You&apos;re all caught up.</p>
+                    ) : (
+                        <ul className="notifications-list">
+                            {items.map((item) => (
+                                <li key={item.channelId}>
+                                    <button
+                                        type="button"
+                                        className="notif-item"
+                                        onClick={() => handleSelect(item)}
+                                    >
+                                        <span className={`notif-kind notif-kind-${item.kind}`}>
+                                            {item.kind === "dm" ? "💬" : item.kind === "mention" ? "@" : "•"}
+                                        </span>
+                                        <span className="notif-label">{item.label}</span>
+                                        <span className="notif-count">{item.count}</span>
+                                    </button>
+                                </li>
+                            ))}
+                        </ul>
+                    )}
+                </div>
+            )}
+
+            <style jsx>{`
+                .notifications-anchor {
+                    position: relative;
+                    display: inline-flex;
+                }
+                .bell-glyph {
+                    font-size: 1rem;
+                }
+                .notif-badge {
+                    position: absolute;
+                    top: -4px;
+                    right: -4px;
+                    background: var(--danger);
+                    color: white;
+                    font-size: 0.65rem;
+                    font-weight: 700;
+                    padding: 2px 5px;
+                    border-radius: 10px;
+                    min-width: 16px;
+                    text-align: center;
+                    line-height: 1;
+                }
+                .notifications-panel {
+                    position: absolute;
+                    top: calc(100% + 6px);
+                    right: 0;
+                    width: 320px;
+                    max-height: 60vh;
+                    overflow-y: auto;
+                    background: var(--surface);
+                    color: var(--text);
+                    border: 1px solid var(--border);
+                    border-radius: 8px;
+                    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
+                    z-index: 4000;
+                }
+                .notifications-header {
+                    display: flex;
+                    align-items: center;
+                    justify-content: space-between;
+                    padding: 0.75rem 1rem;
+                    border-bottom: 1px solid var(--border);
+                }
+                .notifications-header h3 {
+                    margin: 0;
+                    font-size: 0.95rem;
+                }
+                .close-button {
+                    background: transparent;
+                    border: 0;
+                    color: var(--text-muted);
+                    font-size: 1.25rem;
+                    cursor: pointer;
+                    padding: 0 0.25rem;
+                }
+                .notifications-empty {
+                    padding: 1.5rem 1rem;
+                    text-align: center;
+                    color: var(--text-muted);
+                    font-size: 0.875rem;
+                }
+                .notifications-list {
+                    list-style: none;
+                    padding: 0;
+                    margin: 0;
+                }
+                .notif-item {
+                    display: flex;
+                    align-items: center;
+                    gap: 10px;
+                    width: 100%;
+                    padding: 0.6rem 1rem;
+                    background: transparent;
+                    border: 0;
+                    color: var(--text);
+                    cursor: pointer;
+                    text-align: left;
+                    font-size: 0.875rem;
+                }
+                .notif-item:hover {
+                    background: var(--surface-alt);
+                }
+                .notif-kind {
+                    width: 22px;
+                    text-align: center;
+                    color: var(--text-muted);
+                }
+                .notif-kind-mention {
+                    color: var(--accent);
+                    font-weight: 700;
+                }
+                .notif-label {
+                    flex: 1;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                }
+                .notif-count {
+                    background: var(--accent-soft, var(--surface-alt));
+                    color: var(--text);
+                    border-radius: 10px;
+                    padding: 2px 8px;
+                    font-size: 0.75rem;
+                    font-weight: 600;
+                }
+            `}</style>
+        </div>
+    );
+}

--- a/apps/web/components/sidebar.tsx
+++ b/apps/web/components/sidebar.tsx
@@ -6,7 +6,7 @@ import { useChat, ModalType } from "../context/chat-context";
 import { Channel, Server } from "@skerry/shared";
 import { getChannelName, getChannelIcon } from "../lib/channel-utils";
 import { ContextMenu, ContextMenuItem } from "./context-menu";
-import { upsertChannelReadState, joinServer } from "../lib/control-plane";
+import { upsertChannelReadState, joinServer, leaveDmChannel } from "../lib/control-plane";
 
 const cn = (...classes: (string | boolean | undefined)[]) => classes.filter(Boolean).join(" ");
 
@@ -158,6 +158,36 @@ export function Sidebar({
         setContextMenu({ x: e.clientX, y: e.clientY, items });
     };
 
+    const handleDmContextMenu = (e: React.MouseEvent, dm: Channel) => {
+        e.preventDefault();
+        const items: ContextMenuItem[] = [
+            {
+                label: "Leave Conversation",
+                onClick: () => {
+                    dispatch({ type: "SET_ACTIVE_MODAL", payload: "confirmation" });
+                    dispatch({
+                        type: "SET_CONFIRMATION",
+                        payload: {
+                            title: "Leave Conversation",
+                            message: "Leave this direct message? You won't see new messages from this conversation, and other participants will continue to see it.",
+                            confirmLabel: "Leave",
+                            danger: true,
+                            onConfirm: async () => {
+                                try {
+                                    await leaveDmChannel(dm.id);
+                                    dispatch({ type: "REMOVE_DM_CHANNEL", payload: dm.id });
+                                } catch (err) {
+                                    console.error("Failed to leave DM:", err);
+                                }
+                            }
+                        }
+                    });
+                }
+            }
+        ];
+        setContextMenu({ x: e.clientX, y: e.clientY, items });
+    };
+
     const handleServerContextMenu = (e: React.MouseEvent, server: Server) => {
         e.preventDefault();
         const serverChannels = channels.filter(c => c.serverId === server.id);
@@ -303,7 +333,7 @@ export function Sidebar({
                     <ul>
                         {state.allDmChannels?.map((dm) => (
                             <li key={dm.id}>
-                                <div className="list-item-container">
+                                <div className="list-item-container" onContextMenu={(e) => handleDmContextMenu(e, dm)}>
                                     <button
                                         type="button"
                                         className={cn(

--- a/apps/web/context/chat-context.tsx
+++ b/apps/web/context/chat-context.tsx
@@ -244,6 +244,7 @@ type ChatAction =
     | { type: "SET_MEMBERS"; payload: ChatMember[] }
     | { type: "SET_ALL_DM_CHANNELS", payload: Channel[] }
     | { type: "ADD_DM_CHANNEL", payload: Channel }
+    | { type: "REMOVE_DM_CHANNEL", payload: string }
     | { type: "SET_LAST_CHANNEL_BY_SERVER", payload: { serverId: string; channelId: string } }
     | { type: "SET_THREAD_PARENT_ID", payload: string | null }
     | { type: "SET_QUOTING_MESSAGE", payload: MessageItem | null }
@@ -606,6 +607,20 @@ export function chatReducer(state: ChatState, action: ChatAction): ChatState {
                 ? [incoming, ...state.channels]
                 : state.channels;
             return { ...state, allDmChannels: nextDms, channels: nextChannels };
+        }
+        case "REMOVE_DM_CHANNEL": {
+            const channelId = action.payload;
+            const nextDms = state.allDmChannels.filter(c => c.id !== channelId);
+            const nextChannels = state.channels.filter(c => c.id !== channelId);
+            const wasSelected = state.selectedChannelId === channelId;
+            return {
+                ...state,
+                allDmChannels: nextDms,
+                channels: nextChannels,
+                selectedChannelId: wasSelected ? null : state.selectedChannelId,
+                activeChannelData: wasSelected ? null : state.activeChannelData,
+                messages: wasSelected ? [] : state.messages
+            };
         }
         case "SET_LAST_CHANNEL_BY_SERVER":
             return {

--- a/apps/web/e2e/dm-lifecycle.spec.ts
+++ b/apps/web/e2e/dm-lifecycle.spec.ts
@@ -1,0 +1,129 @@
+import { test, expect, type Page } from '@playwright/test';
+import {
+  bootstrapSpaceWithChannel,
+  loginAndOnboard,
+  selectServerByInitial,
+  selectChannelByName,
+  openDetailsDrawer,
+  waitForStatusLive,
+} from './helpers';
+
+/**
+ * Sprint 1 Lane C — DM lifecycle regressions:
+ * - #35: starting a DM updates the creator's sidebar without a refresh.
+ * - #40: receiving a DM updates the recipient's sidebar without a refresh
+ *   (channel.created hub event → ADD_DM_CHANNEL).
+ * - #41: the topbar bell exposes a notifications panel reflecting unread DMs.
+ * - #45: a non-creator can leave the DM and it disappears from their sidebar.
+ *
+ * These run as one scenario because the multi-context bootstrap dominates
+ * runtime — splitting into four tests would 4× a ~30s setup for ~no gain.
+ */
+test.describe('DM lifecycle (Sprint 1 Lane C)', () => {
+  let pageB: Page;
+  let pageBContext: any;
+
+  async function inviteMemberB(page: Page): Promise<string> {
+    await openDetailsDrawer(page);
+    await page.getByTestId('create-hub-invite-button').click();
+    await page.getByTestId('hub-invite-modal').waitFor();
+    await page.getByRole('button', { name: 'Generate Invite Link' }).click();
+    const inviteUrlInput = page.getByTestId('invite-url-input');
+    await expect(inviteUrlInput).toHaveValue(/invite\/[a-zA-Z0-9_-]+/, { timeout: 10000 });
+    const url = await inviteUrlInput.inputValue();
+    await page.getByTestId('done-invite-modal').click();
+    return url;
+  }
+
+  async function joinAsMemberB(
+    browser: any,
+    inviteUrl: string
+  ): Promise<{ context: any; page: Page }> {
+    const context = await browser.newContext();
+    const pb = await context.newPage();
+    await pb.goto('/');
+    await loginAndOnboard(pb, 'dm-bob', 'dm-bob');
+    await pb.goto(inviteUrl);
+    await expect(pb.locator('.invite-card')).toBeVisible({ timeout: 15000 });
+    await Promise.all([
+      pb.waitForURL((url: URL) => new URL(url.toString()).pathname === '/', { timeout: 20000 }),
+      pb.getByRole('button', { name: 'Accept Invite & Join Hub' }).click(),
+    ]);
+    await expect(pb.getByTestId('sidebar-container')).toBeVisible({ timeout: 15000 });
+    await expect(
+      pb.getByTestId('channel-nav-item').filter({ hasText: /#?general/i }).first()
+    ).toBeVisible({ timeout: 20000 });
+    return { context, page: pb };
+  }
+
+  test.beforeEach(async ({ page, browser }) => {
+    const { channelName } = await bootstrapSpaceWithChannel(page);
+    const inviteUrl = await inviteMemberB(page);
+    const joined = await joinAsMemberB(browser, inviteUrl);
+    pageBContext = joined.context;
+    pageB = joined.page;
+
+    // Park both users on the seeded text channel so SSE state is "live"
+    // before we exercise the DM surface.
+    await selectServerByInitial(page, 'P');
+    await selectChannelByName(page, channelName);
+    await waitForStatusLive(page);
+
+    await selectServerByInitial(pageB, 'P');
+    await selectChannelByName(pageB, channelName);
+    await waitForStatusLive(pageB);
+  });
+
+  test.afterEach(async () => {
+    await pageBContext?.close();
+  });
+
+  test('admin DMs bob → both sidebars update live; bob leaves and sees it disappear', async ({ page }) => {
+    // ---- #35: admin opens a DM with bob ----
+    await page.getByTestId('back-to-servers').click();
+    await page.getByRole('button', { name: 'New Message' }).click();
+    await expect(page.getByRole('heading', { name: 'New Direct Message' })).toBeVisible({
+      timeout: 5000,
+    });
+    await page.getByPlaceholder('Type a username...').fill('dm-bob');
+    const bobRow = page.locator('.user-result-item', { hasText: 'dm-bob' });
+    await expect(bobRow).toBeVisible({ timeout: 5000 });
+    await bobRow.click();
+
+    // Modal closes and admin lands on the DM. The sidebar's DMs row must show
+    // bob's username — pre-fix, the row didn't appear at all until refresh.
+    await expect(page.getByRole('heading', { name: 'New Direct Message' })).toBeHidden();
+    await page.getByTestId('back-to-servers').click();
+    const adminDmRow = page.locator('.list-item.server-entry', { hasText: 'dm-bob' });
+    await expect(adminDmRow).toBeVisible({ timeout: 10000 });
+
+    // ---- #40: bob's sidebar reflects the new DM live (no manual refresh) ----
+    // The hub-stream `channel.created` event routes through ADD_DM_CHANNEL when
+    // the viewer is in `participants`. Pre-fix bob would have to wait the full
+    // 60s use-dms poll.
+    await pageB.getByTestId('back-to-servers').click();
+    const bobDmRow = pageB.locator('.list-item.server-entry', { hasText: 'admin' });
+    await expect(bobDmRow).toBeVisible({ timeout: 15000 });
+
+    // ---- #41: the notifications bell renders in the topbar ----
+    // We don't depend on an exact unread count (browser-tab focus + SSE
+    // markChannelAsRead can race), but the bell must be present and openable
+    // and the panel must show the empty/populated state without throwing.
+    await expect(pageB.getByTestId('notifications-bell')).toBeVisible();
+    await pageB.getByTestId('notifications-bell').click();
+    await expect(pageB.getByTestId('notifications-panel')).toBeVisible();
+    // Close the panel before continuing.
+    await pageB.getByTestId('notifications-bell').click();
+
+    // ---- #45: bob leaves the DM via right-click → Leave Conversation ----
+    await bobDmRow.click({ button: 'right' });
+    await pageB.getByTestId('context-menu-item-leave-conversation').click();
+    await pageB.getByRole('button', { name: 'Leave' }).click();
+
+    // The DM disappears from bob's sidebar (REMOVE_DM_CHANNEL) without refresh.
+    await expect(bobDmRow).toBeHidden({ timeout: 10000 });
+
+    // Admin still sees the DM (channel survives until 0 members remain).
+    await expect(adminDmRow).toBeVisible();
+  });
+});

--- a/apps/web/hooks/use-chat-realtime.ts
+++ b/apps/web/hooks/use-chat-realtime.ts
@@ -211,7 +211,19 @@ export function useChatRealtime() {
 
     source.addEventListener("channel.created", (event: any) => {
       const data = JSON.parse(event.data);
-      if (data.serverId === selectedServerId) {
+      // DM channels live on a separate "dm" server. Route them through
+      // ADD_DM_CHANNEL when the viewer is a participant so the sidebar
+      // updates without the 60s use-dms poll. Other channel.created events
+      // upsert into the active server's channel list as before.
+      const isDmForViewer =
+        data.type === "dm" &&
+        Array.isArray(data.participants) &&
+        data.participants.some((p: { productUserId: string }) => p.productUserId === viewer?.productUserId);
+      if (isDmForViewer) {
+        dispatch({ type: "ADD_DM_CHANNEL", payload: data });
+        // Refresh notification summary so the new DM gets unread/mention bookkeeping.
+        void fetchNotificationSummary().then(summary => dispatch({ type: "SET_NOTIFICATIONS", payload: summary }));
+      } else if (data.serverId === selectedServerId) {
         dispatch({ type: "UPSERT_CHANNEL", payload: data });
       }
     });
@@ -228,6 +240,9 @@ export function useChatRealtime() {
       if (data.serverId === selectedServerId) {
         dispatch({ type: "DELETE_CHANNEL", payload: data.id });
       }
+      // Always prune from allDmChannels — DM deletion races server-switch and
+      // the DM list is independent of selectedServerId.
+      dispatch({ type: "REMOVE_DM_CHANNEL", payload: data.id });
     });
 
     source.addEventListener("category.created", (event: any) => {
@@ -257,6 +272,16 @@ export function useChatRealtime() {
       if (isViewer && data.state === "left") {
         showToast("You were kicked from the server.", "error");
         dispatch({ type: "SET_MEMBERSHIP_UPDATE", payload: Date.now() });
+      }
+    });
+
+    source.addEventListener("dm.left", (event: any) => {
+      const data = JSON.parse(event.data) as { channelId: string; userId: string };
+      // The leaver removes the DM from their own state. Other participants
+      // stay on the channel; the channel.deleted event handles cleanup if
+      // the DM was emptied.
+      if (data.userId === viewer?.productUserId) {
+        dispatch({ type: "REMOVE_DM_CHANNEL", payload: data.channelId });
       }
     });
 

--- a/apps/web/lib/control-plane.ts
+++ b/apps/web/lib/control-plane.ts
@@ -340,6 +340,13 @@ export async function createDirectMessage(hubId: string, userIds: string[]): Pro
   });
 }
 
+export async function leaveDmChannel(channelId: string): Promise<{ hubId: string | null; channelDeleted: boolean }> {
+  return apiFetch<{ hubId: string | null; channelDeleted: boolean }>(
+    `/v1/channels/${encodeURIComponent(channelId)}/members/me`,
+    { method: "DELETE" }
+  );
+}
+
 export async function fetchUser(userId: string): Promise<IdentityMapping> {
   return apiFetch<IdentityMapping>(`/v1/users/${encodeURIComponent(userId)}`);
 }

--- a/apps/web/test/chat-context-reducer.test.ts
+++ b/apps/web/test/chat-context-reducer.test.ts
@@ -72,6 +72,56 @@ test("ADD_DM_CHANNEL prepends to state.channels when the DM server is active", (
   assert.equal(next.channels.length, 2);
 });
 
+// #45 — Leaving a DM (or being notified another participant deleted it) drops the
+// channel from both `allDmChannels` and `state.channels`, and clears the active
+// chat surface if that DM was selected, so the user is not stuck reading a stale
+// transcript that no longer exists on the server.
+test("REMOVE_DM_CHANNEL drops the entry and clears active chat when selected", () => {
+  const a = makeDmChannel({ id: "chn_dm_a", serverId: "srv_dm" });
+  const b = makeDmChannel({ id: "chn_dm_b", serverId: "srv_dm" });
+  const state = {
+    ...initialState,
+    allDmChannels: [a, b],
+    channels: [a, b],
+    selectedChannelId: "chn_dm_a",
+    activeChannelData: a,
+    messages: [{ id: "m1", channelId: "chn_dm_a" } as any]
+  };
+
+  const next = chatReducer(state, { type: "REMOVE_DM_CHANNEL", payload: "chn_dm_a" });
+
+  assert.equal(next.allDmChannels.length, 1);
+  assert.equal(next.allDmChannels[0]!.id, "chn_dm_b");
+  assert.equal(next.channels.length, 1);
+  assert.equal(next.channels[0]!.id, "chn_dm_b");
+  assert.equal(next.selectedChannelId, null);
+  assert.equal(next.activeChannelData, null);
+  assert.equal(next.messages.length, 0);
+});
+
+// REMOVE_DM_CHANNEL must not blow away the active chat when the removed DM
+// is a different one — common case: another user we DM'd leaves their DM
+// while we're reading a third channel.
+test("REMOVE_DM_CHANNEL leaves selection alone when a different DM is removed", () => {
+  const a = makeDmChannel({ id: "chn_dm_a", serverId: "srv_dm" });
+  const b = makeDmChannel({ id: "chn_dm_b", serverId: "srv_dm" });
+  const state = {
+    ...initialState,
+    allDmChannels: [a, b],
+    channels: [a, b],
+    selectedChannelId: "chn_dm_b",
+    activeChannelData: b,
+    messages: [{ id: "m1", channelId: "chn_dm_b" } as any]
+  };
+
+  const next = chatReducer(state, { type: "REMOVE_DM_CHANNEL", payload: "chn_dm_a" });
+
+  assert.equal(next.selectedChannelId, "chn_dm_b");
+  assert.equal(next.activeChannelData, b);
+  assert.equal(next.messages.length, 1);
+  assert.equal(next.allDmChannels.length, 1);
+});
+
 // And conversely: when a non-DM server is active, don't pollute its channel list.
 test("ADD_DM_CHANNEL leaves state.channels untouched when a non-DM server is active", () => {
   const textChannel = {


### PR DESCRIPTION
Sprint 1 Lane C done — all four issues fixed on fix/sprint-1-dm-reactivity across four commits.

What landed:

* #35/#40 — Backend emits channel.created on DM creation; frontend SSE handler routes DM events through ADD_DM_CHANNEL for any participant. Both peers' sidebars update without a refresh.
* #45 — New DELETE /v1/channels/:id/members/me + leaveDmChannel service; sidebar context menu "Leave Conversation" gated by the existing confirmation modal; DM survives until last member leaves.
* #41 — NotificationsPanel bell + dropdown in the topbar surfacing unread DMs and @-mentions, honoring mute state. ChatHandlersProvider widened so the topbar can call handleServerChange.

Validation on localhost: shared 16/16, web 11/11 (+2), control-plane 123/123 (+2), Playwright E2E 33/33 (+1 new lifecycle spec). Lint + typecheck clean.

Open follow-up flagged in the report: the hub SSE stream is not user-scoped, so DM channel.created payloads (incl. participant lists) are visible to all hub members on the wire. Frontend filters them, but proper fix is per-user fan-out — left for a future sprint.