### PR TITLE
feat(permissions): drop legacy *_access columns + sync triggers (P2.cleanup)

### DIFF
--- a/.agent-shared/TODO.md
+++ b/.agent-shared/TODO.md
@@ -10,16 +10,13 @@ Land remaining Sprint 2 issues. **No batching, one PR per issue.**
     - [x] **P1**: Role enum cleanup.
     - [x] **P3**: Default Space Owner = Hub
       (`feat/permissions-sprint-p3-default-space-owner`).
-    - [/] **P2**: Audience tiers, cascade, and capability split.
-        - [x] **P2.a**: Capability split (`canModerateServer` /
-          `canEditServerSettings` / `canManageServerRoles` /
-          `canManageRooms`) on
-          `feat/permissions-sprint-p2a-capability-gates`.
+    - [x] **P2**: Audience tiers, cascade, and capability split.
+        - [x] **P2.a**: Capability split.
         - [x] **P2.b**: Normalized access-rules tables + tier
-          expansion + cascade. Branch
-          `feat/permissions-sprint-p2b-access-rules`.
-        - [ ] **P2.cleanup**: Drop legacy `*_access` columns +
-          DB triggers once P2.b is deployed and stable.
+          expansion + cascade.
+        - [x] **P2.cleanup**: Drop legacy `*_access` columns +
+          DB triggers. Branch
+          `feat/permissions-sprint-p2cleanup-drop-legacy-access`.
 - [ ] **Issue #34**: Onboarding Display Name (Blocked on permissions).
 - [ ] **Issue #38**: Server Permissions Persistence (Likely subsumed by P2).
 

--- a/apps/control-plane/migrations/1775800000000_037-drop-legacy-access-columns.js
+++ b/apps/control-plane/migrations/1775800000000_037-drop-legacy-access-columns.js
@@ -1,0 +1,69 @@
+// Permissions sprint P2.cleanup: drop the legacy `*_access` columns
+// and the sync triggers/functions installed by migration 036.
+//
+// P2.b kept the columns in place behind a DB trigger so legacy
+// write paths continued to work during the rollout. After P2.b
+// deployed and proved stable, all code paths now read from
+// `space_access_rules` / `channel_access_rules` directly. This
+// migration removes the legacy shape entirely.
+//
+// Order:
+//   1. Drop triggers (so subsequent column drops don't fire them).
+//   2. Drop functions.
+//   3. Drop columns.
+//
+// `down` re-creates the columns with their previous defaults but
+// does NOT re-install the triggers — rolling back P2.cleanup
+// requires manually re-applying migration 036's trigger SQL or
+// dropping migration 036 first.
+
+export const up = (pgm) => {
+    pgm.sql("drop trigger if exists channels_sync_access_rules on channels;");
+    pgm.sql("drop trigger if exists servers_sync_access_rules on servers;");
+    pgm.sql("drop function if exists sync_channel_access_rules;");
+    pgm.sql("drop function if exists sync_space_access_rules;");
+
+    pgm.dropColumns('servers', [
+        'hub_admin_access',
+        'space_member_access',
+        'hub_member_access',
+        'visitor_access'
+    ]);
+    pgm.dropColumns('channels', [
+        'hub_admin_access',
+        'space_member_access',
+        'hub_member_access',
+        'visitor_access'
+    ]);
+};
+
+export const down = (pgm) => {
+    pgm.addColumns('servers', {
+        hub_admin_access: { type: 'text', notNull: true, default: 'chat' },
+        space_member_access: { type: 'text', notNull: true, default: 'chat' },
+        hub_member_access: { type: 'text', notNull: true, default: 'chat' },
+        visitor_access: { type: 'text', notNull: true, default: 'hidden' }
+    });
+    pgm.addColumns('channels', {
+        hub_admin_access: { type: 'text', notNull: true, default: 'chat' },
+        space_member_access: { type: 'text', notNull: true, default: 'chat' },
+        hub_member_access: { type: 'text', notNull: true, default: 'chat' },
+        visitor_access: { type: 'text', notNull: true, default: 'hidden' }
+    });
+    // Backfill columns from rules table so the rolled-back code can
+    // read meaningful values.
+    pgm.sql(`
+        update servers set
+            visitor_access      = coalesce((select level from space_access_rules where server_id = servers.id and audience_tier = 'visitor'), 'hidden'),
+            hub_member_access   = coalesce((select level from space_access_rules where server_id = servers.id and audience_tier = 'hub_member'), 'chat'),
+            space_member_access = coalesce((select level from space_access_rules where server_id = servers.id and audience_tier = 'space_member'), 'chat'),
+            hub_admin_access    = coalesce((select level from space_access_rules where server_id = servers.id and audience_tier = 'hub_admin'), 'chat');
+    `);
+    pgm.sql(`
+        update channels set
+            visitor_access      = coalesce((select level from channel_access_rules where channel_id = channels.id and audience_tier = 'visitor'), 'hidden'),
+            hub_member_access   = coalesce((select level from channel_access_rules where channel_id = channels.id and audience_tier = 'hub_member'), 'chat'),
+            space_member_access = coalesce((select level from channel_access_rules where channel_id = channels.id and audience_tier = 'space_member'), 'chat'),
+            hub_admin_access    = coalesce((select level from channel_access_rules where channel_id = channels.id and audience_tier = 'hub_admin'), 'chat');
+    `);
+};

--- a/apps/control-plane/src/services/bootstrap-service.ts
+++ b/apps/control-plane/src/services/bootstrap-service.ts
@@ -118,6 +118,14 @@ export async function bootstrapAdmin(input: {
         [defaultChannelId, defaultServerId, "general"]
       );
 
+      // P2.cleanup: seed default access rules for both servers + the
+      // bootstrap channel. The legacy `*_access` columns are gone.
+      const { seedDefaultSpaceAccessRules, seedDefaultChannelAccessRules } =
+        await import("./provisioning-service.js");
+      await seedDefaultSpaceAccessRules(db, defaultServerId);
+      await seedDefaultSpaceAccessRules(db, dmServerId);
+      await seedDefaultChannelAccessRules(db, defaultChannelId, "hidden");
+
       await db.query(
         `insert into role_bindings (id, product_user_id, role, hub_id, server_id, channel_id)
          values ($1, $2, 'hub_admin', $3, null, null)`,

--- a/apps/control-plane/src/services/chat/channel-service.ts
+++ b/apps/control-plane/src/services/chat/channel-service.ts
@@ -29,7 +29,7 @@ export async function listChannels(
          order by ch.position asc, ch.created_at asc`,
         [serverId, productUserId]
       );
-      const channels = rows.rows.map(mapChannel);
+      const channels = rows.rows.map((row) => mapChannel(row));
 
       if (channels.length > 0) {
         const channelIds = channels.map(c => c.id);
@@ -72,16 +72,18 @@ export async function listChannels(
     const isAdminMasquerade = masqueradeRole && ['hub_owner', 'hub_admin', 'space_owner', 'space_admin'].includes(masqueradeRole);
     const badgeIds = isMasquerading ? (authContext?.masqueradeBadgeIds || []) : null;
 
+    // P2.cleanup: visibility predicates that used `ch.visitor_access`
+    // etc. now consult `channel_access_rules`. Behavior unchanged.
     const rows = await db.query<ChannelRow>(
-      `select ch.* 
+      `select ch.*
        from channels ch
        join servers s on s.id = ch.server_id
-       where ch.server_id = $1::text 
+       where ch.server_id = $1::text
          and (
-           ch.visitor_access != 'hidden'
+           exists (select 1 from channel_access_rules car where car.channel_id = ch.id and car.audience_tier = 'visitor' and car.level != 'hidden')
            or ($4::boolean = true)
            or (
-             ch.visitor_access = 'hidden' and (
+             exists (select 1 from channel_access_rules car where car.channel_id = ch.id and car.audience_tier = 'visitor' and car.level = 'hidden') and (
                -- Masquerade check
                ($3::boolean = true and (
                  exists (select 1 from channel_badge_rules cbr where cbr.channel_id = ch.id and cbr.badge_id = any($5::text[]) and cbr.access_level != 'hidden')
@@ -97,20 +99,33 @@ export async function listChannels(
            or ($3::boolean = false and s.owner_user_id = $2::text)
            or ($3::boolean = false and exists (select 1 from role_bindings where (server_id = $1::text or (hub_id = s.hub_id and hub_id is not null)) and product_user_id = $2::text and role in ('hub_owner', 'hub_admin', 'space_owner')))
            or ($3::boolean = false and exists (select 1 from channel_members where channel_id = ch.id and product_user_id = $2::text))
-           or (ch.hub_member_access != 'hidden' and $3::boolean = false and exists (select 1 from hub_members where hub_id = s.hub_id and product_user_id = $2::text))
-           or (ch.space_member_access != 'hidden' and $3::boolean = false and exists (select 1 from server_members where server_id = s.id and product_user_id = $2::text))
            or ($3::boolean = false and exists (
-             select 1 from space_admin_assignments saa 
-             where saa.server_id = s.id 
-               and saa.assigned_user_id = $2::text 
-               and saa.status = 'active' 
+             select 1 from channel_access_rules car
+             where car.channel_id = ch.id and car.audience_tier = 'hub_member' and car.level != 'hidden'
+               and exists (select 1 from hub_members where hub_id = s.hub_id and product_user_id = $2::text)
+           ))
+           or ($3::boolean = false and exists (
+             select 1 from channel_access_rules car
+             where car.channel_id = ch.id and car.audience_tier = 'space_member' and car.level != 'hidden'
+               and exists (select 1 from server_members where server_id = s.id and product_user_id = $2::text)
+           ))
+           or ($3::boolean = false and exists (
+             select 1 from space_admin_assignments saa
+             where saa.server_id = s.id
+               and saa.assigned_user_id = $2::text
+               and saa.status = 'active'
                and (saa.expires_at is null or saa.expires_at > now())
            ))
          )
        order by ch.position asc, ch.created_at asc`,
       [serverId, productUserId ?? null, isMasquerading, isAdminMasquerade, badgeIds]
     );
-    return rows.rows.map(mapChannel);
+
+    // Bulk-fetch the rules for all returned channels so each Channel
+    // response carries the per-tier access fields.
+    const { fetchChannelAccessRules } = await import("./server-service.js");
+    const rulesByChannel = await fetchChannelAccessRules(db, rows.rows.map((r) => r.id));
+    return rows.rows.map((row) => mapChannel(row, rulesByChannel.get(row.id)));
   });
 }
 
