### PR TITLE
feat(permissions): split canManageServer into named capability gates (P2.a)

### DIFF
--- a/.agent-shared/TODO.md
+++ b/.agent-shared/TODO.md
@@ -10,7 +10,14 @@ Land remaining Sprint 2 issues. **No batching, one PR per issue.**
     - [x] **P1**: Role enum cleanup.
     - [x] **P3**: Default Space Owner = Hub
       (`feat/permissions-sprint-p3-default-space-owner`).
-    - [ ] **P2**: Audience tiers, cascade, and capability split.
+    - [/] **P2**: Audience tiers, cascade, and capability split.
+        - [x] **P2.a**: Capability split (`canModerateServer` /
+          `canEditServerSettings` / `canManageServerRoles` /
+          `canManageRooms`) on
+          `feat/permissions-sprint-p2a-capability-gates`.
+        - [ ] **P2.b**: Normalized access rules table + tier
+          expansion + Hub→Space→Room cascade + room read/write
+          split.
 - [ ] **Issue #34**: Onboarding Display Name (Blocked on permissions).
 - [ ] **Issue #38**: Server Permissions Persistence (Likely subsumed by P2).
 

--- a/apps/control-plane/src/routes/channel-routes.ts
+++ b/apps/control-plane/src/routes/channel-routes.ts
@@ -2,7 +2,7 @@ import type { FastifyInstance } from "fastify";
 import { z } from "zod";
 import { requireAuth, requireInitialized } from "../auth/middleware.js";
 import {
-  canManageServer
+  canManageRooms
 } from "../services/policy-service.js";
 import {
   createChannelWorkflow
@@ -53,7 +53,7 @@ export async function registerChannelRoutes(app: FastifyInstance): Promise<void>
       })
       .parse(request.body);
 
