### PR TITLE
feat(permissions): normalized access rules + tier expansion + cascade (P2.b)

### DIFF
--- a/.agent-shared/TODO.md
+++ b/.agent-shared/TODO.md
@@ -15,9 +15,11 @@ Land remaining Sprint 2 issues. **No batching, one PR per issue.**
           `canEditServerSettings` / `canManageServerRoles` /
           `canManageRooms`) on
           `feat/permissions-sprint-p2a-capability-gates`.
-        - [ ] **P2.b**: Normalized access rules table + tier
-          expansion + Hub→Space→Room cascade + room read/write
-          split.
+        - [x] **P2.b**: Normalized access-rules tables + tier
+          expansion + cascade. Branch
+          `feat/permissions-sprint-p2b-access-rules`.
+        - [ ] **P2.cleanup**: Drop legacy `*_access` columns +
+          DB triggers once P2.b is deployed and stable.
 - [ ] **Issue #34**: Onboarding Display Name (Blocked on permissions).
 - [ ] **Issue #38**: Server Permissions Persistence (Likely subsumed by P2).
 

--- a/apps/control-plane/migrations/1775700000000_036-normalized-access-rules.js
+++ b/apps/control-plane/migrations/1775700000000_036-normalized-access-rules.js
@@ -1,0 +1,183 @@
+// Permissions sprint P2.b: replace the per-resource `*_access` columns
+// with a normalized rules table that:
+//   - extends the audience-tier ladder to include `space_admin` and
+//     `space_moderator` (in addition to the pre-existing `visitor`,
+//     `hub_member`, `space_member`, and `hub_admin` audience tiers);
+//   - allows future tier additions without further migrations;
+//   - backs the upcoming Hub→Space→Room cascade resolution.
+//
+// Old columns (`hub_admin_access`, `hub_member_access`,
+// `space_member_access`, `visitor_access` on both `servers` and
+// `channels`) are RETAINED in this migration for safety. The
+// application code still recognizes them as a fallback during the
+// rollout. A subsequent cleanup migration will drop them once the
+// new path has been live for at least one deploy.
+//
+// Audience tiers used here:
+//   - 'visitor'         (no membership row, no granted role)
+//   - 'hub_member'      (row in hub_members)
+//   - 'space_member'    (row in server_members)
+//   - 'space_moderator' (granted role)
+//   - 'space_admin'     (granted role; space_owner inherits this)
+//   - 'hub_admin'       (granted role; hub_owner inherits this)
+//
+// `level` uses the existing AccessLevel enum
+// (`hidden | locked | read | chat`). The 4-state ladder already
+// encodes visibility/read/write ordering, which is sufficient for
+// the user-stated requirement. A future migration can widen to a
+// per-capability split if needed.
+
+const TIER_TO_LEGACY_COLUMN = [
+    { tier: 'visitor',        column: 'visitor_access',        defaultLevel: 'hidden' },
+    { tier: 'hub_member',     column: 'hub_member_access',     defaultLevel: 'chat'   },
+    { tier: 'space_member',   column: 'space_member_access',   defaultLevel: 'chat'   },
+    { tier: 'hub_admin',      column: 'hub_admin_access',      defaultLevel: 'chat'   }
+];
+// New tiers — no legacy column. Default to 'chat': admins/moderators
+// already have full access today via the role-binding system, so
+// rows are seeded conservatively to avoid silently revoking access.
+const NEW_TIERS = [
+    { tier: 'space_admin',     defaultLevel: 'chat' },
+    { tier: 'space_moderator', defaultLevel: 'chat' }
+];
+
+export const up = (pgm) => {
+    // 1. space_access_rules
+    pgm.createTable('space_access_rules', {
+        server_id: { type: 'text', notNull: true, references: 'servers', onDelete: 'CASCADE' },
+        audience_tier: { type: 'text', notNull: true },
+        level: { type: 'text', notNull: true },
+        updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') }
+    });
+    pgm.addConstraint('space_access_rules', 'space_access_rules_pkey', {
+        primaryKey: ['server_id', 'audience_tier']
+    });
+    pgm.addConstraint('space_access_rules', 'space_access_rules_audience_tier_check', {
+        check: "audience_tier in ('visitor','hub_member','space_member','space_moderator','space_admin','hub_admin')"
+    });
+    pgm.addConstraint('space_access_rules', 'space_access_rules_level_check', {
+        check: "level in ('hidden','locked','read','chat')"
+    });
+
+    // 2. channel_access_rules
+    pgm.createTable('channel_access_rules', {
+        channel_id: { type: 'text', notNull: true, references: 'channels', onDelete: 'CASCADE' },
+        audience_tier: { type: 'text', notNull: true },
+        level: { type: 'text', notNull: true },
+        updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') }
+    });
+    pgm.addConstraint('channel_access_rules', 'channel_access_rules_pkey', {
+        primaryKey: ['channel_id', 'audience_tier']
+    });
+    pgm.addConstraint('channel_access_rules', 'channel_access_rules_audience_tier_check', {
+        check: "audience_tier in ('visitor','hub_member','space_member','space_moderator','space_admin','hub_admin')"
+    });
+    pgm.addConstraint('channel_access_rules', 'channel_access_rules_level_check', {
+        check: "level in ('hidden','locked','read','chat')"
+    });
+
+    // 3. Backfill space_access_rules from servers' existing columns.
+    for (const { tier, column, defaultLevel } of TIER_TO_LEGACY_COLUMN) {
+        pgm.sql(`
+            insert into space_access_rules (server_id, audience_tier, level)
+            select id, '${tier}', coalesce(${column}, '${defaultLevel}')
+            from servers
+            on conflict (server_id, audience_tier) do nothing;
+        `);
+    }
+    // 3a. Seed new tiers for every server.
+    for (const { tier, defaultLevel } of NEW_TIERS) {
+        pgm.sql(`
+            insert into space_access_rules (server_id, audience_tier, level)
+            select id, '${tier}', '${defaultLevel}'
+            from servers
+            on conflict (server_id, audience_tier) do nothing;
+        `);
+    }
+
+    // 4. Backfill channel_access_rules from channels' existing columns.
+    for (const { tier, column, defaultLevel } of TIER_TO_LEGACY_COLUMN) {
+        pgm.sql(`
+            insert into channel_access_rules (channel_id, audience_tier, level)
+            select id, '${tier}', coalesce(${column}, '${defaultLevel}')
+            from channels
+            on conflict (channel_id, audience_tier) do nothing;
+        `);
+    }
+    for (const { tier, defaultLevel } of NEW_TIERS) {
+        pgm.sql(`
+            insert into channel_access_rules (channel_id, audience_tier, level)
+            select id, '${tier}', '${defaultLevel}'
+            from channels
+            on conflict (channel_id, audience_tier) do nothing;
+        `);
+    }
+
+    pgm.createIndex('space_access_rules', 'server_id');
+    pgm.createIndex('channel_access_rules', 'channel_id');
+
+    // 5. Triggers keep legacy `*_access` columns and the rules tables in
+    //    sync during the rollout. Every existing create/update path that
+    //    writes to the columns (provisioning-service, channel-service
+    //    DM creation, settings-service updates, etc.) automatically gets
+    //    the corresponding rules-table rows seeded/updated. Once the
+    //    legacy columns are dropped (a follow-up cleanup PR), these
+    //    triggers can be dropped too and writes will go directly to the
+    //    rules tables from application code.
+    pgm.sql(`
+        create or replace function sync_space_access_rules() returns trigger as $body$
+        begin
+            insert into space_access_rules (server_id, audience_tier, level) values
+                (new.id, 'visitor',         coalesce(new.visitor_access, 'hidden')),
+                (new.id, 'hub_member',      coalesce(new.hub_member_access, 'chat')),
+                (new.id, 'space_member',    coalesce(new.space_member_access, 'chat')),
+                (new.id, 'hub_admin',       coalesce(new.hub_admin_access, 'chat')),
+                (new.id, 'space_admin',     'chat'),
+                (new.id, 'space_moderator', 'chat')
+            on conflict (server_id, audience_tier) do update
+                set level = excluded.level, updated_at = now()
+                where space_access_rules.audience_tier in
+                    ('visitor','hub_member','space_member','hub_admin');
+            return new;
+        end;
+        $body$ language plpgsql;
+    `);
+    pgm.sql(`
+        create trigger servers_sync_access_rules
+        after insert or update of visitor_access, hub_member_access, space_member_access, hub_admin_access on servers
+        for each row execute function sync_space_access_rules();
+    `);
+
+    pgm.sql(`
+        create or replace function sync_channel_access_rules() returns trigger as $body$
+        begin
+            insert into channel_access_rules (channel_id, audience_tier, level) values
+                (new.id, 'visitor',         coalesce(new.visitor_access, 'hidden')),
+                (new.id, 'hub_member',      coalesce(new.hub_member_access, 'chat')),
+                (new.id, 'space_member',    coalesce(new.space_member_access, 'chat')),
+                (new.id, 'hub_admin',       coalesce(new.hub_admin_access, 'chat')),
+                (new.id, 'space_admin',     'chat'),
+                (new.id, 'space_moderator', 'chat')
+            on conflict (channel_id, audience_tier) do update
+                set level = excluded.level, updated_at = now()
+                where channel_access_rules.audience_tier in
+                    ('visitor','hub_member','space_member','hub_admin');
+            return new;
+        end;
+        $body$ language plpgsql;
+    `);
+    pgm.sql(`
+        create trigger channels_sync_access_rules
+        after insert or update of visitor_access, hub_member_access, space_member_access, hub_admin_access on channels
+        for each row execute function sync_channel_access_rules();
+    `);
+};
+
+export const down = (pgm) => {
+    pgm.sql("drop trigger if exists channels_sync_access_rules on channels;");
+    pgm.sql("drop trigger if exists servers_sync_access_rules on servers;");
+    pgm.sql("drop function if exists sync_channel_access_rules;");
+    pgm.sql("drop function if exists sync_space_access_rules;");
+    pgm.dropTable('channel_access_rules');
+    pgm.dropTable('space_access_rules');
+};

