### PR TITLE
feat(permissions): default Space Owner = Hub (P3 of permissions sprint)

### DIFF
--- a/.agent-shared/TODO.md
+++ b/.agent-shared/TODO.md
@@ -8,10 +8,8 @@ Land remaining Sprint 2 issues. **No batching, one PR per issue.**
 - [x] **Issue #23**: Invite Link Generation (`fix/issue-23-unauth-invite-redeem`).
 - [/] **Permissions Sprint**:
     - [x] **P1**: Role enum cleanup.
-    - [ ] **P3**: Default Space Owner = Hub.
-        - Nullable `servers.owner_user_id`.
-        - Creation flow: "owned by you / hub" choice.
-        - Expose join_policy in Space Settings.
+    - [x] **P3**: Default Space Owner = Hub
+      (`feat/permissions-sprint-p3-default-space-owner`).
     - [ ] **P2**: Audience tiers, cascade, and capability split.
 - [ ] **Issue #34**: Onboarding Display Name (Blocked on permissions).
 - [ ] **Issue #38**: Server Permissions Persistence (Likely subsumed by P2).

--- a/apps/control-plane/migrations/1775600000000_035-server-owner-nullable.js
+++ b/apps/control-plane/migrations/1775600000000_035-server-owner-nullable.js
@@ -1,0 +1,33 @@
+// Permissions sprint P3: default Space Owner = Hub.
+//
+// Until now `servers.owner_user_id` was NOT NULL — every space had to
+// have a single named human owner. Per the user's framing for the
+// permissions sprint, the default ownership for a new space should
+// instead be "owned by the hub itself" (i.e. any hub manager can
+// manage), and naming a specific human as the owner is an explicit
+// opt-in.
+//
+// This migration relaxes the NOT NULL constraint. It does NOT touch
+// existing rows — every space currently in the database keeps its
+// human owner. The application code interprets `null` as
+// hub-owned going forward.
+
+export const up = (pgm) => {
+    pgm.alterColumn('servers', 'owner_user_id', { notNull: false });
+};
+
+export const down = (pgm) => {
+    // Reversing the relaxation requires every server to have an owner.
+    // Rather than guessing a default user id, we surface it as a
+    // deliberate manual step.
+    pgm.sql(`
+        do $$
+        begin
+            if exists (select 1 from servers where owner_user_id is null) then
+                raise exception 'Cannot reverse 035: % servers have null owner_user_id; assign owners before rolling back.',
+                    (select count(*) from servers where owner_user_id is null);
+            end if;
+        end$$;
+    `);
+    pgm.alterColumn('servers', 'owner_user_id', { notNull: true });
+};

--- a/apps/control-plane/src/routes/server-routes.ts
+++ b/apps/control-plane/src/routes/server-routes.ts
@@ -49,7 +49,8 @@ export async function registerServerRoutes(app: FastifyInstance): Promise<void> 
     const payload = z
       .object({
         hubId: z.string().min(1),
-        name: z.string().min(2).max(80)
+        name: z.string().min(2).max(80),
+        ownership: z.enum(["hub", "self"]).optional()
       })
       .parse(request.body);
 
@@ -241,7 +242,8 @@ export async function registerServerRoutes(app: FastifyInstance): Promise<void> 
       iconUrl: z.string().url().nullable().optional(),
       visibility: z.string().optional(),
       visitorPrivacy: z.string().optional(),