@@ -545,9 +560,12 @@ export async function getOrCreateDMChannel(hubId: string, productUserIds: string
     if (!dmServerId) {
       dmServerId = `srv_${crypto.randomUUID().replaceAll("-", "")}`;
       await db.query(
-        "insert into servers (id, hub_id, name, type, created_by_user_id, owner_user_id, visitor_access, auto_join_hub_members) values ($1, $2, $3, $4, $5, $6, 'hidden', false)",
+        "insert into servers (id, hub_id, name, type, created_by_user_id, owner_user_id, auto_join_hub_members) values ($1, $2, $3, $4, $5, $6, false)",
         [dmServerId, hubId, "Direct Messages", "dm", productUserIds[0], productUserIds[0]]
       );
+      // P2.cleanup: seed default access rules for the new DM server.
+      const { seedDefaultSpaceAccessRules } = await import("../provisioning-service.js");
+      await seedDefaultSpaceAccessRules(db, dmServerId);
     }
 
     const sortedUserIds = [...new Set(productUserIds)].sort();
@@ -595,9 +613,16 @@ export async function getOrCreateDMChannel(hubId: string, productUserIds: string
     const channelId = `chn_${crypto.randomUUID().replaceAll("-", "")}`;
     const name = `DM: ${sortedUserIds.length} members`;
     await db.query(
-      "insert into channels (id, server_id, name, type, topic, visitor_access) values ($1, $2, $3, 'dm', null, 'hidden')",
+      "insert into channels (id, server_id, name, type, topic) values ($1, $2, $3, 'dm', null)",
       [channelId, dmServerId, name]
     );
+    // P2.cleanup: seed access rules for the new DM channel
+    // (visitor='hidden', everyone else 'chat'). DMs are
+    // member-gated by the channel_members membership check
+    // upstream, so the rules are mostly inert but still need to
+    // exist for the resolver.
+    const { seedDefaultChannelAccessRules } = await import("../provisioning-service.js");
+    await seedDefaultChannelAccessRules(db, channelId, "hidden");
 
     for (const userId of sortedUserIds) {
       await db.query(

--- a/apps/control-plane/src/services/chat/mapping-helpers.ts
+++ b/apps/control-plane/src/services/chat/mapping-helpers.ts
@@ -1,5 +1,5 @@
 import crypto from "node:crypto";
-import type { Category, Channel, ChatMessage } from "@skerry/shared";
+import type { AccessLevel, AudienceTier, Category, Channel, ChatMessage } from "@skerry/shared";
 
 export function randomId(prefix: string): string {
   return `${prefix}_${crypto.randomUUID().replaceAll("-", "")}`;
@@ -29,10 +29,6 @@ export interface ChannelRow {
   name: string;
   type: Channel["type"];
   matrix_room_id: string | null;
-  hub_admin_access: string;
-  space_member_access: string;
-  hub_member_access: string;
-  visitor_access: string;
   is_locked: boolean;
   slow_mode_seconds: number;
   posting_restricted_to_roles: string[] | null;
@@ -93,10 +89,6 @@ export interface ServerRow {
   type: "default" | "dm";
   matrix_space_id: string | null;
   icon_url: string | null;
-  hub_admin_access: string;
-  space_member_access: string;
-  hub_member_access: string;
-  visitor_access: string;
   auto_join_hub_members: boolean;
   created_by_user_id: string;
   owner_user_id: string;
@@ -105,7 +97,34 @@ export interface ServerRow {
   join_policy: string;
 }
 
-export function mapChannel(row: ChannelRow): Channel {
+const DEFAULT_TIER_LEVELS: Record<AudienceTier, AccessLevel> = {
+  visitor: "hidden",
+  hub_member: "chat",
+  space_member: "chat",
+  space_moderator: "chat",
+  space_admin: "chat",
+  hub_admin: "chat"
+};
+
+/**
+ * P2.cleanup: the legacy `*_access` columns are gone. Channel/Server
+ * response objects still carry `hubAdminAccess` etc. for API
+ * back-compat — values are now sourced from `channel_access_rules` /
+ * `space_access_rules`. Callers that need accurate values pass the
+ * `rules` map; those that don't (e.g. realtime message payloads,
+ * message-history responses) get conservative defaults.
+ */
+export function tierLevelOrDefault(
+  rules: Partial<Record<AudienceTier, AccessLevel>> | undefined,
+  tier: AudienceTier
+): AccessLevel {
+  return rules?.[tier] ?? DEFAULT_TIER_LEVELS[tier];
+}
+
+export function mapChannel(
+  row: ChannelRow,
+  rules?: Partial<Record<AudienceTier, AccessLevel>>
+): Channel {
   return {
     id: row.id,
     serverId: row.server_id,
@@ -126,10 +145,12 @@ export function mapChannel(row: ChannelRow): Channel {
         }
         : null,
     position: row.position,
-    hubAdminAccess: row.hub_admin_access as any,
-    spaceMemberAccess: row.space_member_access as any,
-    hubMemberAccess: row.hub_member_access as any,
-    visitorAccess: row.visitor_access as any,
+    hubAdminAccess: tierLevelOrDefault(rules, "hub_admin"),
+    spaceAdminAccess: tierLevelOrDefault(rules, "space_admin"),
+    spaceModeratorAccess: tierLevelOrDefault(rules, "space_moderator"),
+    spaceMemberAccess: tierLevelOrDefault(rules, "space_member"),
+    hubMemberAccess: tierLevelOrDefault(rules, "hub_member"),
+    visitorAccess: tierLevelOrDefault(rules, "visitor"),
     topic: row.topic,
     iconUrl: row.icon_url,
     styleContent: row.style_content,

--- a/apps/control-plane/src/services/chat/server-service.ts
+++ b/apps/control-plane/src/services/chat/server-service.ts
@@ -1,12 +1,83 @@
 import crypto from "node:crypto";
-import type { Server, HubInvite } from "@skerry/shared";
+import type { AccessLevel, AudienceTier, Server, HubInvite } from "@skerry/shared";
 import { withDb } from "../../db/client.js";
 import { ServerRow } from "./mapping-helpers.js";
 import type { ScopedAuthContext } from "../../auth/middleware.js";
 import { joinHub } from "../membership-service.js";
 
+type AccessRulesByResource = Map<string, Partial<Record<AudienceTier, AccessLevel>>>;
+
+/**
+ * Bulk-fetch space access rules for a list of server ids. Returns a
+ * Map keyed by `server_id` whose value is a partial record from
+ * audience_tier → level. Used to avoid N+1 queries when surfacing
+ * the legacy `*Access` fields on `Server` responses post-P2.cleanup.
+ */
+export async function fetchSpaceAccessRules(
+  db: { query: <T = unknown>(sql: string, params?: unknown[]) => Promise<{ rows: T[] }> },
+  serverIds: string[]
+): Promise<AccessRulesByResource> {
+  if (serverIds.length === 0) return new Map();
+  const res = await db.query<{ server_id: string; audience_tier: string; level: string }>(
+    `select server_id, audience_tier, level
+       from space_access_rules
+      where server_id = any($1::text[])`,
+    [serverIds]
+  );
+  const map: AccessRulesByResource = new Map();
+  for (const row of res.rows) {
+    let entry = map.get(row.server_id);
+    if (!entry) {
+      entry = {};
+      map.set(row.server_id, entry);
+    }
+    entry[row.audience_tier as AudienceTier] = row.level as AccessLevel;
+  }
+  return map;
+}
+
+/** Same shape as fetchSpaceAccessRules but for `channel_access_rules`. */
+export async function fetchChannelAccessRules(
+  db: { query: <T = unknown>(sql: string, params?: unknown[]) => Promise<{ rows: T[] }> },
+  channelIds: string[]
+): Promise<AccessRulesByResource> {
+  if (channelIds.length === 0) return new Map();
+  const res = await db.query<{ channel_id: string; audience_tier: string; level: string }>(
+    `select channel_id, audience_tier, level
+       from channel_access_rules
+      where channel_id = any($1::text[])`,
+    [channelIds]
+  );
+  const map: AccessRulesByResource = new Map();
+  for (const row of res.rows) {
+    let entry = map.get(row.channel_id);
+    if (!entry) {
+      entry = {};
+      map.set(row.channel_id, entry);
+    }
+    entry[row.audience_tier as AudienceTier] = row.level as AccessLevel;
+  }
+  return map;
+}
+
+const DEFAULT_LEVEL_BY_TIER: Record<AudienceTier, AccessLevel> = {
+  visitor: "hidden",
+  hub_member: "chat",
+  space_member: "chat",
+  space_moderator: "chat",
+  space_admin: "chat",
+  hub_admin: "chat"
+};
+
+function tierLevel(
+  rules: Partial<Record<AudienceTier, AccessLevel>> | undefined,
+  tier: AudienceTier
+): AccessLevel {
+  return rules?.[tier] ?? DEFAULT_LEVEL_BY_TIER[tier];
+}
+
 export async function listServers(
-  productUserId?: string, 
+  productUserId?: string,
   hubId?: string,
   authContext?: ScopedAuthContext
 ): Promise<Server[]> {
@@ -16,37 +87,64 @@ export async function listServers(
     const isAdminMasquerade = masqueradeRole && ["hub_owner", "hub_admin", "space_owner", "space_admin"].includes(masqueradeRole);
     const badgeIds = isMasquerading ? (authContext?.masqueradeBadgeIds || []) : null;
 
-    let query = `select s.*, 
+    // P2.cleanup: visibility predicates that used to read `s.visitor_access`
+    // etc. now consult `space_access_rules` / `channel_access_rules`. The
+    // shape of the predicate is unchanged — only the source.
+    let query = `select s.*,
               (exists (select 1 from server_members where server_id = s.id and product_user_id = $1::text)) as is_member
        from servers s
        where (s.type = 'dm'
           or ($2::boolean = false and s.owner_user_id = $1::text)
           or ($3::boolean = true)
           or ($2::boolean = false and exists (select 1 from role_bindings where (hub_id = s.hub_id or hub_id is null) and product_user_id = $1::text and role in ('hub_owner', 'hub_admin')))
-          or (s.space_member_access != 'hidden' and $2::boolean = false and exists (select 1 from server_members where server_id = s.id and product_user_id = $1::text))
-          or (s.hub_member_access != 'hidden' and $2::boolean = false and exists (select 1 from hub_members where hub_id = s.hub_id and product_user_id = $1::text))
-          or (s.visitor_access != 'hidden')
-          or (s.visitor_access = 'hidden' and (
-              ($2::boolean = true and exists (select 1 from server_badge_rules sbr where sbr.server_id = s.id and sbr.badge_id = any($4::text[]) and sbr.access_level != 'hidden'))
-              or ($2::boolean = false and exists (select 1 from server_badge_rules sbr join user_badges ub on ub.badge_id = sbr.badge_id where sbr.server_id = s.id and ub.product_user_id = $1::text and sbr.access_level != 'hidden'))
-          ))
-          or exists (select 1 from channels c where c.server_id = s.id and (
-              c.visitor_access != 'hidden' 
-              or (c.visitor_access = 'hidden' and (
-                  ($2::boolean = true and exists (select 1 from channel_badge_rules cbr where cbr.channel_id = c.id and cbr.badge_id = any($4::text[]) and cbr.access_level != 'hidden'))
-                  or ($2::boolean = false and exists (select 1 from channel_badge_rules cbr join user_badges ub on ub.badge_id = cbr.badge_id where cbr.channel_id = c.id and ub.product_user_id = $1::text and cbr.access_level != 'hidden'))
-              ))
-              or (c.hub_member_access != 'hidden' and $2::boolean = false and exists (select 1 from hub_members where hub_id = s.hub_id and product_user_id = $1::text))
-              or (c.space_member_access != 'hidden' and $2::boolean = false and exists (select 1 from server_members where server_id = s.id and product_user_id = $1::text))
+          or ($2::boolean = false and exists (
+            select 1 from space_access_rules sar
+            where sar.server_id = s.id and sar.audience_tier = 'space_member' and sar.level != 'hidden'
+              and exists (select 1 from server_members where server_id = s.id and product_user_id = $1::text)
           ))
           or ($2::boolean = false and exists (
-            select 1 from space_admin_assignments saa 
-            where saa.server_id = s.id 
-              and saa.assigned_user_id = $1::text 
-              and saa.status = 'active' 
+            select 1 from space_access_rules sar
+            where sar.server_id = s.id and sar.audience_tier = 'hub_member' and sar.level != 'hidden'
+              and exists (select 1 from hub_members where hub_id = s.hub_id and product_user_id = $1::text)
+          ))
+          or exists (select 1 from space_access_rules sar where sar.server_id = s.id and sar.audience_tier = 'visitor' and sar.level != 'hidden')
+          or exists (
+              select 1 from space_access_rules sar
+              where sar.server_id = s.id and sar.audience_tier = 'visitor' and sar.level = 'hidden'
+                and (
+                  ($2::boolean = true and exists (select 1 from server_badge_rules sbr where sbr.server_id = s.id and sbr.badge_id = any($4::text[]) and sbr.access_level != 'hidden'))
+                  or ($2::boolean = false and exists (select 1 from server_badge_rules sbr join user_badges ub on ub.badge_id = sbr.badge_id where sbr.server_id = s.id and ub.product_user_id = $1::text and sbr.access_level != 'hidden'))
+                )
+          )
+          or exists (select 1 from channels c where c.server_id = s.id and (
+              exists (select 1 from channel_access_rules car where car.channel_id = c.id and car.audience_tier = 'visitor' and car.level != 'hidden')
+              or exists (
+                  select 1 from channel_access_rules car
+                  where car.channel_id = c.id and car.audience_tier = 'visitor' and car.level = 'hidden'
+                    and (
+                      ($2::boolean = true and exists (select 1 from channel_badge_rules cbr where cbr.channel_id = c.id and cbr.badge_id = any($4::text[]) and cbr.access_level != 'hidden'))
+                      or ($2::boolean = false and exists (select 1 from channel_badge_rules cbr join user_badges ub on ub.badge_id = cbr.badge_id where cbr.channel_id = c.id and ub.product_user_id = $1::text and cbr.access_level != 'hidden'))
+                    )
+              )
+              or ($2::boolean = false and exists (
+                  select 1 from channel_access_rules car
+                  where car.channel_id = c.id and car.audience_tier = 'hub_member' and car.level != 'hidden'
+                    and exists (select 1 from hub_members where hub_id = s.hub_id and product_user_id = $1::text)
+              ))
+              or ($2::boolean = false and exists (
+                  select 1 from channel_access_rules car
+                  where car.channel_id = c.id and car.audience_tier = 'space_member' and car.level != 'hidden'
+                    and exists (select 1 from server_members where server_id = s.id and product_user_id = $1::text)
+              ))
+          ))
+          or ($2::boolean = false and exists (
+            select 1 from space_admin_assignments saa
+            where saa.server_id = s.id
+              and saa.assigned_user_id = $1::text
+              and saa.status = 'active'
               and (saa.expires_at is null or saa.expires_at > now())
           )))`;
-          
+
     const params: any[] = [productUserId, isMasquerading, isAdminMasquerade, badgeIds];
     if (hubId) {
       query += ` and s.hub_id = $5::text`;
@@ -54,25 +152,31 @@ export async function listServers(
     }
 
     const rows = await db.query<ServerRow>(query + ` order by s.created_at asc`, params);
+    const rulesByServer = await fetchSpaceAccessRules(db, rows.rows.map((r) => r.id));
 
-    return rows.rows.map((row) => ({
-      id: row.id,
-      hubId: row.hub_id,
-      name: row.name,
-      type: row.type || "default",
-      matrixSpaceId: row.matrix_space_id,
-      iconUrl: row.icon_url,
-      hubAdminAccess: row.hub_admin_access as any,
-      spaceMemberAccess: row.space_member_access as any,
-      hubMemberAccess: row.hub_member_access as any,
-      visitorAccess: row.visitor_access as any,
-      autoJoinHubMembers: row.auto_join_hub_members,
-      createdByUserId: row.created_by_user_id,
-      ownerUserId: row.owner_user_id,
-      createdAt: row.created_at,
-      isMember: row.is_member,
-      joinPolicy: row.join_policy as any
-    }));
+    return rows.rows.map((row) => {
+      const rules = rulesByServer.get(row.id);
+      return {
+        id: row.id,
+        hubId: row.hub_id,
+        name: row.name,
+        type: row.type || "default",
+        matrixSpaceId: row.matrix_space_id,
+        iconUrl: row.icon_url,
+        hubAdminAccess: tierLevel(rules, "hub_admin"),
+        spaceAdminAccess: tierLevel(rules, "space_admin"),
+        spaceModeratorAccess: tierLevel(rules, "space_moderator"),
+        spaceMemberAccess: tierLevel(rules, "space_member"),
+        hubMemberAccess: tierLevel(rules, "hub_member"),
+        visitorAccess: tierLevel(rules, "visitor"),
+        autoJoinHubMembers: row.auto_join_hub_members,
+        createdByUserId: row.created_by_user_id,
+        ownerUserId: row.owner_user_id,
+        createdAt: row.created_at,
+        isMember: row.is_member,
+        joinPolicy: row.join_policy as any
+      };
+    });
   });
 }
 
@@ -91,6 +195,9 @@ export async function renameServer(input: { serverId: string; name: string }): P
       throw new Error("Server not found.");
     }
 
+    const rulesByServer = await fetchSpaceAccessRules(db, [value.id]);
+    const rules = rulesByServer.get(value.id);
+
     return {
       id: value.id,
       hubId: value.hub_id,
@@ -98,10 +205,12 @@ export async function renameServer(input: { serverId: string; name: string }): P
       type: value.type,
       matrixSpaceId: value.matrix_space_id,
       iconUrl: value.icon_url,
-      hubAdminAccess: value.hub_admin_access as any,
-      spaceMemberAccess: value.space_member_access as any,
-      hubMemberAccess: value.hub_member_access as any,
-      visitorAccess: value.visitor_access as any,
+      hubAdminAccess: tierLevel(rules, "hub_admin"),
+      spaceAdminAccess: tierLevel(rules, "space_admin"),
+      spaceModeratorAccess: tierLevel(rules, "space_moderator"),
+      spaceMemberAccess: tierLevel(rules, "space_member"),
+      hubMemberAccess: tierLevel(rules, "hub_member"),
+      visitorAccess: tierLevel(rules, "visitor"),
       autoJoinHubMembers: value.auto_join_hub_members,
       createdByUserId: value.created_by_user_id,
       ownerUserId: value.owner_user_id,

--- a/apps/control-plane/src/services/provisioning-service.ts
+++ b/apps/control-plane/src/services/provisioning-service.ts
@@ -87,10 +87,6 @@ export async function createServerWorkflow(input: {
       name: string;
       matrix_space_id: string | null;
       type: "default" | "dm";
-      hub_admin_access: string;
-      space_member_access: string;
-      hub_member_access: string;
-      visitor_access: string;
       auto_join_hub_members: boolean;
       created_by_user_id: string;
       owner_user_id: string | null;
@@ -98,8 +94,8 @@ export async function createServerWorkflow(input: {
       join_policy: string;
       icon_url: string | null;
     }>(
-      `insert into servers (id, hub_id, name, type, matrix_space_id, created_by_user_id, owner_user_id, auto_join_hub_members, hub_admin_access, space_member_access, hub_member_access, visitor_access, join_policy)
-       values ($1, $2, $3, 'default', $4, $5, $6, true, 'chat', 'chat', 'chat', 'hidden', 'open')
+      `insert into servers (id, hub_id, name, type, matrix_space_id, created_by_user_id, owner_user_id, auto_join_hub_members, join_policy)
+       values ($1, $2, $3, 'default', $4, $5, $6, true, 'open')
        returning *`,
       [id, input.hubId, input.name, matrixSpaceId, input.productUserId, ownerUserId]
     );
@@ -109,6 +105,11 @@ export async function createServerWorkflow(input: {
       throw new Error("Server creation failed.");
     }
 
+    // P2.cleanup: legacy `*_access` columns are gone. Seed the
+    // rules table with default tier levels — visitor=hidden,
+    // everyone else=chat. Settings UI surfaces these for editing.
+    await seedDefaultSpaceAccessRules(db, value.id);
+
     return {
       id: value.id,
       hubId: value.hub_id,
@@ -116,10 +117,12 @@ export async function createServerWorkflow(input: {
       type: value.type,
       matrixSpaceId: value.matrix_space_id,
       iconUrl: value.icon_url,
-      hubAdminAccess: value.hub_admin_access as any,
-      spaceMemberAccess: value.space_member_access as any,
-      hubMemberAccess: value.hub_member_access as any,
-      visitorAccess: value.visitor_access as any,
+      hubAdminAccess: "chat" as const,
+      spaceAdminAccess: "chat" as const,
+      spaceModeratorAccess: "chat" as const,
+      spaceMemberAccess: "chat" as const,
+      hubMemberAccess: "chat" as const,
+      visitorAccess: "hidden" as const,
       autoJoinHubMembers: value.auto_join_hub_members,
       createdByUserId: value.created_by_user_id,
       ownerUserId: value.owner_user_id,
@@ -181,12 +184,12 @@ export async function createChannelWorkflow(input: {
     );
     const position = (posRow.rows[0]?.max_pos ?? -1) + 1;
 
-    const defaultVisitorAccess = input.type === "landing" ? "read" : "hidden";
+    const defaultVisitorLevel = input.type === "landing" ? "read" : "hidden";
 
     const created = await db.query<ChannelRow>(
       `insert into channels
-       (id, server_id, category_id, name, type, matrix_room_id, position, topic, icon_url, style_content, voice_sfu_room_id, voice_max_participants, video_enabled, video_max_participants, hub_admin_access, space_member_access, hub_member_access, visitor_access)
-       values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, 'chat', 'chat', 'chat', $15)
+       (id, server_id, category_id, name, type, matrix_room_id, position, topic, icon_url, style_content, voice_sfu_room_id, voice_max_participants, video_enabled, video_max_participants)
+       values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
        returning *`,
       [
         id,
@@ -202,8 +205,7 @@ export async function createChannelWorkflow(input: {
         voiceRoomId,
         input.type === "voice" ? 25 : null,
         false,
-        input.type === "voice" ? 4 : null,
-        defaultVisitorAccess
+        input.type === "voice" ? 4 : null
       ]
     );
 
@@ -211,6 +213,11 @@ export async function createChannelWorkflow(input: {
     if (!value) {
       throw new Error("Channel creation failed.");
     }
+
+    // P2.cleanup: seed the channel's access rules. Defaults match
+    // the pre-cleanup column defaults (visitor=hidden|read for
+    // landing channels; everyone else=chat).
+    await seedDefaultChannelAccessRules(db, value.id, defaultVisitorLevel);
 
     const matrixSpaceId = server.matrix_space_id;
     if (matrixSpaceId && matrixRoomId) {
@@ -228,10 +235,12 @@ export async function createChannelWorkflow(input: {
       isLocked: value.is_locked,
       slowModeSeconds: value.slow_mode_seconds,
       postingRestrictedToRoles: (value.posting_restricted_to_roles ?? []) as Channel["postingRestrictedToRoles"],
-      hubAdminAccess: value.hub_admin_access as any,
-      spaceMemberAccess: value.space_member_access as any,
-      hubMemberAccess: value.hub_member_access as any,
-      visitorAccess: value.visitor_access as any,
+      hubAdminAccess: "chat" as const,
+      spaceAdminAccess: "chat" as const,
+      spaceModeratorAccess: "chat" as const,
+      spaceMemberAccess: "chat" as const,
+      hubMemberAccess: "chat" as const,
+      visitorAccess: defaultVisitorLevel as any,
       voiceMetadata:
         value.voice_sfu_room_id && value.voice_max_participants
           ? {
@@ -256,4 +265,50 @@ export async function createChannelWorkflow(input: {
 
   await storeIdempotency(input.idempotencyKey, input, channel);
   return channel;
+}
+
+/**
+ * Seed default access rules for a newly-created server. P2.cleanup
+ * removed the legacy `*_access` columns and their auto-sync trigger;
+ * create paths now insert rule rows directly.
+ */
+export async function seedDefaultSpaceAccessRules(
+  db: { query: (sql: string, params?: unknown[]) => Promise<unknown> },
+  serverId: string
+): Promise<void> {
+  await db.query(
+    `insert into space_access_rules (server_id, audience_tier, level) values
+       ($1, 'visitor', 'hidden'),
+       ($1, 'hub_member', 'chat'),
+       ($1, 'space_member', 'chat'),
+       ($1, 'space_moderator', 'chat'),
+       ($1, 'space_admin', 'chat'),
+       ($1, 'hub_admin', 'chat')
+     on conflict (server_id, audience_tier) do nothing`,
+    [serverId]
+  );
+}
+
+/**
+ * Seed default access rules for a newly-created channel. The visitor
+ * level is pulled from the caller — landing channels default to
+ * 'read' (publicly viewable but no posting), everything else defaults
+ * to 'hidden'.
+ */
+export async function seedDefaultChannelAccessRules(
+  db: { query: (sql: string, params?: unknown[]) => Promise<unknown> },
+  channelId: string,
+  visitorLevel: "hidden" | "locked" | "read" | "chat"
+): Promise<void> {
+  await db.query(
+    `insert into channel_access_rules (channel_id, audience_tier, level) values
+       ($1, 'visitor', $2),
+       ($1, 'hub_member', 'chat'),
+       ($1, 'space_member', 'chat'),
+       ($1, 'space_moderator', 'chat'),
+       ($1, 'space_admin', 'chat'),
+       ($1, 'hub_admin', 'chat')
+     on conflict (channel_id, audience_tier) do nothing`,
+    [channelId, visitorLevel]
+  );
 }

--- a/apps/control-plane/src/services/settings-service.ts
+++ b/apps/control-plane/src/services/settings-service.ts
@@ -71,34 +71,30 @@ export async function updateHubSettings(hubId: string, settings: {
 export async function getServerSettings(serverId: string): Promise<Partial<Server>> {
   return withDb(async (db) => {
     const res = await db.query(
-      "select starting_channel_id, icon_url, hub_admin_access, space_member_access, hub_member_access, visitor_access, auto_join_hub_members, join_policy from servers where id = $1",
+      "select starting_channel_id, icon_url, auto_join_hub_members, join_policy from servers where id = $1",
       [serverId]
     );
     const row = res.rows[0];
     if (!row) throw new Error("Server not found");
 
-    // P2.b: pull the new-tier rule rows directly from the rules table.
-    // Legacy columns above keep the pre-existing 4 tiers in sync via DB
-    // trigger (see migration 036).
-    const newTierRules = await db.query<{ audience_tier: string; level: string }>(
-      `select audience_tier, level
-         from space_access_rules
-        where server_id = $1
-          and audience_tier in ('space_admin', 'space_moderator')`,
+    // P2.cleanup: legacy *_access columns are gone. All tier levels
+    // come from `space_access_rules`.
+    const ruleRows = await db.query<{ audience_tier: string; level: string }>(
+      "select audience_tier, level from space_access_rules where server_id = $1",
       [serverId]
     );
     const tierLevels: Record<string, string> = {};
-    for (const r of newTierRules.rows) tierLevels[r.audience_tier] = r.level;
+    for (const r of ruleRows.rows) tierLevels[r.audience_tier] = r.level;
 
     return {
       startingChannelId: row.starting_channel_id,
       iconUrl: row.icon_url,
-      hubAdminAccess: row.hub_admin_access as any,
-      spaceMemberAccess: row.space_member_access as any,
-      hubMemberAccess: row.hub_member_access as any,
-      visitorAccess: row.visitor_access as any,
+      hubAdminAccess: (tierLevels.hub_admin ?? "chat") as any,
       spaceAdminAccess: (tierLevels.space_admin ?? "chat") as any,
       spaceModeratorAccess: (tierLevels.space_moderator ?? "chat") as any,
+      spaceMemberAccess: (tierLevels.space_member ?? "chat") as any,
+      hubMemberAccess: (tierLevels.hub_member ?? "chat") as any,
+      visitorAccess: (tierLevels.visitor ?? "hidden") as any,
       autoJoinHubMembers: row.auto_join_hub_members,
       joinPolicy: row.join_policy as any
     };
@@ -122,43 +118,44 @@ export async function updateServerSettings(serverId: string, settings: {
       `update servers set
         starting_channel_id = case when $2::text is not null or $6::boolean then $2::text else starting_channel_id end,
         icon_url = case when $3::text is not null or $7::boolean then $3::text else icon_url end,
-        hub_admin_access = coalesce($4, hub_admin_access),
-        space_member_access = coalesce($5, space_member_access),
-        hub_member_access = coalesce($8, hub_member_access),
-        visitor_access = coalesce($10, visitor_access),
-        auto_join_hub_members = coalesce($9, auto_join_hub_members),
-        join_policy = coalesce($11, join_policy)
+        auto_join_hub_members = coalesce($4, auto_join_hub_members),
+        join_policy = coalesce($5, join_policy)
       where id = $1`,
       [
         serverId,
         settings.startingChannelId,
         settings.iconUrl,
-        settings.hubAdminAccess,
-        settings.spaceMemberAccess,
-        settings.startingChannelId === null,
-        settings.iconUrl === null,
-        settings.hubMemberAccess,
         settings.autoJoinHubMembers,
-        settings.visitorAccess,
-        settings.joinPolicy
+        settings.joinPolicy,
+        settings.startingChannelId === null,
+        settings.iconUrl === null
       ]
     );
 
-    // P2.b: write the new-tier rules directly to the rules table.
-    // (Legacy tiers — visitor / hub_member / space_member / hub_admin —
-    // are kept in sync via DB trigger when their column gets updated
-    // above. New tiers don't have legacy columns.)
+    // P2.cleanup: all access fields go to space_access_rules.
     await upsertSpaceAccessRules(db, serverId, {
+      visitor: settings.visitorAccess,
+      hub_member: settings.hubMemberAccess,
+      space_member: settings.spaceMemberAccess,
+      space_moderator: settings.spaceModeratorAccess,
       space_admin: settings.spaceAdminAccess,
-      space_moderator: settings.spaceModeratorAccess
+      hub_admin: settings.hubAdminAccess
     });
   });
 }
 
+type AccessTierKey =
+  | "visitor"
+  | "hub_member"
+  | "space_member"
+  | "space_moderator"
+  | "space_admin"
+  | "hub_admin";
+
 async function upsertSpaceAccessRules(
   db: Parameters<Parameters<typeof withDb>[0]>[0],
   serverId: string,
-  byTier: Partial<Record<"space_admin" | "space_moderator", string | undefined>>
+  byTier: Partial<Record<AccessTierKey, string | undefined>>
 ): Promise<void> {
   for (const [tier, level] of Object.entries(byTier)) {
     if (!level) continue;
@@ -175,7 +172,7 @@ async function upsertSpaceAccessRules(
 async function upsertChannelAccessRules(
   db: Parameters<Parameters<typeof withDb>[0]>[0],
   channelId: string,
-  byTier: Partial<Record<"space_admin" | "space_moderator", string | undefined>>
+  byTier: Partial<Record<AccessTierKey, string | undefined>>
 ): Promise<void> {
   for (const [tier, level] of Object.entries(byTier)) {
     if (!level) continue;
@@ -192,30 +189,27 @@ async function upsertChannelAccessRules(
 export async function getChannelSettings(channelId: string): Promise<Partial<Channel>> {
   return withDb(async (db) => {
     const res = await db.query(
-      "select restricted_visibility, hub_admin_access, space_member_access, hub_member_access, visitor_access from channels where id = $1",
+      "select restricted_visibility from channels where id = $1",
       [channelId]
     );
     const row = res.rows[0];
     if (!row) throw new Error("Channel not found");
 
-    const newTierRules = await db.query<{ audience_tier: string; level: string }>(
-      `select audience_tier, level
-         from channel_access_rules
-        where channel_id = $1
-          and audience_tier in ('space_admin', 'space_moderator')`,
+    const ruleRows = await db.query<{ audience_tier: string; level: string }>(
+      "select audience_tier, level from channel_access_rules where channel_id = $1",
       [channelId]
     );
     const tierLevels: Record<string, string> = {};
-    for (const r of newTierRules.rows) tierLevels[r.audience_tier] = r.level;
+    for (const r of ruleRows.rows) tierLevels[r.audience_tier] = r.level;
 
     return {
       restrictedVisibility: row.restricted_visibility,
-      hubAdminAccess: row.hub_admin_access as any,
-      spaceMemberAccess: row.space_member_access as any,
-      hubMemberAccess: row.hub_member_access as any,
-      visitorAccess: row.visitor_access as any,
+      hubAdminAccess: (tierLevels.hub_admin ?? "chat") as any,
       spaceAdminAccess: (tierLevels.space_admin ?? "chat") as any,
-      spaceModeratorAccess: (tierLevels.space_moderator ?? "chat") as any
+      spaceModeratorAccess: (tierLevels.space_moderator ?? "chat") as any,
+      spaceMemberAccess: (tierLevels.space_member ?? "chat") as any,
+      hubMemberAccess: (tierLevels.hub_member ?? "chat") as any,
+      visitorAccess: (tierLevels.visitor ?? "hidden") as any
     };
   });
 }
@@ -232,26 +226,18 @@ export async function updateChannelSettings(channelId: string, settings: {
   return withDb(async (db) => {
     await db.query(
       `update channels set
-        restricted_visibility = coalesce($2, restricted_visibility),
-        hub_admin_access = coalesce($3, hub_admin_access),
-        space_member_access = coalesce($4, space_member_access),
-        hub_member_access = coalesce($5, hub_member_access),
-        visitor_access = coalesce($6, visitor_access)
+        restricted_visibility = coalesce($2, restricted_visibility)
       where id = $1`,
-      [
-        channelId,
-        settings.restrictedVisibility,
-        settings.hubAdminAccess,
-        settings.spaceMemberAccess,
-        settings.hubMemberAccess,
-        settings.visitorAccess
-      ]
+      [channelId, settings.restrictedVisibility]
     );
 
-    // P2.b: new-tier rules go straight to the rules table.
     await upsertChannelAccessRules(db, channelId, {
+      visitor: settings.visitorAccess,
+      hub_member: settings.hubMemberAccess,
+      space_member: settings.spaceMemberAccess,
+      space_moderator: settings.spaceModeratorAccess,
       space_admin: settings.spaceAdminAccess,
-      space_moderator: settings.spaceModeratorAccess
+      hub_admin: settings.hubAdminAccess
     });
   });
 }

--- a/apps/control-plane/src/test/masquerade.test.ts
+++ b/apps/control-plane/src/test/masquerade.test.ts
@@ -37,8 +37,12 @@ test("Masquerade: admin masquerading as user with badge can see hidden channel",
   await pool!.query("insert into hubs (id, name, owner_user_id) values ('hub_3', 'Badge Hub', $1)", [adminIdentity.productUserId]);
   await pool!.query("insert into servers (id, hub_id, name, created_by_user_id, owner_user_id) values ('srv_badge', 'hub_3', 'Badge Server', $1, $1)", [adminIdentity.productUserId]);
 
-  // Create a hidden channel
-  await pool!.query("insert into channels (id, server_id, name, type, visitor_access) values ('chn_hidden', 'srv_badge', 'top-secret', 'text', 'hidden')", []);
+  // Create a hidden channel (default visitor=hidden via seed helpers).
+  await pool!.query("insert into channels (id, server_id, name, type) values ('chn_hidden', 'srv_badge', 'top-secret', 'text')", []);
+  const { seedDefaultSpaceAccessRules: __seedSpace1, seedDefaultChannelAccessRules: __seedChannel1 } =
+    await import("../services/provisioning-service.js");
+  await __seedSpace1(pool!, 'srv_badge');
+  await __seedChannel1(pool!, 'chn_hidden', 'hidden');
 
   // Create a badge and a rule that grants access to the hidden channel
   await pool!.query("insert into badges (id, hub_id, server_id, name, rank) values ('bdg_vip', 'hub_3', 'srv_badge', 'VIP', 10)", []);
@@ -91,11 +95,17 @@ test("Masquerade: admin masquerading as guest cannot see private channels", asyn
   await pool!.query("insert into hubs (id, name, owner_user_id) values ('hub_1', 'Test Hub', $1)", [adminIdentity.productUserId]);
   await pool!.query("insert into servers (id, hub_id, name, created_by_user_id, owner_user_id) values ('srv_1', 'hub_1', 'Test Server', $1, $1)", [adminIdentity.productUserId]);
 
-  // Create a public and a private channel
-  // visitor_access = 'chat' means visible to guests
-  // visitor_access = 'hidden' means invisible to guests
-  await pool!.query("insert into channels (id, server_id, name, type, visitor_access) values ('chn_pub', 'srv_1', 'public', 'text', 'chat')", []);
-  await pool!.query("insert into channels (id, server_id, name, type, visitor_access) values ('chn_priv', 'srv_1', 'private', 'text', 'hidden')", []);
+  // Create a public and a private channel.
+  // P2.cleanup: visitor access lives in `channel_access_rules` now;
+  // seed via the public helpers (visitor=chat for public, hidden
+  // for private).
+  await pool!.query("insert into channels (id, server_id, name, type) values ('chn_pub', 'srv_1', 'public', 'text')", []);
+  await pool!.query("insert into channels (id, server_id, name, type) values ('chn_priv', 'srv_1', 'private', 'text')", []);
+  const { seedDefaultSpaceAccessRules: __seedSpace2, seedDefaultChannelAccessRules: __seedChannel2 } =
+    await import("../services/provisioning-service.js");
+  await __seedSpace2(pool!, 'srv_1');
+  await __seedChannel2(pool!, 'chn_pub', 'chat');
+  await __seedChannel2(pool!, 'chn_priv', 'hidden');
 
   const guestCookie = createAuthCookie({
     ...adminIdentity,

--- a/apps/control-plane/src/test/policy.test.ts
+++ b/apps/control-plane/src/test/policy.test.ts
@@ -209,18 +209,17 @@ test("plain hub member fails every server-capability gate", async (t) => {
   assert.equal(await canManageRooms(input), false);
 });
 
-test("P2.b: backfill seeded space_access_rules for existing servers (all 6 tiers)", async (t) => {
+test("P2.cleanup: seedDefaultSpaceAccessRules produces all 6 tier rows for a new server", async (t) => {
   if (!pool) { t.skip("DATABASE_URL not configured."); return; }
+  const { seedDefaultSpaceAccessRules } = await import("../services/provisioning-service.js");
 
   await pool.query("insert into hubs (id, name, owner_user_id) values ('hub_p2b_a', 'P2b Hub A', 'owner_p2b_a')");
-  // Insert with the legacy columns set; the trigger should produce the rule rows.
   await pool.query(
     `insert into servers
-       (id, hub_id, name, type, created_by_user_id, owner_user_id,
-        hub_admin_access, space_member_access, hub_member_access, visitor_access)
-     values ('srv_p2b_a', 'hub_p2b_a', 'A', 'default', 'owner_p2b_a', null,
-             'chat', 'chat', 'chat', 'hidden')`
+       (id, hub_id, name, type, created_by_user_id, owner_user_id)
+     values ('srv_p2b_a', 'hub_p2b_a', 'A', 'default', 'owner_p2b_a', null)`
   );
+  await seedDefaultSpaceAccessRules(pool, 'srv_p2b_a');
 
   const rules = await pool.query<{ audience_tier: string; level: string }>(
     "select audience_tier, level from space_access_rules where server_id = $1 order by audience_tier",
@@ -235,45 +234,34 @@ test("P2.b: backfill seeded space_access_rules for existing servers (all 6 tiers
   assert.equal(byTier.space_moderator, 'chat');
 });
 
-test("P2.b: legacy column update propagates to rule via trigger", async (t) => {
-  if (!pool) { t.skip("DATABASE_URL not configured."); return; }
-
-  await pool.query("insert into hubs (id, name, owner_user_id) values ('hub_p2b_b', 'P2b Hub B', 'owner_p2b_b')");
-  await pool.query(
-    `insert into servers
-       (id, hub_id, name, type, created_by_user_id, owner_user_id, visitor_access)
-     values ('srv_p2b_b', 'hub_p2b_b', 'B', 'default', 'owner_p2b_b', null, 'hidden')`
-  );
-
-  await pool.query("update servers set visitor_access = 'read' where id = 'srv_p2b_b'");
-  const r = await pool.query<{ level: string }>(
-    "select level from space_access_rules where server_id = $1 and audience_tier = 'visitor'",
-    ['srv_p2b_b']
-  );
-  assert.equal(r.rows[0]?.level, 'read');
-});
+// (The "legacy column update propagates to rule via trigger" test from
+// the P2.b PR is intentionally removed here — P2.cleanup dropped both
+// the columns and the trigger. The seed-test above covers the
+// equivalent positive path.)
 
 test("P2.b: channel rule overrides server rule for same tier (cascade)", async (t) => {
   if (!pool) { t.skip("DATABASE_URL not configured."); return; }
   const { isActionAllowed } = await import("../services/policy-service.js");
+  const { seedDefaultSpaceAccessRules, seedDefaultChannelAccessRules } =
+    await import("../services/provisioning-service.js");
 
   await pool.query("insert into hubs (id, name, owner_user_id) values ('hub_p2b_c', 'P2b Hub C', 'owner_p2b_c')");
   await pool.query(
-    `insert into servers
-       (id, hub_id, name, type, created_by_user_id, owner_user_id,
-        hub_admin_access, space_member_access, hub_member_access, visitor_access)
-     values ('srv_p2b_c', 'hub_p2b_c', 'C', 'default', 'owner_p2b_c', null,
-             'chat', 'chat', 'chat', 'chat')`
+    `insert into servers (id, hub_id, name, type, created_by_user_id, owner_user_id)
+     values ('srv_p2b_c', 'hub_p2b_c', 'C', 'default', 'owner_p2b_c', null)`
   );
+  await seedDefaultSpaceAccessRules(pool, 'srv_p2b_c');
+  // Server says visitor=chat (override the default of hidden).
   await pool.query(
-    `insert into channels (id, server_id, name, type, visitor_access, hub_member_access, space_member_access, hub_admin_access)
-     values ('chn_p2b_c', 'srv_p2b_c', 'general', 'text', 'chat', 'chat', 'chat', 'chat')`
+    `update space_access_rules set level = 'chat' where server_id = 'srv_p2b_c' and audience_tier = 'visitor'`
   );
-  // A random visitor (no membership row) — server says 'chat' for visitors,
-  // but the channel overrides to 'hidden'. Reading should be denied.
+
   await pool.query(
-    "update channels set visitor_access = 'hidden' where id = 'chn_p2b_c'"
+    `insert into channels (id, server_id, name, type) values ('chn_p2b_c', 'srv_p2b_c', 'general', 'text')`
   );
+  await seedDefaultChannelAccessRules(pool, 'chn_p2b_c', 'hidden');
+  // Channel keeps visitor=hidden (default). Verify the channel-level
+  // rule overrides the server's chat for visitors.
 
   const allowed = await isActionAllowed({
     productUserId: "rando_p2b_c",
@@ -286,23 +274,29 @@ test("P2.b: channel rule overrides server rule for same tier (cascade)", async (
 test("P2.b: space_admin tier resolves to admin rule level (not falling through to space_member)", async (t) => {
   if (!pool) { t.skip("DATABASE_URL not configured."); return; }
   const { isActionAllowed } = await import("../services/policy-service.js");
+  const { seedDefaultSpaceAccessRules, seedDefaultChannelAccessRules } =
+    await import("../services/provisioning-service.js");
 
   await pool.query("insert into hubs (id, name, owner_user_id) values ('hub_p2b_d', 'P2b Hub D', 'owner_p2b_d')");
   await pool.query(
-    `insert into servers
-       (id, hub_id, name, type, created_by_user_id, owner_user_id,
-        hub_admin_access, space_member_access, hub_member_access, visitor_access)
-     values ('srv_p2b_d', 'hub_p2b_d', 'D', 'default', 'owner_p2b_d', null,
-             'chat', 'hidden', 'hidden', 'hidden')`
+    `insert into servers (id, hub_id, name, type, created_by_user_id, owner_user_id)
+     values ('srv_p2b_d', 'hub_p2b_d', 'D', 'default', 'owner_p2b_d', null)`
   );
+  await seedDefaultSpaceAccessRules(pool, 'srv_p2b_d');
+  // Server denies everyone but hub_admin / space_admin / hub_owner.
   await pool.query(
-    `insert into channels (id, server_id, name, type, visitor_access, hub_member_access, space_member_access, hub_admin_access)
-     values ('chn_p2b_d', 'srv_p2b_d', 'general', 'text', 'hidden', 'hidden', 'hidden', 'chat')`
+    `update space_access_rules set level = 'hidden'
+       where server_id = 'srv_p2b_d' and audience_tier in ('visitor', 'hub_member', 'space_member')`
   );
 
-  // Set space_admin to 'chat' explicitly via the rules table.
   await pool.query(
-    `update channel_access_rules set level = 'chat' where channel_id = 'chn_p2b_d' and audience_tier = 'space_admin'`
+    `insert into channels (id, server_id, name, type) values ('chn_p2b_d', 'srv_p2b_d', 'general', 'text')`
+  );
+  await seedDefaultChannelAccessRules(pool, 'chn_p2b_d', 'hidden');
+  // Channel is also locked down for member/visitor tiers.
+  await pool.query(
+    `update channel_access_rules set level = 'hidden'
+       where channel_id = 'chn_p2b_d' and audience_tier in ('visitor', 'hub_member', 'space_member')`
   );
 
   // Grant a user space_admin.
@@ -322,21 +316,22 @@ test("P2.b: space_admin tier resolves to admin rule level (not falling through t
 test("P2.b: space_moderator tier resolves to moderator rule level when set 'hidden'", async (t) => {
   if (!pool) { t.skip("DATABASE_URL not configured."); return; }
   const { isActionAllowed } = await import("../services/policy-service.js");
+  const { seedDefaultSpaceAccessRules, seedDefaultChannelAccessRules } =
+    await import("../services/provisioning-service.js");
 
   await pool.query("insert into hubs (id, name, owner_user_id) values ('hub_p2b_e', 'P2b Hub E', 'owner_p2b_e')");
   await pool.query(
-    `insert into servers
-       (id, hub_id, name, type, created_by_user_id, owner_user_id,
-        hub_admin_access, space_member_access, hub_member_access, visitor_access)
-     values ('srv_p2b_e', 'hub_p2b_e', 'E', 'default', 'owner_p2b_e', null,
-             'chat', 'chat', 'chat', 'chat')`
+    `insert into servers (id, hub_id, name, type, created_by_user_id, owner_user_id)
+     values ('srv_p2b_e', 'hub_p2b_e', 'E', 'default', 'owner_p2b_e', null)`
   );
-  await pool.query(
-    `insert into channels (id, server_id, name, type, visitor_access, hub_member_access, space_member_access, hub_admin_access)
-     values ('chn_p2b_e', 'srv_p2b_e', 'private', 'text', 'chat', 'chat', 'chat', 'chat')`
-  );
+  await seedDefaultSpaceAccessRules(pool, 'srv_p2b_e');
 
-  // Force the moderator tier off for this channel.
+  await pool.query(
+    `insert into channels (id, server_id, name, type) values ('chn_p2b_e', 'srv_p2b_e', 'private', 'text')`
+  );
+  await seedDefaultChannelAccessRules(pool, 'chn_p2b_e', 'chat');
+  // Force the moderator tier off for this channel even though everyone
+  // else can read.
   await pool.query(
     `update channel_access_rules set level = 'hidden'
        where channel_id = 'chn_p2b_e' and audience_tier = 'space_moderator'`

--- a/apps/control-plane/src/test/schema-regression.test.ts
+++ b/apps/control-plane/src/test/schema-regression.test.ts
@@ -2,38 +2,49 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { pool, initDb } from "../db/client.js";
 
-test("schema has granular access columns and no privacy_tier", async () => {
+test("schema: legacy *_access columns dropped; rules tables present", async () => {
   await initDb();
   if (!pool) {
     console.error("No database connection pool available for schema regression test.");
     return;
   }
 
-  // Check channels table
+  // Channels table
   const channelCols = await pool.query(`
-    SELECT column_name 
-    FROM information_schema.columns 
+    SELECT column_name
+    FROM information_schema.columns
     WHERE table_name = 'channels'
   `);
   const channelColNames = channelCols.rows.map(r => r.column_name);
-  
-  assert.ok(channelColNames.includes('hub_admin_access'), "channels should have hub_admin_access");
-  assert.ok(channelColNames.includes('space_member_access'), "channels should have space_member_access");
-  assert.ok(channelColNames.includes('hub_member_access'), "channels should have hub_member_access");
-  assert.ok(channelColNames.includes('visitor_access'), "channels should have visitor_access");
+
+  // P2.cleanup (2026-05-08): legacy `*_access` columns are gone.
+  assert.ok(!channelColNames.includes('hub_admin_access'), "channels should NOT have hub_admin_access");
+  assert.ok(!channelColNames.includes('space_member_access'), "channels should NOT have space_member_access");
+  assert.ok(!channelColNames.includes('hub_member_access'), "channels should NOT have hub_member_access");
+  assert.ok(!channelColNames.includes('visitor_access'), "channels should NOT have visitor_access");
   assert.ok(!channelColNames.includes('privacy_tier'), "channels should NOT have privacy_tier");
 
-  // Check servers table
+  // Servers table
   const serverCols = await pool.query(`
-    SELECT column_name 
-    FROM information_schema.columns 
+    SELECT column_name
+    FROM information_schema.columns
     WHERE table_name = 'servers'
   `);
   const serverColNames = serverCols.rows.map(r => r.column_name);
 
-  assert.ok(serverColNames.includes('hub_admin_access'), "servers should have hub_admin_access");
-  assert.ok(serverColNames.includes('space_member_access'), "servers should have space_member_access");
-  assert.ok(serverColNames.includes('hub_member_access'), "servers should have hub_member_access");
-  assert.ok(serverColNames.includes('visitor_access'), "servers should have visitor_access");
+  assert.ok(!serverColNames.includes('hub_admin_access'), "servers should NOT have hub_admin_access");
+  assert.ok(!serverColNames.includes('space_member_access'), "servers should NOT have space_member_access");
+  assert.ok(!serverColNames.includes('hub_member_access'), "servers should NOT have hub_member_access");
+  assert.ok(!serverColNames.includes('visitor_access'), "servers should NOT have visitor_access");
   assert.ok(!serverColNames.includes('privacy_tier'), "servers should NOT have privacy_tier");
+
+  // The replacement tables exist.
+  const tables = await pool.query(`
+    SELECT table_name
+    FROM information_schema.tables
+    WHERE table_name in ('space_access_rules', 'channel_access_rules')
+  `);
+  const tableNames = tables.rows.map(r => r.table_name);
+  assert.ok(tableNames.includes('space_access_rules'), "space_access_rules table should exist");
+  assert.ok(tableNames.includes('channel_access_rules'), "channel_access_rules table should exist");
 });


### PR DESCRIPTION
Closes out the permissions sprint by removing the storage layer
that P2.b superseded. P2.b's normalized rules tables
(`space_access_rules`, `channel_access_rules`) are the sole
source of truth for per-resource access from this PR forward.
Legacy `*_access` columns and the bridging DB triggers are gone.

After this merges, **the `permissions-sprint` branch is ready to
merge into `main`** — see "Sprint readiness check" at the bottom.

## Migration 037

- Drops triggers `servers_sync_access_rules` /
  `channels_sync_access_rules` and the functions backing them.
  Trigger drops happen first so the column drops don't fire
  them.
- Drops `hub_admin_access`, `space_member_access`,
  `hub_member_access`, `visitor_access` from both `servers` and
  `channels`.
- `down` re-creates the columns and backfills from the rules
  table. It does **not** re-install the triggers; rolling back
  P2.cleanup requires re-applying migration 036's trigger SQL
  manually.

## Service code

- `provisioning-service` exports `seedDefaultSpaceAccessRules` /
  `seedDefaultChannelAccessRules` and calls them from every
  create path. The legacy columns are gone from
  `createServerWorkflow` and `createChannelWorkflow` INSERTs.
- `chat/channel-service.getOrCreateDMChannel` and
  `bootstrap-service.bootstrapAdmin` invoke the seed helpers
  for every server and channel they create.
- `chat/server-service.listServers` — visibility predicates that
  read `s.visitor_access` etc. now consult the rules tables.
  Behavior preserved. `renameServer` enriches its response from
  the rules table.
- `chat/channel-service.listChannels` — same treatment; uses new
  bulk-fetch helpers `fetchSpaceAccessRules` /
  `fetchChannelAccessRules` to avoid N+1 queries.
- `chat/mapping-helpers.mapChannel` accepts an optional rules
  map and populates the API response's tier-level fields from
  it; defaults applied when not provided. `ChannelRow` and
  `ServerRow` no longer carry the legacy column fields.
- `settings-service`:
  - `getServerSettings` / `getChannelSettings` read all six tier
    levels from the rules table.
  - `updateServerSettings` / `updateChannelSettings` upsert all
    six tiers to the rules table; legacy `update ... set
    *_access = ...` clauses are removed. Server settings update
    only touches non-access columns
    (`starting_channel_id`, `icon_url`, `auto_join_hub_members`,
    `join_policy`).

## API contract preserved

`Server` and `Channel` response objects still carry
`hubAdminAccess`, `spaceMemberAccess`, `hubMemberAccess`,
`visitorAccess`, `spaceAdminAccess`, `spaceModeratorAccess` —
values are now sourced from the rules tables at the API
boundary. No frontend changes are needed; the
`PermissionsEditor` keeps working.

## Tests

- `policy.test.ts`: rewrote the five P2.b cases to use the new
  insert + seed-helper pattern (legacy column inserts no longer
  work). Removed the now-irrelevant "trigger propagates legacy
  update" test. Added the equivalent positive coverage via
  `seedDefaultSpaceAccessRules`.
- `masquerade.test.ts`: two channel-creation sites updated to
  use raw inserts + seed helpers.
- `schema-regression.test.ts`: flipped — asserts the legacy
  columns are **absent** and the rules tables are **present**.

Suite results on the live test stack:
- shared 16/16
- web 12/12
- **control-plane 138/138** (one less than before because the
  trigger-propagation case from P2.b is no longer applicable)

## Test plan

- [x] `pnpm --filter @skerry/shared test` — 16/16.
- [x] `pnpm --filter @skerry/web test` — 12/12.
- [x] **`pnpm --filter @skerry/control-plane test` — 138/138**.
- [x] Typecheck clean.
- [ ] **Pangolin migration verification** (this is the "deploy and
      sanity-check" gate before merging the whole sprint to main):
      1. Run migration 037; confirm the columns are gone:
         `select column_name from information_schema.columns
          where table_name in ('servers','channels')
            and column_name like '%_access'` returns no rows.
      2. Confirm `space_access_rules` / `channel_access_rules`
         row counts match `servers × 6` and `channels × 6`.
      3. Walk a hub admin through Space Settings → Permissions:
         load (read all six tier dropdowns), save a change, reload,
         confirm the change persists.
      4. Visitor view: open the public Pangolin URL signed-out,
         confirm visibility behaves identically to pre-P2.cleanup.
      5. Create a brand-new space (server) and a new channel via
         the UI; confirm both got rule rows seeded
         (`select count(*) from space_access_rules where
          server_id = '<new>'` should be 6, and same for
         `channel_access_rules`).
      6. Hub admin can still see + post in every channel; visitor
         still locked out of `hidden` resources.

## Sprint readiness check

After this merges into `permissions-sprint`, the
`permissions-sprint` → `main` merge has these PRs in flight:

| Slice    | PR      | Status |
| -------- | ------- | ------ |
| P1       | #94     | merged |
| P3       | #95     | merged |
| P2.a     | #96     | merged |
| P2.b     | #97     | merged |
| P2.cleanup | _this PR_ | open |

Outstanding before the sprint merge:
- This PR + a Pangolin walk-through.
- Issue #34 (Onboarding Display Name) and #38 (Server Permissions
  Persistence) come back into scope after the sprint merges. #38
  is likely partially or fully subsumed by P2.b's resolver — re-read
  in light of the new shape before re-scoping.