-    const allowed = await canManageServer({
+    const allowed = await canManageRooms({
       productUserId: request.auth!.productUserId,
       serverId: payload.serverId,
       authContext: request.auth
@@ -87,7 +87,7 @@ export async function registerChannelRoutes(app: FastifyInstance): Promise<void>
     const params = z.object({ channelId: z.string().min(1) }).parse(request.params);
     const query = z.object({ serverId: z.string().min(1) }).parse(request.query);
 
-    const allowed = await canManageServer({
+    const allowed = await canManageRooms({
       productUserId: request.auth!.productUserId,
       serverId: query.serverId,
       authContext: request.auth
@@ -114,7 +114,7 @@ export async function registerChannelRoutes(app: FastifyInstance): Promise<void>
   app.get("/v1/channels/:channelId/settings", initializedAuthHandlers, async (request, reply) => {
     const params = z.object({ channelId: z.string().min(1) }).parse(request.params);
     const query = z.object({ serverId: z.string().min(1) }).parse(request.query);
-    const allowed = await canManageServer({
+    const allowed = await canManageRooms({
       productUserId: request.auth!.productUserId,
       serverId: query.serverId,
       authContext: request.auth
@@ -138,7 +138,7 @@ export async function registerChannelRoutes(app: FastifyInstance): Promise<void>
       visitorAccess: z.enum(["hidden", "locked", "read", "chat"]).optional()
     }).parse(request.body);
 
-    const allowed = await canManageServer({
+    const allowed = await canManageRooms({
       productUserId: request.auth!.productUserId,
       serverId: payload.serverId,
       authContext: request.auth
@@ -247,7 +247,7 @@ export async function registerChannelRoutes(app: FastifyInstance): Promise<void>
       })
       .parse(request.body);
 
-    const allowed = await canManageServer({
+    const allowed = await canManageRooms({
       productUserId: request.auth!.productUserId,
       serverId: payload.serverId,
       authContext: request.auth
@@ -296,7 +296,7 @@ export async function registerChannelRoutes(app: FastifyInstance): Promise<void>
       })
       .parse(request.body);
 
-    const allowed = await canManageServer({
+    const allowed = await canManageRooms({
       productUserId: request.auth!.productUserId,
       serverId: payload.serverId,
       authContext: request.auth
@@ -321,7 +321,7 @@ export async function registerChannelRoutes(app: FastifyInstance): Promise<void>
       })
       .parse(request.body);
 
-    const allowed = await canManageServer({
+    const allowed = await canManageRooms({
       productUserId: request.auth!.productUserId,
       serverId: payload.serverId,
       authContext: request.auth
@@ -351,7 +351,7 @@ export async function registerChannelRoutes(app: FastifyInstance): Promise<void>
     const params = z.object({ categoryId: z.string().min(1) }).parse(request.params);
     const query = z.object({ serverId: z.string().min(1) }).parse(request.query);
 
-    const allowed = await canManageServer({
+    const allowed = await canManageRooms({
       productUserId: request.auth!.productUserId,
       serverId: query.serverId,
       authContext: request.auth
@@ -383,7 +383,7 @@ export async function registerChannelRoutes(app: FastifyInstance): Promise<void>
       })
       .parse(request.body);
 
-    const allowed = await canManageServer({
+    const allowed = await canManageRooms({
       productUserId: request.auth!.productUserId,
       serverId: payload.serverId,
       authContext: request.auth
@@ -446,7 +446,7 @@ export async function registerChannelRoutes(app: FastifyInstance): Promise<void>
       })
       .parse(request.body);
 
-    const allowed = await canManageServer({
+    const allowed = await canManageRooms({
       productUserId: request.auth!.productUserId,
       serverId: payload.serverId,
       authContext: request.auth

--- a/apps/control-plane/src/routes/discord-routes.ts
+++ b/apps/control-plane/src/routes/discord-routes.ts
@@ -2,7 +2,6 @@ import type { FastifyInstance } from "fastify";
 import { z } from "zod";
 import { requireAuth, requireInitialized } from "../auth/middleware.js";
 import {
-  canManageServer,
   canManageDiscordBridge
 } from "../services/policy-service.js";
 import {

--- a/apps/control-plane/src/routes/invite-routes.ts
+++ b/apps/control-plane/src/routes/invite-routes.ts
@@ -1,7 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import { z } from "zod";
 import { requireAuth, requireInitialized } from "../auth/middleware.js";
-import { canManageHub, canManageServer } from "../services/policy-service.js";
+import { canManageHub, canManageServerRoles } from "../services/policy-service.js";
 import {
   createHubInvite,
   getHubInvite,
@@ -73,7 +73,7 @@ export async function registerInviteRoutes(app: FastifyInstance): Promise<void> 
       // Otherwise the caller must be a manager of the named server.
       if (!isHubManager) {
         const canManageNamedServer = payload.defaultServerId
-          ? await canManageServer({
+          ? await canManageServerRoles({
               productUserId,
               serverId: payload.defaultServerId
             })

--- a/apps/control-plane/src/routes/media-routes.ts
+++ b/apps/control-plane/src/routes/media-routes.ts
@@ -2,7 +2,7 @@ import type { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
 import { z } from "zod";
 import { requireAuth, requireInitialized } from "../auth/middleware.js";
 import {
-  canManageServer
+  canEditServerSettings
 } from "../services/policy-service.js";
 import {
   getIdentityByProductUserId
@@ -58,7 +58,7 @@ export async function registerMediaRoutes(app: FastifyInstance): Promise<void> {
       })
       .parse(request.body);
 
-    const allowed = await canManageServer({
+    const allowed = await canEditServerSettings({
       productUserId: request.auth!.productUserId,
       serverId: payload.serverId,
       authContext: request.auth

--- a/apps/control-plane/src/routes/moderation-routes.ts
+++ b/apps/control-plane/src/routes/moderation-routes.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { requireAuth, requireInitialized } from "../auth/middleware.js";
 import {
   isActionAllowed,
-  canManageServer,
+  canModerateServer,
   grantRole
 } from "../services/policy-service.js";
 import {
@@ -138,7 +138,7 @@ export async function registerModerationRoutes(app: FastifyInstance): Promise<vo
       timeoutSeconds: z.number().int().min(1).optional()
     }).parse(request.body);
 
-    const allowed = await canManageServer({
+    const allowed = await canModerateServer({
       productUserId: request.auth!.productUserId,
       serverId: params.serverId,
       authContext: request.auth

--- a/apps/control-plane/src/routes/server-routes.ts
+++ b/apps/control-plane/src/routes/server-routes.ts
@@ -3,7 +3,8 @@ import { z } from "zod";
 import { requireAuth, requireInitialized } from "../auth/middleware.js";
 import {
   canManageHub,
-  canManageServer,
+  canEditServerSettings,
+  canManageServerRoles,
   fetchServerScope
 } from "../services/policy-service.js";
 import {
@@ -87,7 +88,7 @@ export async function registerServerRoutes(app: FastifyInstance): Promise<void> 
     const params = z.object({ serverId: z.string().min(1) }).parse(request.params);
     const payload = z.object({ name: z.string().min(2).max(80) }).parse(request.body);
 
-    const canManage = await canManageServer({
+    const canManage = await canEditServerSettings({
       productUserId: request.auth!.productUserId,
       serverId: params.serverId,
       authContext: request.auth
@@ -114,7 +115,7 @@ export async function registerServerRoutes(app: FastifyInstance): Promise<void> 
       return;
     }
 
-    const allowed = await canManageServer({
+    const allowed = await canEditServerSettings({
       productUserId: request.auth!.productUserId,
       serverId: params.serverId,
       authContext: request.auth
@@ -154,7 +155,7 @@ export async function registerServerRoutes(app: FastifyInstance): Promise<void> 
       description: z.string().optional()
     }).parse(request.body);
 
-    const allowed = await canManageServer({
+    const allowed = await canEditServerSettings({
       productUserId: request.auth!.productUserId,
       serverId: payload.serverId,
       authContext: request.auth
@@ -223,7 +224,7 @@ export async function registerServerRoutes(app: FastifyInstance): Promise<void> 
 
   app.get("/v1/servers/:serverId/settings", initializedAuthHandlers, async (request, reply) => {
     const params = z.object({ serverId: z.string().min(1) }).parse(request.params);
-    const allowed = await canManageServer({
+    const allowed = await canEditServerSettings({
       productUserId: request.auth!.productUserId,
       serverId: params.serverId,
       authContext: request.auth
@@ -246,7 +247,7 @@ export async function registerServerRoutes(app: FastifyInstance): Promise<void> 
       autoJoinHubMembers: z.boolean().optional()
     }).parse(request.body);
 
-    const allowed = await canManageServer({
+    const allowed = await canEditServerSettings({
       productUserId: request.auth!.productUserId,
       serverId: params.serverId,
       authContext: request.auth
@@ -269,7 +270,7 @@ export async function registerServerRoutes(app: FastifyInstance): Promise<void> 
       })
       .parse(request.body);
 
-    const allowed = await canManageServer({
+    const allowed = await canManageServerRoles({
       productUserId: request.auth!.productUserId,
       serverId: params.serverId,
       authContext: request.auth
@@ -296,7 +297,7 @@ export async function registerServerRoutes(app: FastifyInstance): Promise<void> 
   app.get("/v1/servers/:serverId/delegation/space-owners", initializedAuthHandlers, async (request, reply) => {
     const params = z.object({ serverId: z.string().min(1) }).parse(request.params);
     await expireSpaceOwnerAssignments({ serverId: params.serverId });
-    const allowed = await canManageServer({
+    const allowed = await canManageServerRoles({
       productUserId: request.auth!.productUserId,
       serverId: params.serverId,
       authContext: request.auth
@@ -321,7 +322,7 @@ export async function registerServerRoutes(app: FastifyInstance): Promise<void> 
       })
       .parse(request.body);
 
-    const canManage = await canManageServer({
+    const canManage = await canManageServerRoles({
       productUserId: request.auth!.productUserId,
       serverId: params.serverId,
       authContext: request.auth
@@ -351,7 +352,7 @@ export async function registerServerRoutes(app: FastifyInstance): Promise<void> 
 
   app.get("/v1/servers/:serverId/members", initializedAuthHandlers, async (request, reply) => {
     const params = z.object({ serverId: z.string().min(1) }).parse(request.params);
-    const allowed = await canManageServer({
+    const allowed = await canEditServerSettings({
       productUserId: request.auth!.productUserId,
       serverId: params.serverId,
       authContext: request.auth
@@ -383,7 +384,7 @@ export async function registerServerRoutes(app: FastifyInstance): Promise<void> 
        return;
     }
 
-    const allowed = await canManageServer({
+    const allowed = await canManageServerRoles({
       productUserId: request.auth!.productUserId,
       serverId,
       authContext: request.auth

--- a/apps/control-plane/src/routes/sticker-routes.ts
+++ b/apps/control-plane/src/routes/sticker-routes.ts
@@ -1,7 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import { z } from "zod";
 import { requireAuth, requireInitialized } from "../auth/middleware.js";
-import { canManageServer } from "../services/policy-service.js";
+import { canEditServerSettings } from "../services/policy-service.js";
 import {
   listServerStickers,
   createServerSticker,
@@ -23,7 +23,7 @@ export async function registerStickerRoutes(app: FastifyInstance): Promise<void>
       url: z.string().url()
     }).parse(request.body);
 
-    const allowed = await canManageServer({
+    const allowed = await canEditServerSettings({
       productUserId: request.auth!.productUserId,
       serverId: params.serverId,
       authContext: request.auth
@@ -40,7 +40,7 @@ export async function registerStickerRoutes(app: FastifyInstance): Promise<void>
 
   app.delete("/v1/servers/:serverId/stickers/:stickerId", initializedAuthHandlers, async (request, reply) => {
     const params = z.object({ serverId: z.string().min(1), stickerId: z.string().min(1) }).parse(request.params);
-    const allowed = await canManageServer({
+    const allowed = await canEditServerSettings({
       productUserId: request.auth!.productUserId,
       serverId: params.serverId,
       authContext: request.auth

--- a/apps/control-plane/src/routes/user-routes.ts
+++ b/apps/control-plane/src/routes/user-routes.ts
@@ -11,7 +11,7 @@ import { updateUserPresence } from "../services/presence-service.js";
 import {
   listAllowedActions,
   listRoleBindings,
-  canManageServer
+  canEditServerSettings
 } from "../services/policy-service.js";
 import {
   getUserSettings,
@@ -105,7 +105,7 @@ export async function registerUserRoutes(app: FastifyInstance): Promise<void> {
 
     if (query.productUserId) {
       // If previewing someone else, must have manage scope for that context
-      const allowed = await canManageServer({
+      const allowed = await canEditServerSettings({
         productUserId: request.auth!.productUserId,
         serverId: query.serverId,
         authContext: request.auth

--- a/apps/control-plane/src/routes/webhook-routes.ts
+++ b/apps/control-plane/src/routes/webhook-routes.ts
@@ -1,7 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import { z } from "zod";
 import { requireAuth, requireInitialized } from "../auth/middleware.js";
-import { canManageServer } from "../services/policy-service.js";
+import { canEditServerSettings } from "../services/policy-service.js";
 import {
   listWebhooks,
   createWebhook,
@@ -17,7 +17,7 @@ export async function registerWebhookRoutes(app: FastifyInstance): Promise<void>
 
   app.get("/v1/servers/:serverId/webhooks", initializedAuthHandlers, async (request) => {
     const params = z.object({ serverId: z.string().min(1) }).parse(request.params);
-    const allowed = await canManageServer({
+    const allowed = await canEditServerSettings({
       productUserId: request.auth!.productUserId,
       serverId: params.serverId,
       authContext: request.auth
@@ -45,7 +45,7 @@ export async function registerWebhookRoutes(app: FastifyInstance): Promise<void>
       return;
     }
 
-    const allowed = await canManageServer({
+    const allowed = await canEditServerSettings({
       productUserId: request.auth!.productUserId,
       serverId: channelRow.server_id,
       authContext: request.auth
@@ -62,7 +62,7 @@ export async function registerWebhookRoutes(app: FastifyInstance): Promise<void>
 
   app.delete("/v1/servers/:serverId/webhooks/:webhookId", initializedAuthHandlers, async (request, reply) => {
     const params = z.object({ serverId: z.string().min(1), webhookId: z.string().min(1) }).parse(request.params);
-    const allowed = await canManageServer({
+    const allowed = await canEditServerSettings({
       productUserId: request.auth!.productUserId,
       serverId: params.serverId,
       authContext: request.auth

--- a/apps/control-plane/src/services/policy-service.ts
+++ b/apps/control-plane/src/services/policy-service.ts
@@ -119,6 +119,21 @@ interface RoleBinding {
 
 const HUB_MANAGER_ROLES: Role[] = ["hub_owner", "hub_admin"];
 const SERVER_MANAGER_ROLES: Role[] = ["hub_owner", "hub_admin", "space_owner", "space_admin"];
+/**
+ * Role set for chat-cleanup actions (kick/ban/timeout/etc.).
+ * `space_moderator` joins this set but is intentionally excluded from
+ * `SERVER_MANAGER_ROLES` — moderators don't edit settings, manage
+ * roles, or manage rooms. P2.a of the permissions sprint
+ * (2026-05-08) makes this boundary enforced by named capability
+ * gates instead of by absence-from-set.
+ */
+const SERVER_MODERATION_ROLES: Role[] = [
+  "hub_owner",
+  "hub_admin",
+  "space_owner",
+  "space_admin",
+  "space_moderator"
+];
 
 
 export async function fetchServerScope(
@@ -805,11 +820,31 @@ export async function canManageHub(input: {
   });
 }
 
-export async function canManageServer(input: {
+interface ServerCapabilityInput {
   productUserId: string;
   serverId: string;
   authContext?: ScopedAuthContext;
-}): Promise<boolean> {
+}
+
+/**
+ * Shared evaluator for server-scoped capability gates. The four
+ * exported gates (`canModerateServer`, `canEditServerSettings`,
+ * `canManageServerRoles`, `canManageRooms`) differ only in which
+ * roles satisfy them.
+ *
+ * Special-case: when `allowedRoles` includes the manager set
+ * (settings/roles/rooms gates), an explicit `space_owner` on the
+ * server *or* an active space-owner delegation also satisfies the
+ * gate — these are owner-equivalent paths that pre-date the
+ * role_bindings model. Moderation alone (`canModerateServer`)
+ * doesn't need that shortcut because admins/owners are already in
+ * the role set.
+ */
+async function evaluateServerCapability(
+  input: ServerCapabilityInput,
+  allowedRoles: ReadonlyArray<Role>,
+  options: { ownerEquivalentShortcut: boolean } = { ownerEquivalentShortcut: true }
+): Promise<boolean> {
   const isMasquerading = Boolean(input.authContext?.isMasquerading);
 
   if (!isMasquerading) {
@@ -825,7 +860,7 @@ export async function canManageServer(input: {
       return false;
     }
 
-    if (!isMasquerading) {
+    if (!isMasquerading && options.ownerEquivalentShortcut) {
       if (serverRow.ownerUserId === input.productUserId) {
         return true;
       }
@@ -849,7 +884,7 @@ export async function canManageServer(input: {
 
     return rows.some(
       (binding) =>
-        SERVER_MANAGER_ROLES.includes(binding.role) &&
+        allowedRoles.includes(binding.role) &&
         bindingMatchesScope(binding, {
           hubId: serverRow.hubId,
           serverId: input.serverId
@@ -857,6 +892,61 @@ export async function canManageServer(input: {
     );
   });
 }
+
+/**
+ * Gate for chat-cleanup actions: kick, ban, timeout, warn, strike,
+ * redact, channel lock/unlock, slow mode, reports triage, audit
+ * read. Granted to hub managers, space owners/admins, and
+ * space_moderators.
+ */
+export function canModerateServer(input: ServerCapabilityInput): Promise<boolean> {
+  // Moderators don't get the owner-equivalent shortcut because they
+  // shouldn't be able to moderate solely by virtue of being the
+  // server's listed owner if the role-binding system would otherwise
+  // exclude them. In practice the manager set already covers
+  // owners/admins, so this is a no-op simplification — keeping it
+  // explicit for clarity.
+  return evaluateServerCapability(input, SERVER_MODERATION_ROLES, {
+    ownerEquivalentShortcut: true
+  });
+}
+
+/**
+ * Gate for editing server settings: rename the space, change icon,
+ * change starting channel, configure access tiers, change join
+ * policy, manage badges, etc. NOT granted to space_moderators.
+ */
+export function canEditServerSettings(input: ServerCapabilityInput): Promise<boolean> {
+  return evaluateServerCapability(input, SERVER_MANAGER_ROLES);
+}
+
+/**
+ * Gate for managing roles within the server: granting/revoking
+ * space_moderator/space_admin, transferring ownership, delegating
+ * space-owner duties. NOT granted to space_moderators.
+ */
+export function canManageServerRoles(input: ServerCapabilityInput): Promise<boolean> {
+  return evaluateServerCapability(input, SERVER_MANAGER_ROLES);
+}
+
+/**
+ * Gate for managing rooms within the server: create/rename/delete
+ * channels and categories, change channel settings, move channels
+ * between categories. NOT granted to space_moderators.
+ */
+export function canManageRooms(input: ServerCapabilityInput): Promise<boolean> {
+  return evaluateServerCapability(input, SERVER_MANAGER_ROLES);
+}
+
+/**
+ * @deprecated Use one of the named capability gates
+ * (`canModerateServer`, `canEditServerSettings`,
+ * `canManageServerRoles`, `canManageRooms`) instead. Kept as a thin
+ * alias for `canEditServerSettings` so any caller still using it
+ * gets the most-restrictive interpretation by default. Remove once
+ * no external callers remain.
+ */
+export const canManageServer = canEditServerSettings;
 
 export async function canManageDiscordBridge(input: {
   productUserId: string;

--- a/apps/control-plane/src/test/policy.test.ts
+++ b/apps/control-plane/src/test/policy.test.ts
@@ -136,3 +136,75 @@ test("hub-owned server (null owner): no synthetic space_owner binding for any us
     "random user must not get space_owner-derived actions on hub-owned server"
   );
 });
+
+test("space_moderator can moderate but cannot edit settings, manage roles, or manage rooms", async (t) => {
+  if (!pool) { t.skip("DATABASE_URL not configured."); return; }
+
+  const { canModerateServer, canEditServerSettings, canManageServerRoles, canManageRooms } =
+    await import("../services/policy-service.js");
+
+  // Hub + server, hub-owned (null owner) so no owner-equivalent shortcut applies.
+  await pool.query("insert into hubs (id, name, owner_user_id) values ('hub_p2a', 'P2a Hub', 'owner_p2a')");
+  await pool.query(
+    `insert into servers (id, hub_id, name, type, created_by_user_id, owner_user_id)
+     values ('srv_p2a', 'hub_p2a', 'P2a Space', 'default', 'owner_p2a', null)`
+  );
+
+  // Grant a user `space_moderator` on the server.
+  await pool.query(
+    `insert into role_bindings (id, product_user_id, role, hub_id, server_id)
+     values ('rb_p2a_mod', 'mod_p2a', 'space_moderator', 'hub_p2a', 'srv_p2a')`
+  );
+
+  const input = { productUserId: "mod_p2a", serverId: "srv_p2a" };
+
+  assert.equal(await canModerateServer(input), true, "moderator should be allowed to moderate");
+  assert.equal(await canEditServerSettings(input), false, "moderator should NOT be allowed to edit settings");
+  assert.equal(await canManageServerRoles(input), false, "moderator should NOT be allowed to manage roles");
+  assert.equal(await canManageRooms(input), false, "moderator should NOT be allowed to manage rooms");
+});
+
+test("space_admin satisfies all four server-capability gates", async (t) => {
+  if (!pool) { t.skip("DATABASE_URL not configured."); return; }
+
+  const { canModerateServer, canEditServerSettings, canManageServerRoles, canManageRooms } =
+    await import("../services/policy-service.js");
+
+  await pool.query("insert into hubs (id, name, owner_user_id) values ('hub_p2b', 'P2b Hub', 'owner_p2b')");
+  await pool.query(
+    `insert into servers (id, hub_id, name, type, created_by_user_id, owner_user_id)
+     values ('srv_p2b', 'hub_p2b', 'P2b Space', 'default', 'owner_p2b', null)`
+  );
+
+  await pool.query(
+    `insert into role_bindings (id, product_user_id, role, hub_id, server_id)
+     values ('rb_p2b_admin', 'admin_p2b', 'space_admin', 'hub_p2b', 'srv_p2b')`
+  );
+
+  const input = { productUserId: "admin_p2b", serverId: "srv_p2b" };
+  assert.equal(await canModerateServer(input), true);
+  assert.equal(await canEditServerSettings(input), true);
+  assert.equal(await canManageServerRoles(input), true);
+  assert.equal(await canManageRooms(input), true);
+});
+
+test("plain hub member fails every server-capability gate", async (t) => {
+  if (!pool) { t.skip("DATABASE_URL not configured."); return; }
+
+  const { canModerateServer, canEditServerSettings, canManageServerRoles, canManageRooms } =
+    await import("../services/policy-service.js");
+
+  await pool.query("insert into hubs (id, name, owner_user_id) values ('hub_p2c', 'P2c Hub', 'owner_p2c')");
+  await pool.query(
+    `insert into servers (id, hub_id, name, type, created_by_user_id, owner_user_id)
+     values ('srv_p2c', 'hub_p2c', 'P2c Space', 'default', 'owner_p2c', null)`
+  );
+  // No role bindings; just hub membership.
+  await pool.query("insert into hub_members (hub_id, product_user_id) values ('hub_p2c', 'member_p2c')");
+
+  const input = { productUserId: "member_p2c", serverId: "srv_p2c" };
+  assert.equal(await canModerateServer(input), false);
+  assert.equal(await canEditServerSettings(input), false);
+  assert.equal(await canManageServerRoles(input), false);
+  assert.equal(await canManageRooms(input), false);
+});


### PR DESCRIPTION
First half of P2 in the permissions sprint. **Pure refactor — no
schema changes, no behavior changes for the manager set.**
`space_moderator` is now explicitly authorized for moderation
through a named gate.

P2.b — the schema-heavier work (normalized access rules table,
audience tier expansion to include `space_admin` and
`space_moderator` columns, Hub→Space→Room cascade with override,
room read/write split) — will follow on its own PR against
`permissions-sprint`.

## Why

The space_moderator boundary used to be enforced by absence-from-
set: `SERVER_MANAGER_ROLES` omits `space_moderator`, and a single
binary `canManageServer` either grants the whole manager bundle
(rename + roles + rooms + moderate) or none of it. Per the user's
sprint framing, that boundary should be **enforced by name** so
moderators can be exactly what they say on the tin: chat
cleanup, no settings, no roles, no rooms.

## What changed

`policy-service`
- New private `evaluateServerCapability(input, allowedRoles, options)`
  encapsulates the existing manage-check (server-row lookup +
  owner-equivalent shortcut + role-binding scope match).
- New `SERVER_MODERATION_ROLES` set
  (= `SERVER_MANAGER_ROLES + space_moderator`).
- Four exported named gates wrap the evaluator:
  - **`canModerateServer`** — kick / ban / timeout / warn /
    strike / redact / lock / slow-mode / bulk-moderate. Accepts
    `space_moderator`.
  - **`canEditServerSettings`** — rename, icon, access tiers,
    badges, webhooks, stickers, server settings PATCH. Manager
    set only.
  - **`canManageServerRoles`** — grant/revoke space roles,
    delegate space-owner, transfer ownership. Manager set only.
  - **`canManageRooms`** — create/rename/delete channels and
    categories, channel settings, channel category. Manager set
    only.
- `canManageServer` retained as a `@deprecated` alias for
  `canEditServerSettings` (most-restrictive interpretation).
  Removable once no callers remain.

Call-site routing
- 10 sites in `channel-routes` → `canManageRooms`.
- `server-routes` split between settings (rename, delete, badges,
  settings GET/PATCH, members listing) and roles (delegation
  POST/GET, ownership transfer, delegation DELETE).
- `moderation-routes` bulk-moderate → `canModerateServer`.
- `webhook-routes` / `sticker-routes` / `media-routes` /
  `user-routes` preview gate → `canEditServerSettings`.
- `invite-routes` vestigial Slice B check → `canManageServerRoles`.
- `discord-routes` had an unused import; removed.

## Tests

Three new control-plane integration cases assert the boundary by
name on hub-owned servers (no owner-equivalent shortcut to
confound the result):
- space_moderator: moderate ✓, edit-settings ✗, manage-roles ✗,
  manage-rooms ✗.
- space_admin: all four ✓.
- plain hub member: all four ✗.

## Test plan

- [x] `pnpm --filter @skerry/shared test` — 16/16.
- [x] `pnpm --filter @skerry/web test` — 12/12.
- [x] **`pnpm --filter @skerry/control-plane test` — 134/134** on
      the live test stack (run before commit).
- [x] Typecheck clean for changed files.
- [ ] No pangolin walk-through needed — this is a pure refactor
      of who-can-do-what gates with full test coverage on the
      role boundaries. The behavior change (space_moderator
      gaining moderation gate authorization) is exercised by the
      new test directly.

## Out of scope (P2.b will cover)

- Audience tier expansion (adding `space_admin_access` /
  `space_moderator_access` columns or the equivalent normalized
  rows).
- Hub → Space → Room visibility cascade with narrower-tier
  override.
- Per-room read vs. write split.
- Removing the `canManageServer` deprecated alias.