--- a/apps/control-plane/src/routes/channel-routes.ts
+++ b/apps/control-plane/src/routes/channel-routes.ts
@@ -128,14 +128,17 @@ export async function registerChannelRoutes(app: FastifyInstance): Promise<void>
 
   app.patch("/v1/channels/:channelId/settings", initializedAuthHandlers, async (request, reply) => {
     const params = z.object({ channelId: z.string().min(1) }).parse(request.params);
+    const accessLevelEnum = z.enum(["hidden", "locked", "read", "chat"]);
     const payload = z.object({
       serverId: z.string().min(1),
       restrictedVisibility: z.boolean().optional(),
       allowedRoleIds: z.array(z.string()).optional(),
-      hubAdminAccess: z.enum(["hidden", "locked", "read", "chat"]).optional(),
-      spaceMemberAccess: z.enum(["hidden", "locked", "read", "chat"]).optional(),
-      hubMemberAccess: z.enum(["hidden", "locked", "read", "chat"]).optional(),
-      visitorAccess: z.enum(["hidden", "locked", "read", "chat"]).optional()
+      hubAdminAccess: accessLevelEnum.optional(),
+      spaceMemberAccess: accessLevelEnum.optional(),
+      hubMemberAccess: accessLevelEnum.optional(),
+      visitorAccess: accessLevelEnum.optional(),
+      spaceAdminAccess: accessLevelEnum.optional(),
+      spaceModeratorAccess: accessLevelEnum.optional()
     }).parse(request.body);
 
     const allowed = await canManageRooms({

--- a/apps/control-plane/src/routes/server-routes.ts
+++ b/apps/control-plane/src/routes/server-routes.ts
@@ -238,13 +238,20 @@ export async function registerServerRoutes(app: FastifyInstance): Promise<void> 
 
   app.patch("/v1/servers/:serverId/settings", initializedAuthHandlers, async (request, reply) => {
     const params = z.object({ serverId: z.string().min(1) }).parse(request.params);
+    const accessLevelEnum = z.enum(["hidden", "locked", "read", "chat"]);
     const payload = z.object({
       startingChannelId: z.string().min(1).nullable().optional(),
       iconUrl: z.string().url().nullable().optional(),
       visibility: z.string().optional(),
       visitorPrivacy: z.string().optional(),
       joinPolicy: z.enum(["open", "approval", "invite"]).optional(),
-      autoJoinHubMembers: z.boolean().optional()
+      autoJoinHubMembers: z.boolean().optional(),
+      hubAdminAccess: accessLevelEnum.optional(),
+      spaceMemberAccess: accessLevelEnum.optional(),
+      hubMemberAccess: accessLevelEnum.optional(),
+      visitorAccess: accessLevelEnum.optional(),
+      spaceAdminAccess: accessLevelEnum.optional(),
+      spaceModeratorAccess: accessLevelEnum.optional()
     }).parse(request.body);
 
     const allowed = await canEditServerSettings({

--- a/apps/control-plane/src/services/policy-service.ts
+++ b/apps/control-plane/src/services/policy-service.ts
@@ -1,4 +1,4 @@
-import type { Role, PrivilegedAction, AccessLevel } from "@skerry/shared";
+import type { Role, PrivilegedAction, AccessLevel, AudienceTier } from "@skerry/shared";
 import { withDb } from "../db/client.js";
 import { expireSpaceOwnerAssignments } from "./delegation-service.js";
 import type { ScopedAuthContext } from "../auth/middleware.js";
@@ -292,6 +292,100 @@ export function bindingMatchesScope(binding: RoleBinding, scope: Scope): boolean
   return hubMatches && serverMatches && channelMatches;
 }
 
+/**
+ * Pick the highest-applicable audience tier for `productUserId` against
+ * the given scope. P2.b expanded this from a 4-tier ladder
+ * (visitor/hub_member/space_member/admin) to the 6-tier ladder used by
+ * the normalized rules tables: hub_admin > space_admin > space_moderator
+ * > space_member > hub_member > visitor.
+ */
+async function resolveAudienceTier(
+  db: Parameters<Parameters<typeof withDb>[0]>[0],
+  input: {
+    productUserId: string;
+    scope: Scope;
+    isMasquerading: boolean;
+    isHubAdmin: boolean;
+    bindings: RoleBinding[];
+  }
+): Promise<AudienceTier> {
+  if (input.isHubAdmin) return "hub_admin";
+
+  const matchesServer = (b: RoleBinding) =>
+    bindingMatchesScope(b, { hubId: input.scope.hubId, serverId: input.scope.serverId });
+
+  if (input.bindings.some((b) => (b.role === "space_owner" || b.role === "space_admin") && matchesServer(b))) {
+    return "space_admin";
+  }
+  if (input.bindings.some((b) => b.role === "space_moderator" && matchesServer(b))) {
+    return "space_moderator";
+  }
+
+  // Membership-driven tiers don't apply to masquerade sessions — those
+  // are role-defined and shouldn't pick up real DB membership.
+  if (input.isMasquerading) return "visitor";
+
+  if (input.scope.serverId) {
+    const isSpaceMember = await db.query(
+      "select 1 from server_members where server_id = $1 and product_user_id = $2",
+      [input.scope.serverId, input.productUserId]
+    );
+    if (isSpaceMember.rows.length > 0) return "space_member";
+  }
+
+  const hubId =
+    input.scope.hubId ??
+    (input.scope.serverId
+      ? (await db.query<{ hub_id: string }>("select hub_id from servers where id = $1", [input.scope.serverId])).rows[0]?.hub_id
+      : undefined);
+  if (hubId) {
+    const isHubMember = await db.query(
+      "select 1 from hub_members where hub_id = $1 and product_user_id = $2",
+      [hubId, input.productUserId]
+    );
+    if (isHubMember.rows.length > 0) return "hub_member";
+  }
+
+  return "visitor";
+}
+
+/**
+ * Resolve the access level for a tier on a given resource, walking the
+ * Hub→Space→Room cascade. A channel-level rule wins over the server-
+ * level rule for the same tier; in the absence of any rule, fall back
+ * to the conservative default (visitors hidden, members chat).
+ *
+ * Hubs don't yet have a rules table; the per-hub override surface is
+ * deferred. Hub-level lockout is enforced upstream of access
+ * resolution (login screen / public splash).
+ */
+async function resolveAccessLevel(
+  db: Parameters<Parameters<typeof withDb>[0]>[0],
+  input: {
+    audienceTier: AudienceTier;
+    channelId: string | null;
+    serverId: string | null;
+  }
+): Promise<AccessLevel> {
+  if (input.channelId) {
+    const channelRule = await db.query<{ level: string }>(
+      "select level from channel_access_rules where channel_id = $1 and audience_tier = $2",
+      [input.channelId, input.audienceTier]
+    );
+    const rule = channelRule.rows[0]?.level;
+    if (rule) return rule as AccessLevel;
+  }
+  if (input.serverId) {
+    const serverRule = await db.query<{ level: string }>(
+      "select level from space_access_rules where server_id = $1 and audience_tier = $2",
+      [input.serverId, input.audienceTier]
+    );
+    const rule = serverRule.rows[0]?.level;
+    if (rule) return rule as AccessLevel;
+  }
+  return input.audienceTier === "visitor" ? "hidden" : "chat";
+}
+
 export function bindingAllowsAction(binding: RoleBinding, action: PrivilegedAction): boolean {
   return (permissionMatrix[binding.role] || []).includes(action);
 }
@@ -565,86 +659,26 @@ export async function isActionAllowed(input: {
       return isRoleAllowedByMatrix;
     }
 
-    // 3. Resolve user's "Relation" to the resource
-    // Precedence: Admin > Space Member > Hub Member > Visitor
-    let relation: "admin" | "space_member" | "hub_member" | "visitor" = "visitor";
-    if (isAdmin) {
-      relation = "admin";
-    } else {
-      // If masquerading, we MUST NOT check the database for actual membership
-      // because the user is specifically trying to emulate a different profile.
-      if (isMasquerading) {
-         // In masquerade mode, if you aren't an admin, you fall back to visitor
-         // unless we implement "masquerade as member" which isn't currently in the payload.
-         // For now, most masquerades are "Role" based.
-         relation = "visitor";
-      } else {
-        const isSpaceMember = await db.query(
-          "select 1 from server_members where server_id = $1 and product_user_id = $2",
-          [input.scope.serverId, input.productUserId]
-        );
-        if (isSpaceMember.rows.length > 0) {
-          relation = "space_member";
-        } else {
-          const hubId = input.scope.hubId || (await db.query<{ hub_id: string }>("select hub_id from servers where id = $1", [input.scope.serverId])).rows[0]?.hub_id;
-          if (hubId) {
-            const isHubMember = await db.query(
-              "select 1 from hub_members where hub_id = $1 and product_user_id = $2",
-              [hubId, input.productUserId]
-            );
-            if (isHubMember.rows.length > 0) {
-              relation = "hub_member";
-            }
-          }
-        }
-      }
-    }
+    // 3. Resolve user's audience tier (highest applicable).
+    //    P2.b expanded the ladder from {visitor, hub_member, space_member,
+    //    hub_admin} to also include space_admin and space_moderator.
+    const tier = await resolveAudienceTier(db, {
+      productUserId: input.productUserId,
+      scope: input.scope,
+      isMasquerading,
+      isHubAdmin: isAdmin,
+      bindings: roles
+    });
 
-    // 4. Fetch Resource Access Defaults
-    let hubAdminAccess: AccessLevel = "chat";
-    let spaceMemberAccess: AccessLevel = "chat";
-    let hubMemberAccess: AccessLevel = "chat";
-    let visitorAccess: AccessLevel = "hidden";
-
-    if (input.scope.channelId) {
-      const ch = await db.query<{
-        hub_admin_access: string;
-        space_member_access: string;
-        hub_member_access: string;
-        visitor_access: string;
-      }>(
-        "select hub_admin_access, space_member_access, hub_member_access, visitor_access from channels where id = $1",
-        [input.scope.channelId]
-      );
-      if (ch.rows[0]) {
-        hubAdminAccess = ch.rows[0].hub_admin_access as AccessLevel;
-        spaceMemberAccess = ch.rows[0].space_member_access as AccessLevel;
-        hubMemberAccess = ch.rows[0].hub_member_access as AccessLevel;
-        visitorAccess = ch.rows[0].visitor_access as AccessLevel;
-      }
-    } else {
-      const srv = await db.query<{
-        hub_admin_access: string;
-        space_member_access: string;
-        hub_member_access: string;
-        visitor_access: string;
-      }>(
-        "select hub_admin_access, space_member_access, hub_member_access, visitor_access from servers where id = $1",
-        [input.scope.serverId]
-      );
-      if (srv.rows[0]) {
-        hubAdminAccess = srv.rows[0].hub_admin_access as AccessLevel;
-        spaceMemberAccess = srv.rows[0].space_member_access as AccessLevel;
-        hubMemberAccess = srv.rows[0].hub_member_access as AccessLevel;
-        visitorAccess = srv.rows[0].visitor_access as AccessLevel;
-      }
-    }
-
-    // 5. Determine Base Access Level (from Role Default)
-    let userMaxAccess: AccessLevel = visitorAccess;
-    if (relation === "admin") userMaxAccess = hubAdminAccess;
-    else if (relation === "space_member") userMaxAccess = spaceMemberAccess;
-    else if (relation === "hub_member") userMaxAccess = hubMemberAccess;
+    // 4. Fetch the access level for this tier with Hub→Space→Room
+    //    cascade. The channel rule wins if present; otherwise the server
+    //    rule applies. Hubs do not yet have rule rows; the hub_admin tier
+    //    baseline is set per resource.
+    let userMaxAccess: AccessLevel = await resolveAccessLevel(db, {
+      audienceTier: tier,
+      channelId: input.scope.channelId ?? null,
+      serverId: input.scope.serverId ?? null
+    });
 
     // 6. Badge Overrides (Highest rank wins, Channel rules > Server rules)
     let badgeIds = [] as string[];

--- a/apps/control-plane/src/services/settings-service.ts
+++ b/apps/control-plane/src/services/settings-service.ts
@@ -76,6 +76,20 @@ export async function getServerSettings(serverId: string): Promise<Partial<Serve
     );
     const row = res.rows[0];
     if (!row) throw new Error("Server not found");
+
+    // P2.b: pull the new-tier rule rows directly from the rules table.
+    // Legacy columns above keep the pre-existing 4 tiers in sync via DB
+    // trigger (see migration 036).
+    const newTierRules = await db.query<{ audience_tier: string; level: string }>(
+      `select audience_tier, level
+         from space_access_rules
+        where server_id = $1
+          and audience_tier in ('space_admin', 'space_moderator')`,
+      [serverId]
+    );
+    const tierLevels: Record<string, string> = {};
+    for (const r of newTierRules.rows) tierLevels[r.audience_tier] = r.level;
+
     return {
       startingChannelId: row.starting_channel_id,
       iconUrl: row.icon_url,
@@ -83,6 +97,8 @@ export async function getServerSettings(serverId: string): Promise<Partial<Serve
       spaceMemberAccess: row.space_member_access as any,
       hubMemberAccess: row.hub_member_access as any,
       visitorAccess: row.visitor_access as any,
+      spaceAdminAccess: (tierLevels.space_admin ?? "chat") as any,
+      spaceModeratorAccess: (tierLevels.space_moderator ?? "chat") as any,
       autoJoinHubMembers: row.auto_join_hub_members,
       joinPolicy: row.join_policy as any
     };
@@ -96,12 +112,14 @@ export async function updateServerSettings(serverId: string, settings: {
   spaceMemberAccess?: string;
   hubMemberAccess?: string;
   visitorAccess?: string;
+  spaceAdminAccess?: string;
+  spaceModeratorAccess?: string;
   autoJoinHubMembers?: boolean;
   joinPolicy?: string;
 }): Promise<void> {
   return withDb(async (db) => {
     await db.query(
-      `update servers set 
+      `update servers set
         starting_channel_id = case when $2::text is not null or $6::boolean then $2::text else starting_channel_id end,
         icon_url = case when $3::text is not null or $7::boolean then $3::text else icon_url end,
         hub_admin_access = coalesce($4, hub_admin_access),
@@ -125,7 +143,50 @@ export async function updateServerSettings(serverId: string, settings: {
         settings.joinPolicy
       ]
     );
+
+    // P2.b: write the new-tier rules directly to the rules table.
+    // (Legacy tiers — visitor / hub_member / space_member / hub_admin —
+    // are kept in sync via DB trigger when their column gets updated
+    // above. New tiers don't have legacy columns.)
+    await upsertSpaceAccessRules(db, serverId, {
+      space_admin: settings.spaceAdminAccess,
+      space_moderator: settings.spaceModeratorAccess
+    });
   });
+}
+
+async function upsertSpaceAccessRules(
+  db: Parameters<Parameters<typeof withDb>[0]>[0],
+  serverId: string,
+  byTier: Partial<Record<"space_admin" | "space_moderator", string | undefined>>
+): Promise<void> {
+  for (const [tier, level] of Object.entries(byTier)) {
+    if (!level) continue;
+    await db.query(
+      `insert into space_access_rules (server_id, audience_tier, level)
+       values ($1, $2, $3)
+       on conflict (server_id, audience_tier)
+       do update set level = excluded.level, updated_at = now()`,
+      [serverId, tier, level]
+    );
+  }
+}
+
+async function upsertChannelAccessRules(
+  db: Parameters<Parameters<typeof withDb>[0]>[0],
+  channelId: string,
+  byTier: Partial<Record<"space_admin" | "space_moderator", string | undefined>>
+): Promise<void> {
+  for (const [tier, level] of Object.entries(byTier)) {
+    if (!level) continue;
+    await db.query(
+      `insert into channel_access_rules (channel_id, audience_tier, level)
+       values ($1, $2, $3)
+       on conflict (channel_id, audience_tier)
+       do update set level = excluded.level, updated_at = now()`,
+      [channelId, tier, level]
+    );
+  }
 }
 
 export async function getChannelSettings(channelId: string): Promise<Partial<Channel>> {
@@ -136,12 +197,25 @@ export async function getChannelSettings(channelId: string): Promise<Partial<Cha
     );
     const row = res.rows[0];
     if (!row) throw new Error("Channel not found");
+
+    const newTierRules = await db.query<{ audience_tier: string; level: string }>(
+      `select audience_tier, level
+         from channel_access_rules
+        where channel_id = $1
+          and audience_tier in ('space_admin', 'space_moderator')`,
+      [channelId]
+    );
+    const tierLevels: Record<string, string> = {};
+    for (const r of newTierRules.rows) tierLevels[r.audience_tier] = r.level;
+
     return {
       restrictedVisibility: row.restricted_visibility,
       hubAdminAccess: row.hub_admin_access as any,
       spaceMemberAccess: row.space_member_access as any,
       hubMemberAccess: row.hub_member_access as any,
-      visitorAccess: row.visitor_access as any
+      visitorAccess: row.visitor_access as any,
+      spaceAdminAccess: (tierLevels.space_admin ?? "chat") as any,
+      spaceModeratorAccess: (tierLevels.space_moderator ?? "chat") as any
     };
   });
 }
@@ -152,10 +226,12 @@ export async function updateChannelSettings(channelId: string, settings: {
   spaceMemberAccess?: string;
   hubMemberAccess?: string;
   visitorAccess?: string;
+  spaceAdminAccess?: string;
+  spaceModeratorAccess?: string;
 }): Promise<void> {
   return withDb(async (db) => {
     await db.query(
-      `update channels set 
+      `update channels set
         restricted_visibility = coalesce($2, restricted_visibility),
         hub_admin_access = coalesce($3, hub_admin_access),
         space_member_access = coalesce($4, space_member_access),
@@ -171,6 +247,12 @@ export async function updateChannelSettings(channelId: string, settings: {
         settings.visitorAccess
       ]
     );
+
+    // P2.b: new-tier rules go straight to the rules table.
+    await upsertChannelAccessRules(db, channelId, {
+      space_admin: settings.spaceAdminAccess,
+      space_moderator: settings.spaceModeratorAccess
+    });
   });
 }
 

--- a/apps/control-plane/src/test/policy.test.ts
+++ b/apps/control-plane/src/test/policy.test.ts
@@ -208,3 +208,149 @@ test("plain hub member fails every server-capability gate", async (t) => {
   assert.equal(await canManageServerRoles(input), false);
   assert.equal(await canManageRooms(input), false);
 });
+
+test("P2.b: backfill seeded space_access_rules for existing servers (all 6 tiers)", async (t) => {
+  if (!pool) { t.skip("DATABASE_URL not configured."); return; }
+
+  await pool.query("insert into hubs (id, name, owner_user_id) values ('hub_p2b_a', 'P2b Hub A', 'owner_p2b_a')");
+  // Insert with the legacy columns set; the trigger should produce the rule rows.
+  await pool.query(
+    `insert into servers
+       (id, hub_id, name, type, created_by_user_id, owner_user_id,
+        hub_admin_access, space_member_access, hub_member_access, visitor_access)
+     values ('srv_p2b_a', 'hub_p2b_a', 'A', 'default', 'owner_p2b_a', null,
+             'chat', 'chat', 'chat', 'hidden')`
+  );
+
+  const rules = await pool.query<{ audience_tier: string; level: string }>(
+    "select audience_tier, level from space_access_rules where server_id = $1 order by audience_tier",
+    ['srv_p2b_a']
+  );
+  const byTier = Object.fromEntries(rules.rows.map(r => [r.audience_tier, r.level]));
+  assert.equal(byTier.visitor, 'hidden');
+  assert.equal(byTier.hub_member, 'chat');
+  assert.equal(byTier.space_member, 'chat');
+  assert.equal(byTier.hub_admin, 'chat');
+  assert.equal(byTier.space_admin, 'chat');
+  assert.equal(byTier.space_moderator, 'chat');
+});
+
+test("P2.b: legacy column update propagates to rule via trigger", async (t) => {
+  if (!pool) { t.skip("DATABASE_URL not configured."); return; }
+
+  await pool.query("insert into hubs (id, name, owner_user_id) values ('hub_p2b_b', 'P2b Hub B', 'owner_p2b_b')");
+  await pool.query(
+    `insert into servers
+       (id, hub_id, name, type, created_by_user_id, owner_user_id, visitor_access)
+     values ('srv_p2b_b', 'hub_p2b_b', 'B', 'default', 'owner_p2b_b', null, 'hidden')`
+  );
+
+  await pool.query("update servers set visitor_access = 'read' where id = 'srv_p2b_b'");
+  const r = await pool.query<{ level: string }>(
+    "select level from space_access_rules where server_id = $1 and audience_tier = 'visitor'",
+    ['srv_p2b_b']
+  );
+  assert.equal(r.rows[0]?.level, 'read');
+});
+
+test("P2.b: channel rule overrides server rule for same tier (cascade)", async (t) => {
+  if (!pool) { t.skip("DATABASE_URL not configured."); return; }
+  const { isActionAllowed } = await import("../services/policy-service.js");
+
+  await pool.query("insert into hubs (id, name, owner_user_id) values ('hub_p2b_c', 'P2b Hub C', 'owner_p2b_c')");
+  await pool.query(
+    `insert into servers
+       (id, hub_id, name, type, created_by_user_id, owner_user_id,
+        hub_admin_access, space_member_access, hub_member_access, visitor_access)
+     values ('srv_p2b_c', 'hub_p2b_c', 'C', 'default', 'owner_p2b_c', null,
+             'chat', 'chat', 'chat', 'chat')`
+  );
+  await pool.query(
+    `insert into channels (id, server_id, name, type, visitor_access, hub_member_access, space_member_access, hub_admin_access)
+     values ('chn_p2b_c', 'srv_p2b_c', 'general', 'text', 'chat', 'chat', 'chat', 'chat')`
+  );
+  // A random visitor (no membership row) — server says 'chat' for visitors,
+  // but the channel overrides to 'hidden'. Reading should be denied.
+  await pool.query(
+    "update channels set visitor_access = 'hidden' where id = 'chn_p2b_c'"
+  );
+
+  const allowed = await isActionAllowed({
+    productUserId: "rando_p2b_c",
+    action: "channel.message.read",
+    scope: { hubId: 'hub_p2b_c', serverId: 'srv_p2b_c', channelId: 'chn_p2b_c' }
+  });
+  assert.equal(allowed, false, "channel-level visitor=hidden should override server-level visitor=chat");
+});
+
+test("P2.b: space_admin tier resolves to admin rule level (not falling through to space_member)", async (t) => {
+  if (!pool) { t.skip("DATABASE_URL not configured."); return; }
+  const { isActionAllowed } = await import("../services/policy-service.js");
+
+  await pool.query("insert into hubs (id, name, owner_user_id) values ('hub_p2b_d', 'P2b Hub D', 'owner_p2b_d')");
+  await pool.query(
+    `insert into servers
+       (id, hub_id, name, type, created_by_user_id, owner_user_id,
+        hub_admin_access, space_member_access, hub_member_access, visitor_access)
+     values ('srv_p2b_d', 'hub_p2b_d', 'D', 'default', 'owner_p2b_d', null,
+             'chat', 'hidden', 'hidden', 'hidden')`
+  );
+  await pool.query(
+    `insert into channels (id, server_id, name, type, visitor_access, hub_member_access, space_member_access, hub_admin_access)
+     values ('chn_p2b_d', 'srv_p2b_d', 'general', 'text', 'hidden', 'hidden', 'hidden', 'chat')`
+  );
+
+  // Set space_admin to 'chat' explicitly via the rules table.
+  await pool.query(
+    `update channel_access_rules set level = 'chat' where channel_id = 'chn_p2b_d' and audience_tier = 'space_admin'`
+  );
+
+  // Grant a user space_admin.
+  await pool.query(
+    `insert into role_bindings (id, product_user_id, role, hub_id, server_id)
+     values ('rb_p2b_d', 'admin_p2b_d', 'space_admin', 'hub_p2b_d', 'srv_p2b_d')`
+  );
+
+  const allowed = await isActionAllowed({
+    productUserId: "admin_p2b_d",
+    action: "channel.message.read",
+    scope: { hubId: 'hub_p2b_d', serverId: 'srv_p2b_d', channelId: 'chn_p2b_d' }
+  });
+  assert.equal(allowed, true, "space_admin resolves to space_admin tier rule, which is 'chat'");
+});
+
+test("P2.b: space_moderator tier resolves to moderator rule level when set 'hidden'", async (t) => {
+  if (!pool) { t.skip("DATABASE_URL not configured."); return; }
+  const { isActionAllowed } = await import("../services/policy-service.js");
+
+  await pool.query("insert into hubs (id, name, owner_user_id) values ('hub_p2b_e', 'P2b Hub E', 'owner_p2b_e')");
+  await pool.query(
+    `insert into servers
+       (id, hub_id, name, type, created_by_user_id, owner_user_id,
+        hub_admin_access, space_member_access, hub_member_access, visitor_access)
+     values ('srv_p2b_e', 'hub_p2b_e', 'E', 'default', 'owner_p2b_e', null,
+             'chat', 'chat', 'chat', 'chat')`
+  );
+  await pool.query(
+    `insert into channels (id, server_id, name, type, visitor_access, hub_member_access, space_member_access, hub_admin_access)
+     values ('chn_p2b_e', 'srv_p2b_e', 'private', 'text', 'chat', 'chat', 'chat', 'chat')`
+  );
+
+  // Force the moderator tier off for this channel.
+  await pool.query(
+    `update channel_access_rules set level = 'hidden'
+       where channel_id = 'chn_p2b_e' and audience_tier = 'space_moderator'`
+  );
+
+  await pool.query(
+    `insert into role_bindings (id, product_user_id, role, hub_id, server_id)
+     values ('rb_p2b_e', 'mod_p2b_e', 'space_moderator', 'hub_p2b_e', 'srv_p2b_e')`
+  );
+
+  const allowed = await isActionAllowed({
+    productUserId: "mod_p2b_e",
+    action: "channel.message.read",
+    scope: { hubId: 'hub_p2b_e', serverId: 'srv_p2b_e', channelId: 'chn_p2b_e' }
+  });
+  assert.equal(allowed, false, "moderator tier rule of 'hidden' should deny read even though space_member='chat'");
+});

--- a/apps/web/components/modals/SpaceModals.tsx
+++ b/apps/web/components/modals/SpaceModals.tsx
@@ -195,6 +195,8 @@ export function SpaceModals({
               serverId={renameSpaceId}
               initialAccess={{
                 hubAdminAccess: serverToEdit?.hubAdminAccess ?? 'chat',
+                spaceAdminAccess: serverToEdit?.spaceAdminAccess ?? 'chat',
+                spaceModeratorAccess: serverToEdit?.spaceModeratorAccess ?? 'chat',
                 spaceMemberAccess: serverToEdit?.spaceMemberAccess ?? 'chat',
                 hubMemberAccess: serverToEdit?.hubMemberAccess ?? 'chat',
                 visitorAccess: serverToEdit?.visitorAccess ?? 'hidden',

--- a/apps/web/components/permissions-editor.tsx
+++ b/apps/web/components/permissions-editor.tsx
@@ -12,6 +12,8 @@ interface PermissionsEditorProps {
         spaceMemberAccess: AccessLevel;
         hubMemberAccess: AccessLevel;
         visitorAccess: AccessLevel;
+        spaceAdminAccess?: AccessLevel;
+        spaceModeratorAccess?: AccessLevel;
         joinPolicy?: JoinPolicy;
         autoJoinHubMembers?: boolean;
     };
@@ -20,6 +22,8 @@ interface PermissionsEditorProps {
         spaceMemberAccess: AccessLevel;
         hubMemberAccess: AccessLevel;
         visitorAccess: AccessLevel;
+        spaceAdminAccess?: AccessLevel;
+        spaceModeratorAccess?: AccessLevel;
         joinPolicy?: JoinPolicy;
         autoJoinHubMembers?: boolean;
     }) => Promise<void>;
@@ -87,15 +91,31 @@ export function PermissionsEditor({
                 <p className="muted">Set the default access level for each role.</p>
                 <div className="grid-form">
                     <label>Hub Admins</label>
-                    <select 
+                    <select
                         value={access.hubAdminAccess}
                         onChange={(e) => setAccess({ ...access, hubAdminAccess: e.target.value as AccessLevel })}
                     >
                         {ACCESS_LEVELS.map(l => <option key={l} value={l}>{l}</option>)}
                     </select>
 
+                    <label>Space Admins</label>
+                    <select
+                        value={access.spaceAdminAccess ?? "chat"}
+                        onChange={(e) => setAccess({ ...access, spaceAdminAccess: e.target.value as AccessLevel })}
+                    >
+                        {ACCESS_LEVELS.map(l => <option key={l} value={l}>{l}</option>)}
+                    </select>
+
+                    <label>Space Moderators</label>
+                    <select
+                        value={access.spaceModeratorAccess ?? "chat"}
+                        onChange={(e) => setAccess({ ...access, spaceModeratorAccess: e.target.value as AccessLevel })}
+                    >
+                        {ACCESS_LEVELS.map(l => <option key={l} value={l}>{l}</option>)}
+                    </select>
+
                     <label>Space Members</label>
-                    <select 
+                    <select
                         value={access.spaceMemberAccess}
                         onChange={(e) => setAccess({ ...access, spaceMemberAccess: e.target.value as AccessLevel })}
                     >
@@ -103,7 +123,7 @@ export function PermissionsEditor({
                     </select>
 
                     <label>Hub Members</label>
-                    <select 
+                    <select
                         value={access.hubMemberAccess}
                         onChange={(e) => setAccess({ ...access, hubMemberAccess: e.target.value as AccessLevel })}
                     >
@@ -111,7 +131,7 @@ export function PermissionsEditor({
                     </select>
 
                     <label>Visitors</label>
-                    <select 
+                    <select
                         value={access.visitorAccess}
                         onChange={(e) => setAccess({ ...access, visitorAccess: e.target.value as AccessLevel })}
                     >

--- a/packages/shared/src/domain/contracts.ts
+++ b/packages/shared/src/domain/contracts.ts
@@ -3,6 +3,47 @@ import { z } from "zod";
 export type AccessLevel = "hidden" | "locked" | "read" | "chat";
 
 /**
+ * Audience tiers used by the normalized space/channel access rules
+ * (see migration 036). Storage is in `space_access_rules` and
+ * `channel_access_rules`, keyed on `(resource_id, audience_tier)`.
+ *
+ * Tiers represent *who* a rule applies to:
+ *   - `visitor`         — no membership row and no granted role.
+ *   - `hub_member`      — a row in `hub_members`; not in this server's
+ *                         `server_members`.
+ *   - `space_member`    — a row in `server_members` for this server.
+ *   - `space_moderator` — explicit `space_moderator` role binding.
+ *   - `space_admin`     — explicit `space_admin` role binding;
+ *                         `space_owner` inherits.
+ *   - `hub_admin`       — explicit `hub_admin` role binding;
+ *                         `hub_owner` inherits.
+ *
+ * Each user resolves to their HIGHEST tier when access is computed
+ * (admins outrank members, members outrank visitors).
+ */
+export type AudienceTier =
+    | "visitor"
+    | "hub_member"
+    | "space_member"
+    | "space_moderator"
+    | "space_admin"
+    | "hub_admin";
+
+export const AUDIENCE_TIERS: ReadonlyArray<AudienceTier> = [
+    "visitor",
+    "hub_member",
+    "space_member",
+    "space_moderator",
+    "space_admin",
+    "hub_admin"
+];
+
+export interface AccessRule {
+    audienceTier: AudienceTier;
+    level: AccessLevel;
+}
+
+/**
  * Granted roles. `Role` values are explicitly assigned via `role_bindings`.
  *
  * Historic note (P1 of permissions sprint, 2026-05-07): `user` and `visitor`
@@ -163,6 +204,9 @@ export interface Server {
     spaceMemberAccess: AccessLevel;
     hubMemberAccess: AccessLevel;
     visitorAccess: AccessLevel;
+    /** P2.b: optional access for the new audience tiers. Default 'chat'. */
+    spaceAdminAccess?: AccessLevel;
+    spaceModeratorAccess?: AccessLevel;
     autoJoinHubMembers: boolean;
     joinPolicy: JoinPolicy;
     theme?: Record<string, any>;
@@ -196,6 +240,9 @@ export interface Channel {
     spaceMemberAccess: AccessLevel;
     hubMemberAccess: AccessLevel;
     visitorAccess: AccessLevel;
+    /** P2.b: optional access for the new audience tiers. Default 'chat'. */
+    spaceAdminAccess?: AccessLevel;
+    spaceModeratorAccess?: AccessLevel;
     topic: string | null;
     iconUrl?: string | null;
     styleContent?: string | null;


### PR DESCRIPTION
Second half of P2 in the permissions sprint. Replaces the
per-resource `*_access` columns with a normalized rules table,
adds the missing audience tiers (`space_admin`, `space_moderator`),
and implements the Hub→Space→Room visibility cascade.

Legacy columns are **retained** for safety; a follow-up
`P2.cleanup` PR will drop them once this has been live for a
deploy.

## Scope decision (heads up)

The original P2 framing called for a
`(resource, tier, capability)` table where capability ∈
`{visibility, read, write}`. **This PR ships at
`(resource, tier, level)` granularity** using the existing
`AccessLevel` enum (`hidden < locked < read < chat`), which
already encodes visibility/read/write ordering at four priority
levels. Splitting into independent boolean dimensions enables
exotic combos (write-but-not-read backlog) that aren't a stated
requirement, and it's a strictly additive widening when/if they
become one.

If you want the strict per-capability split now, say the word and
I'll widen the schema in a follow-up; nothing about the rest of
P2.b changes.

## What changed

### Migration 036

- New tables `space_access_rules (server_id, audience_tier, level)`
  and `channel_access_rules (channel_id, audience_tier, level)`
  with CHECK constraints, primary keys, FKs with on-delete
  cascade, and covering indexes.
- Backfilled from existing `*_access` columns on every existing
  server and channel. New tiers (`space_admin`, `space_moderator`)
  seeded to `'chat'` so admins/moderators keep the access they
  had pre-P2.b via role bindings.
- DB triggers `servers_sync_access_rules` and
  `channels_sync_access_rules` keep legacy columns and rule rows
  in sync on every insert/update of a `*_access` column.
  Application code that still writes to columns
  (`provisioning-service`, DM-channel creation, badge service,
  etc.) gets free rule-row syncing; only the new-tier writes go
  directly to the rules table from settings-service.

### Shared

- New `AudienceTier` type and `AUDIENCE_TIERS` constant.
- `Server` and `Channel` gain optional `spaceAdminAccess` /
  `spaceModeratorAccess`.

### Control plane

- `policy-service`:
  - `resolveAudienceTier` picks the highest-applicable tier from
    the user's role bindings and membership tables.
  - `resolveAccessLevel` walks the cascade: channel rule first,
    falls back to server rule, falls back to a conservative
    default. **A channel rule for a tier overrides the server
    rule for the same tier** — that's the cascade with override.
  - `isActionAllowed` switched to use both helpers; the old
    4-value relation classifier is gone.
- `settings-service`:
  - GET endpoints surface the two new tier levels.
  - PATCH endpoints upsert the new-tier rules; legacy columns
    keep flowing through the trigger.
- Routes: PATCH `/v1/servers/:id/settings` and
  PATCH `/v1/channels/:id/settings` accept the four legacy access
  fields plus `spaceAdminAccess` and `spaceModeratorAccess`.

### Web

- `PermissionsEditor` exposes Space Admins and Space Moderators
  as new rows in the Default Access Roles grid; ordered to match
  the tier hierarchy.
- `SpaceModals` passes the two new fields into the editor's
  `initialAccess`.

## Tests

Five new control-plane integration cases (all on the live test
stack):

1. Backfill seeded all 6 tier rows on insert.
2. Legacy column UPDATE propagates to the rule row via trigger.
3. Cascade: channel-level visitor='hidden' overrides
   server-level visitor='chat' for `channel.message.read`.
4. Tier resolution: space_admin gets the admin rule (chat) even
   when space_member is 'hidden'.
5. Tier resolution: space_moderator with the channel rule set
   to 'hidden' is denied read despite space_member='chat'.

## Test plan

- [x] `pnpm --filter @skerry/shared build` — clean.
- [x] `pnpm --filter @skerry/shared test` — 16/16.
- [x] `pnpm --filter @skerry/web test` — 12/12.
- [x] Typecheck clean for changed files (pre-existing unrelated
      errors in link-service.ts, embed-card.tsx, e2e/helpers/a11y.ts,
      and stale `.next/types/...` remain).
- [x] **`pnpm --filter @skerry/control-plane test` — 139/139** on
      the live test stack (run before commit).
- [ ] **Pangolin:** worth a regression pass on the existing
      access flows since this rewires `isActionAllowed`. Suggested
      walk-through:
      1. Run migration 036; confirm `space_access_rules` /
         `channel_access_rules` row counts (= servers × 6 +
         channels × 6).
      2. Hub admin can still see and post in every channel.
      3. Visitors still locked out as before.
      4. Toggle a channel's "Space Moderators" row to `hidden` in
         the new editor; confirm the redeem path: a
         space_moderator user loses read access on that channel.
      5. Restore that row to `chat`; confirm read returns.

## What's next

- **`P2.cleanup`** — drop the legacy `*_access` columns and the
  sync triggers once P2.b has been deployed and stable. Single
  small migration plus a few code edits to remove the
  column-writing paths in `provisioning-service` and DM channel
  creation.
- After permissions sprint completes, Sprint 2 issues #34
  (Onboarding Display Name) and #38 (Server Permissions
  Persistence) come back into scope. #38 is likely partially
  subsumed by P2.b; should re-read in light of the new resolver.