-      joinPolicy: z.enum(["open", "approval", "invite"]).optional()
+      joinPolicy: z.enum(["open", "approval", "invite"]).optional(),
+      autoJoinHubMembers: z.boolean().optional()
     }).parse(request.body);
 
     const allowed = await canManageServer({

--- a/apps/control-plane/src/services/policy-service.ts
+++ b/apps/control-plane/src/services/policy-service.ts
@@ -124,8 +124,8 @@ const SERVER_MANAGER_ROLES: Role[] = ["hub_owner", "hub_admin", "space_owner", "
 export async function fetchServerScope(
   db: Parameters<Parameters<typeof withDb>[0]>[0],
   serverId: string
-): Promise<{ hubId: string; ownerUserId: string } | null> {
-  const row = await db.query<{ hub_id: string; owner_user_id: string }>(
+): Promise<{ hubId: string; ownerUserId: string | null } | null> {
+  const row = await db.query<{ hub_id: string; owner_user_id: string | null }>(
     "select hub_id, owner_user_id from servers where id = $1 limit 1",
     [serverId]
   );
@@ -135,6 +135,9 @@ export async function fetchServerScope(
   }
   return {
     hubId: result.hub_id,
+    // null means hub-owned (P3, 2026-05-08): the space carries no
+    // explicit owner; hub managers handle management. Owner-equality
+    // checks naturally fail for null, which is what we want.
     ownerUserId: result.owner_user_id
   };
 }

--- a/apps/control-plane/src/services/provisioning-service.ts
+++ b/apps/control-plane/src/services/provisioning-service.ts
@@ -59,6 +59,16 @@ export async function createServerWorkflow(input: {
   hubId: string;
   name: string;
   productUserId: string;
+  /**
+   * Ownership choice for the new space.
+   *  - "hub" (default): the space is owned by the hub itself; any hub
+   *    manager may manage it. `owner_user_id` stored as null.
+   *  - "self": the calling user becomes the named space_owner.
+   *
+   * P3 of the permissions sprint (2026-05-08) made "hub" the default;
+   * pre-P3 the creator was always the owner.
+   */
+  ownership?: "hub" | "self";
   idempotencyKey?: string;
 }): Promise<Server> {
   const cached = await checkIdempotency<Server>(input.idempotencyKey, input);
@@ -67,6 +77,7 @@ export async function createServerWorkflow(input: {
   }
 
   const matrixSpaceId = await withRetry(() => createSpace({ name: input.name }));
+  const ownerUserId = input.ownership === "self" ? input.productUserId : null;
 
   const server = await withDb(async (db) => {
     const id = randomId("srv");
@@ -82,7 +93,7 @@ export async function createServerWorkflow(input: {
       visitor_access: string;
       auto_join_hub_members: boolean;
       created_by_user_id: string;
-      owner_user_id: string;
+      owner_user_id: string | null;
       created_at: string;
       join_policy: string;
       icon_url: string | null;
@@ -90,7 +101,7 @@ export async function createServerWorkflow(input: {
       `insert into servers (id, hub_id, name, type, matrix_space_id, created_by_user_id, owner_user_id, auto_join_hub_members, hub_admin_access, space_member_access, hub_member_access, visitor_access, join_policy)
        values ($1, $2, $3, 'default', $4, $5, $6, true, 'chat', 'chat', 'chat', 'hidden', 'open')
        returning *`,
-      [id, input.hubId, input.name, matrixSpaceId, input.productUserId, input.productUserId]
+      [id, input.hubId, input.name, matrixSpaceId, input.productUserId, ownerUserId]
     );
 
     const value = row.rows[0];

--- a/apps/control-plane/src/test/policy.test.ts
+++ b/apps/control-plane/src/test/policy.test.ts
@@ -77,3 +77,62 @@ test("grantRole and canManageServer integration", async (t) => {
   assert.equal(auditLogs.rows[0].role, "space_moderator");
   assert.equal(auditLogs.rows[0].outcome, "granted");
 });
+
+test("hub-owned server (null owner_user_id): hub admin manages, random user does not", async (t) => {
+  if (!pool) { t.skip("DATABASE_URL not configured."); return; }
+
+  // Hub with explicit owner; one server with NULL owner (hub-owned).
+  await pool.query("insert into hubs (id, name, owner_user_id) values ('hub_p3', 'P3 Hub', 'owner_p3')");
+  await pool.query(
+    `insert into servers (id, hub_id, name, type, created_by_user_id, owner_user_id)
+     values ('srv_huboned', 'hub_p3', 'Hub-Owned', 'default', 'owner_p3', null)`
+  );
+
+  // The hub owner (synthesized as hub_owner via getEffectiveRoleBindings)
+  // can manage the hub-owned server.
+  const ownerCanManage = await canManageServer({
+    productUserId: "owner_p3",
+    serverId: "srv_huboned"
+  });
+  assert.equal(ownerCanManage, true, "hub owner should manage hub-owned server");
+
+  // A random unrelated user cannot.
+  const randomCanManage = await canManageServer({
+    productUserId: "rando_p3",
+    serverId: "srv_huboned"
+  });
+  assert.equal(randomCanManage, false, "rando should not manage hub-owned server");
+
+  // A user with hub_admin binding can.
+  await pool.query(
+    `insert into role_bindings (id, product_user_id, role, hub_id)
+     values ('rb_p3_admin', 'admin_p3', 'hub_admin', 'hub_p3')`
+  );
+  const adminCanManage = await canManageServer({
+    productUserId: "admin_p3",
+    serverId: "srv_huboned"
+  });
+  assert.equal(adminCanManage, true, "hub_admin should manage hub-owned server");
+});
+
+test("hub-owned server (null owner): no synthetic space_owner binding for any user", async (t) => {
+  if (!pool) { t.skip("DATABASE_URL not configured."); return; }
+
+  await pool.query("insert into hubs (id, name, owner_user_id) values ('hub_p3b', 'P3b Hub', 'owner_p3b')");
+  await pool.query(
+    `insert into servers (id, hub_id, name, type, created_by_user_id, owner_user_id)
+     values ('srv_huboned_b', 'hub_p3b', 'Hub-Owned B', 'default', 'owner_p3b', null)`
+  );
+
+  // listAllowedActions for an unrelated user with no role bindings: should be empty.
+  const allowed = await listAllowedActions({
+    productUserId: "rando_p3b",
+    scope: { hubId: "hub_p3b", serverId: "srv_huboned_b" }
+  });
+  // Visitor relation has no privileged actions in the matrix.
+  assert.equal(
+    allowed.includes("moderation.ban"),
+    false,
+    "random user must not get space_owner-derived actions on hub-owned server"
+  );
+});

--- a/apps/web/components/chat-client.tsx
+++ b/apps/web/components/chat-client.tsx
@@ -253,6 +253,7 @@ export function ChatClient() {
 
   const {
     spaceName, setSpaceName,
+    spaceOwnership, setSpaceOwnership,
     roomName, setRoomName,
     roomType, setRoomType,
     roomIcon, setRoomIcon,
@@ -960,6 +961,8 @@ export function ChatClient() {
         dispatch={dispatch}
         spaceName={spaceName}
         setSpaceName={setSpaceName}
+        spaceOwnership={spaceOwnership}
+        setSpaceOwnership={setSpaceOwnership}
         renameSpaceId={renameSpaceId}
         renameSpaceName={renameSpaceName}
         renameSpaceIconUrl={renameSpaceIconUrl}

--- a/apps/web/components/modals/ClientModals.tsx
+++ b/apps/web/components/modals/ClientModals.tsx
@@ -16,6 +16,8 @@ interface ClientModalsProps {
   // State from ChatClient/Hooks
   spaceName: string;
   setSpaceName: (name: string) => void;
+  spaceOwnership: "hub" | "self";
+  setSpaceOwnership: (val: "hub" | "self") => void;
   renameSpaceId: string;
   renameSpaceName: string;
   renameSpaceIconUrl: string | null;
@@ -139,6 +141,8 @@ export function ClientModals(props: ClientModalsProps) {
               setSpaceSettingsTab={props.setSpaceSettingsTab}
               spaceName={props.spaceName}
               setSpaceName={props.setSpaceName}
+              spaceOwnership={props.spaceOwnership}
+              setSpaceOwnership={props.setSpaceOwnership}
               renameSpaceId={props.renameSpaceId}
               renameSpaceName={props.renameSpaceName}
               renameSpaceIconUrl={props.renameSpaceIconUrl}

--- a/apps/web/components/modals/SpaceModals.tsx
+++ b/apps/web/components/modals/SpaceModals.tsx
@@ -13,6 +13,8 @@ interface SpaceModalsProps {
   setSpaceSettingsTab: (tab: "general" | "permissions") => void;
   spaceName: string;
   setSpaceName: (name: string) => void;
+  spaceOwnership: "hub" | "self";
+  setSpaceOwnership: (val: "hub" | "self") => void;
   renameSpaceId: string;
   renameSpaceName: string;
   renameSpaceIconUrl: string | null;
@@ -34,6 +36,8 @@ export function SpaceModals({
   setSpaceSettingsTab,
   spaceName,
   setSpaceName,
+  spaceOwnership,
+  setSpaceOwnership,
   renameSpaceId,
   renameSpaceName,
   renameSpaceIconUrl,
@@ -66,6 +70,37 @@ export function SpaceModals({
           maxLength={80}
           required
         />
+
+        <fieldset className="constrained-stack" style={{ border: "1px solid var(--border)", borderRadius: "6px", padding: "0.5rem 0.75rem" }}>
+          <legend style={{ fontSize: "0.85rem", padding: "0 0.25rem" }}>Ownership</legend>
+          <label style={{ display: "flex", gap: "0.5rem", alignItems: "flex-start", fontSize: "0.85rem", padding: "0.25rem 0" }}>
+            <input
+              type="radio"
+              name="space-ownership"
+              value="hub"
+              checked={spaceOwnership === "hub"}
+              onChange={() => setSpaceOwnership("hub")}
+            />
+            <span>
+              <strong>Owned by the Hub</strong> — any hub admin can manage this space.
+              Recommended unless you specifically want a single named owner.
+            </span>
+          </label>
+          <label style={{ display: "flex", gap: "0.5rem", alignItems: "flex-start", fontSize: "0.85rem", padding: "0.25rem 0" }}>
+            <input
+              type="radio"
+              name="space-ownership"
+              value="self"
+              checked={spaceOwnership === "self"}
+              onChange={() => setSpaceOwnership("self")}
+            />
+            <span>
+              <strong>Owned by me</strong> — you become the named space_owner.
+              Hub admins still retain management rights at the hub level.
+            </span>
+          </label>
+        </fieldset>
+
         <button type="submit" disabled={mutatingStructure}>Create Space</button>
       </form>
     );
@@ -156,14 +191,15 @@ export function SpaceModals({
         ) : (() => {
           const serverToEdit = servers.find(s => s.id === renameSpaceId) || activeServer;
           return (
-            <PermissionsEditor 
+            <PermissionsEditor
               serverId={renameSpaceId}
               initialAccess={{
                 hubAdminAccess: serverToEdit?.hubAdminAccess ?? 'chat',
                 spaceMemberAccess: serverToEdit?.spaceMemberAccess ?? 'chat',
                 hubMemberAccess: serverToEdit?.hubMemberAccess ?? 'chat',
                 visitorAccess: serverToEdit?.visitorAccess ?? 'hidden',
-                joinPolicy: serverToEdit?.joinPolicy
+                joinPolicy: serverToEdit?.joinPolicy,
+                autoJoinHubMembers: serverToEdit?.autoJoinHubMembers ?? false
               }}
               onSaveDefaults={async (access) => {
                 await updateServerSettings(renameSpaceId, access);

--- a/apps/web/components/permissions-editor.tsx
+++ b/apps/web/components/permissions-editor.tsx
@@ -13,6 +13,7 @@ interface PermissionsEditorProps {
         hubMemberAccess: AccessLevel;
         visitorAccess: AccessLevel;
         joinPolicy?: JoinPolicy;
+        autoJoinHubMembers?: boolean;
     };
     onSaveDefaults: (access: {
         hubAdminAccess: AccessLevel;
@@ -20,6 +21,7 @@ interface PermissionsEditorProps {
         hubMemberAccess: AccessLevel;
         visitorAccess: AccessLevel;
         joinPolicy?: JoinPolicy;
+        autoJoinHubMembers?: boolean;
     }) => Promise<void>;
 }
 
@@ -119,7 +121,7 @@ export function PermissionsEditor({
                     {!channelId && (
                         <>
                             <label>Join Policy</label>
-                            <select 
+                            <select
                                 value={access.joinPolicy || "open"}
                                 onChange={(e) => setAccess({ ...access, joinPolicy: e.target.value as JoinPolicy })}
                             >
@@ -127,6 +129,20 @@ export function PermissionsEditor({
                                 <option value="approval">Approval (Admins must approve)</option>
                                 <option value="invite">Invite Only (Explicit invite required)</option>
                             </select>
+
+                            <label htmlFor="auto-join-hub-members">Auto-join new hub members</label>
+                            <div style={{ display: "flex", gap: "0.5rem", alignItems: "center" }}>
+                                <input
+                                    id="auto-join-hub-members"
+                                    type="checkbox"
+                                    checked={access.autoJoinHubMembers ?? false}
+                                    onChange={(e) => setAccess({ ...access, autoJoinHubMembers: e.target.checked })}
+                                />
+                                <span style={{ fontSize: "0.85rem", color: "var(--text-muted)" }}>
+                                    When enabled, anyone who joins the hub (via registration or
+                                    a hub-level invite) is automatically added to this space.
+                                </span>
+                            </div>
                         </>
                     )}
                 </div>

--- a/apps/web/hooks/use-chat-mutations.ts
+++ b/apps/web/hooks/use-chat-mutations.ts
@@ -57,6 +57,7 @@ export function useChatMutations({
   // Local state for forms
   const [selectedHubIdForCreate, setSelectedHubIdForCreate] = useState<string | null>(null);
   const [spaceName, setSpaceName] = useState("New Space");
+  const [spaceOwnership, setSpaceOwnership] = useState<"hub" | "self">("hub");
   const [roomName, setRoomName] = useState("new-room");
   const [roomType, setRoomType] = useState<ChannelType>("text");
   const [roomIcon, setRoomIcon] = useState("");
@@ -100,9 +101,11 @@ export function useChatMutations({
     try {
       const server = await createServer({
         hubId: effectiveHubId,
-        name: spaceName.trim()
+        name: spaceName.trim(),
+        ownership: spaceOwnership
       });
       setSpaceName("New Space");
+      setSpaceOwnership("hub");
       dispatch({ type: "SET_ACTIVE_MODAL", payload: null });
       showToast("Space created successfully", "success");
       await refreshChatState(server.id, undefined, undefined, true);
@@ -395,6 +398,7 @@ export function useChatMutations({
 
   return {
     spaceName, setSpaceName,
+    spaceOwnership, setSpaceOwnership,
     roomName, setRoomName,
     roomType, setRoomType,
     roomIcon, setRoomIcon,

--- a/apps/web/lib/control-plane.ts
+++ b/apps/web/lib/control-plane.ts
@@ -471,7 +471,11 @@ export async function sendTypingStatus(channelId: string, isTyping: boolean): Pr
   });
 }
 
-export async function createServer(input: { hubId: string; name: string }): Promise<Server> {
+export async function createServer(input: {
+  hubId: string;
+  name: string;
+  ownership?: "hub" | "self";
+}): Promise<Server> {
   return apiFetch<Server>("/v1/servers", {
     method: "POST",
     headers: { "Content-Type": "application/json" },

--- a/packages/shared/src/domain/contracts.ts
+++ b/packages/shared/src/domain/contracts.ts
@@ -150,7 +150,13 @@ export interface Server {
     type: "default" | "dm";
     matrixSpaceId: string | null;
     createdByUserId: string;
-    ownerUserId: string;
+    /**
+     * Explicit space owner. `null` means the space is owned by the hub
+     * itself — any hub manager may manage it, no individual user holds
+     * the owner role. P3 of the permissions sprint (2026-05-08) made
+     * this the default for newly-created spaces.
+     */
+    ownerUserId: string | null;
     startingChannelId?: string | null;
     iconUrl?: string | null;
     hubAdminAccess: AccessLevel;


### PR DESCRIPTION
Second slice of the permissions sprint, off `permissions-sprint`.
Hub-ownership is now the default for newly-created spaces. P1 (role
enum cleanup) merged earlier; P2 (audience tiers + cascade +
canManageServer capability split) is the remaining slice.

## Why

Per the user's permissions-sprint framing, "Spaces should have an
Owner (default to Ownership by the hub itself, giving Hub Admins
control)." Pre-P3 every space had a single named human owner —
necessarily the creator — which forced personal ownership even for
spaces that were really just hub real estate.

After P3:
- `owner_user_id IS NULL` ⇒ space is owned by the hub. No synthetic
  `space_owner` binding fires for anyone. Hub admins manage via
  their existing role bindings.
- `owner_user_id = <user>` ⇒ legacy named-owner behavior. The flag
  is opt-in via the new "Owned by me" radio.

## What changed

**Migration 035** — drops `NOT NULL` on `servers.owner_user_id`.
Existing rows preserved.

**Shared** — `Server.ownerUserId: string | null`.

**Control plane**
- `fetchServerScope` returns nullable owner.
- `createServerWorkflow` takes `ownership: "hub" | "self"` (default
  `"hub"`).
- `POST /v1/servers` accepts the new `ownership` body field.
- `PATCH /v1/servers/:serverId/settings` accepts
  `autoJoinHubMembers`.

**Web**
- New-space modal: radio fieldset "Owned by the Hub" (default) /
  "Owned by me".
- Permissions editor gains an "Auto-join new hub members" checkbox.

**Tests** — two new control-plane integration cases for the
null-owner path. Suite green: shared 16/16, web 12/12,
**control-plane 131/131** on the live test stack.

## Test plan

- [x] `pnpm --filter @skerry/shared build` — clean.
- [x] `pnpm --filter @skerry/shared test` — 16/16.
- [x] `pnpm --filter @skerry/web test` — 12/12.
- [x] **`pnpm --filter @skerry/control-plane test` — 131/131** on
      the live test stack (run before commit).
- [x] Typecheck clean for changed files (pre-existing unrelated
      errors in `link-service.ts`, `embed-card.tsx`,
      `e2e/helpers/a11y.ts`, stale `.next/types/...` remain).
- [ ] **Pangolin walk-through:**
      1. Run migration 035; `select count(*) from servers where
         owner_user_id is null` should still be zero unless someone
         created a space post-merge.
      2. Create a new space leaving "Owned by the Hub" selected.
         Verify the new row in `servers` has `owner_user_id IS
         NULL`. Verify the creating hub admin can rename the space
         and create rooms.
      3. Create a second space with "Owned by me". Verify
         `owner_user_id = creator.productUserId` and that the
         creator (and only the creator + hub admins) can manage.
      4. Open the second space's Space Settings → Permissions tab.
         Toggle "Auto-join new hub members"; reload and confirm
         the toggle persists. Confirm no console errors.

## Open question (not blocking)

Newly-created spaces still default to `auto_join_hub_members =
true` (existing behavior, preserved by P3). The toggle is exposed
either way; the default is a separate product call. Flip it to
`false` if hub-wide auto-join feels too opinionated.

## What's NOT in this PR

- The `canManageServer` → capability-gates split (`canModerateServer`,
  `canEditServerSettings`, `canManageServerRoles`, `canManageRooms`).
  That's P2.
- Audience tier expansion (adding `space_admin_access` /
  `space_moderator_access` columns) and the Hub→Space→Room cascade
  with override semantics. Also P2.
- A "Transfer ownership to Hub" UI affordance for existing
  named-owner spaces. The capability is reachable via SQL but no
  web flow exists yet — follow-up if needed.
