### PR TITLE
fix(sprint-2): close out #34 (onboarding display name) and #38 (server permissions persistence)

### DIFF
--- a/.agent-shared/TODO.md
+++ b/.agent-shared/TODO.md
@@ -17,8 +17,11 @@ Land remaining Sprint 2 issues. **No batching, one PR per issue.**
         - [x] **P2.cleanup**: Drop legacy `*_access` columns +
           DB triggers. Branch
           `feat/permissions-sprint-p2cleanup-drop-legacy-access`.
-- [ ] **Issue #34**: Onboarding Display Name (Blocked on permissions).
-- [ ] **Issue #38**: Server Permissions Persistence (Likely subsumed by P2).
+- [x] **Issue #34**: Onboarding Display Name. Branch
+  `fix/sprint-2-tail`.
+- [x] **Issue #38**: Server Permissions Persistence — verified
+  fixed by P2.b's resolver + P2.cleanup's storage rewrite.
+  Regression test added on `fix/sprint-2-tail`.
 
 ## Open Questions
 - None.

--- a/apps/control-plane/src/routes/auth-routes.ts
+++ b/apps/control-plane/src/routes/auth-routes.ts
@@ -453,17 +453,29 @@ export async function registerAuthRoutes(app: FastifyInstance): Promise<void> {
   });
 
   app.post("/auth/onboarding/username", { preHandler: requireAuth }, async (request, reply) => {
+    // Issue #34: the UI labels this field "Display Name" — the API
+    // payload key is still `username` for backwards compatibility but
+    // the validation now matches display-name semantics. Spaces are
+    // allowed; the storage column (`identity_mappings.preferred_username`)
+    // and the surrounding helpers retain their pre-#34 names.
     const payload = z
       .object({
         username: z
           .string()
           .min(3)
           .max(40)
-          .regex(/^[a-zA-Z0-9._-]+$/)
+          .regex(/^[\p{L}\p{N}._\- ]+$/u, "Display name may include letters, numbers, spaces, dots, underscores, and hyphens.")
       })
       .parse(request.body);
 
-    const normalizedUsername = payload.username.trim();
+    const normalizedUsername = payload.username.trim().replace(/\s+/g, " ");
+    if (normalizedUsername.length < 3) {
+      reply.code(400).send({
+        message: "Display name must be at least 3 characters after trimming.",
+        code: "display_name_too_short"
+      });
+      return;
+    }
     const taken = await isPreferredUsernameTaken({
       preferredUsername: normalizedUsername,
       excludingProductUserId: request.auth!.productUserId

--- a/apps/control-plane/src/test/policy.test.ts
+++ b/apps/control-plane/src/test/policy.test.ts
@@ -349,3 +349,148 @@ test("P2.b: space_moderator tier resolves to moderator rule level when set 'hidd
   });
   assert.equal(allowed, false, "moderator tier rule of 'hidden' should deny read even though space_member='chat'");
 });
+
+test("Issue #38: PATCH /v1/servers/:id/settings persists all six audience-tier access levels", async (t) => {
+  if (!pool) { t.skip("DATABASE_URL not configured."); return; }
+  const { config } = await import("../config.js");
+  if (!config.setupBootstrapToken) { t.skip("SETUP_BOOTSTRAP_TOKEN not configured."); return; }
+
+  const { buildApp } = await import("../app.js");
+  const { bootstrap: bootstrapHub } = await import("./helpers/bootstrap.js");
+
+  const app = await buildApp();
+  try {
+    const { adminCookie, defaultServerId } = await bootstrapHub(app, { prefix: "issue38" });
+
+    const patchRes = await app.inject({
+      method: "PATCH",
+      url: `/v1/servers/${defaultServerId}/settings`,
+      headers: { cookie: adminCookie },
+      payload: {
+        visitorAccess: "read",
+        hubMemberAccess: "locked",
+        spaceMemberAccess: "read",
+        spaceModeratorAccess: "read",
+        spaceAdminAccess: "chat",
+        hubAdminAccess: "chat"
+      }
+    });
+    assert.equal(patchRes.statusCode, 204, `Expected 204 but got ${patchRes.statusCode}: ${patchRes.body}`);
+
+    const rules = await pool.query<{ audience_tier: string; level: string }>(
+      "select audience_tier, level from space_access_rules where server_id = $1",
+      [defaultServerId]
+    );
+    const byTier = Object.fromEntries(rules.rows.map(r => [r.audience_tier, r.level]));
+    assert.equal(byTier.visitor, 'read', "visitorAccess should persist");
+    assert.equal(byTier.hub_member, 'locked', "hubMemberAccess should persist");
+    assert.equal(byTier.space_member, 'read', "spaceMemberAccess should persist");
+    assert.equal(byTier.space_moderator, 'read', "spaceModeratorAccess should persist");
+    assert.equal(byTier.space_admin, 'chat', "spaceAdminAccess should persist");
+    assert.equal(byTier.hub_admin, 'chat', "hubAdminAccess should persist");
+
+    const getRes = await app.inject({
+      method: "GET",
+      url: `/v1/servers/${defaultServerId}/settings`,
+      headers: { cookie: adminCookie }
+    });
+    assert.equal(getRes.statusCode, 200);
+    const settings = getRes.json() as Record<string, string>;
+    assert.equal(settings.visitorAccess, 'read');
+    assert.equal(settings.hubMemberAccess, 'locked');
+    assert.equal(settings.spaceMemberAccess, 'read');
+    assert.equal(settings.spaceModeratorAccess, 'read');
+    assert.equal(settings.spaceAdminAccess, 'chat');
+    assert.equal(settings.hubAdminAccess, 'chat');
+  } finally {
+    await app.close();
+  }
+});
+
+test("Issue #34: onboarding accepts display names with spaces", async (t) => {
+  if (!pool) { t.skip("DATABASE_URL not configured."); return; }
+  const { config } = await import("../config.js");
+  if (!config.setupBootstrapToken) { t.skip("SETUP_BOOTSTRAP_TOKEN not configured."); return; }
+
+  const { buildApp } = await import("../app.js");
+  const { upsertIdentityMapping } = await import("../services/identity-service.js");
+  const { createAuthCookie } = await import("./helpers/auth.js");
+  const { bootstrap: bootstrapHub } = await import("./helpers/bootstrap.js");
+
+  const app = await buildApp();
+  try {
+    await bootstrapHub(app, { prefix: "issue34" });
+
+    // A second user signs up; they're prompted to choose a display name.
+    const newUser = await upsertIdentityMapping({
+      provider: "dev",
+      oidcSubject: "issue34_newcomer",
+      email: "issue34-newcomer@dev.local",
+      preferredUsername: null,
+      avatarUrl: null
+    });
+    const cookie = createAuthCookie({
+      productUserId: newUser.productUserId,
+      provider: "dev",
+      oidcSubject: "issue34_newcomer"
+    });
+
+    const okRes = await app.inject({
+      method: "POST",
+      url: "/auth/onboarding/username",
+      headers: { cookie },
+      payload: { username: "Alice Smith" }
+    });
+    assert.equal(okRes.statusCode, 204, `Expected 204 but got ${okRes.statusCode}: ${okRes.body}`);
+
+    const stored = await pool.query<{ preferred_username: string | null }>(
+      "select preferred_username from identity_mappings where product_user_id = $1 limit 1",
+      [newUser.productUserId]
+    );
+    assert.equal(stored.rows[0]?.preferred_username, "Alice Smith");
+  } finally {
+    await app.close();
+  }
+});
+
+test("Issue #34: onboarding rejects whitespace-only display names", async (t) => {
+  if (!pool) { t.skip("DATABASE_URL not configured."); return; }
+  const { config } = await import("../config.js");
+  if (!config.setupBootstrapToken) { t.skip("SETUP_BOOTSTRAP_TOKEN not configured."); return; }
+
+  const { buildApp } = await import("../app.js");
+  const { upsertIdentityMapping } = await import("../services/identity-service.js");
+  const { createAuthCookie } = await import("./helpers/auth.js");
+  const { bootstrap: bootstrapHub } = await import("./helpers/bootstrap.js");
+
+  const app = await buildApp();
+  try {
+    await bootstrapHub(app, { prefix: "issue34b" });
+
+    const newUser = await upsertIdentityMapping({
+      provider: "dev",
+      oidcSubject: "issue34b_newcomer",
+      email: "issue34b-newcomer@dev.local",
+      preferredUsername: null,
+      avatarUrl: null
+    });
+    const cookie = createAuthCookie({
+      productUserId: newUser.productUserId,
+      provider: "dev",
+      oidcSubject: "issue34b_newcomer"
+    });
+
+    // Three spaces — passes min(3) and the regex, but trims to empty.
+    const res = await app.inject({
+      method: "POST",
+      url: "/auth/onboarding/username",
+      headers: { cookie },
+      payload: { username: "   " }
+    });
+    assert.equal(res.statusCode, 400);
+    const body = JSON.parse(res.body) as { code?: string };
+    assert.equal(body.code, "display_name_too_short");
+  } finally {
+    await app.close();
+  }
+});

--- a/apps/web/components/auth-overlay.tsx
+++ b/apps/web/components/auth-overlay.tsx
@@ -139,21 +139,21 @@ export function AuthOverlay() {
     if (viewer.needsOnboarding) {
         return (
             <section className="panel">
-                <h2>Choose Username</h2>
-                <p>Complete onboarding by picking your handle. This is used for mentions and display.</p>
+                <h2>Choose Display Name</h2>
+                <p>Complete onboarding by picking the name shown next to your messages. Spaces are allowed.</p>
                 <form onSubmit={handleOnboardingUsername} className="stack">
-                    <label htmlFor="onboarding-username">Username</label>
+                    <label htmlFor="onboarding-username">Display Name</label>
                     <input
                         id="onboarding-username"
                         value={onboardingUsername}
                         onChange={(event) => setOnboardingUsername(event.target.value)}
                         minLength={3}
                         maxLength={40}
-                        pattern="^[a-zA-Z0-9._-]+$"
+                        pattern="^[\p{L}\p{N}._\- ]+$"
                         required
                     />
                     <button type="submit" disabled={savingOnboarding}>
-                        {savingOnboarding ? "Saving..." : "Save Username"}
+                        {savingOnboarding ? "Saving..." : "Save Display Name"}
                     </button>
                 </form>
             </section>

--- a/apps/web/e2e/accessibility.spec.ts
+++ b/apps/web/e2e/accessibility.spec.ts
@@ -21,13 +21,13 @@ test.describe('Accessibility', () => {
     await runA11yScan(page);
   });
 
-  test('onboarding (choose username)', async ({ page }) => {
+  test('onboarding (choose display name)', async ({ page }) => {
     await resetPlatform(page);
     await page.goto('/');
     await expect(page.locator('.login-container')).toBeVisible({ timeout: 15000 });
     await page.locator('#dev-username').fill('local-admin');
     await page.getByRole('button', { name: 'Dev Login' }).click();
-    await expect(page.getByText('Choose Username')).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText('Choose Display Name')).toBeVisible({ timeout: 15000 });
     await runA11yScan(page);
   });
 

--- a/apps/web/e2e/helpers/auth.ts
+++ b/apps/web/e2e/helpers/auth.ts
@@ -1,7 +1,7 @@
 import { expect, type Page } from '@playwright/test';
 
 /**
- * Performs dev-login and the onboarding "Choose Username" step.
+ * Performs dev-login and the onboarding "Choose Display Name" step.
  * Leaves the page on whatever the post-onboarding view is.
  */
 export async function loginAndOnboard(
@@ -13,9 +13,9 @@ export async function loginAndOnboard(
   await page.locator('#dev-username').fill(devUsername);
   await page.getByRole('button', { name: 'Dev Login' }).click();
 
-  await expect(page.getByText('Choose Username')).toBeVisible({ timeout: 15000 });
+  await expect(page.getByText('Choose Display Name')).toBeVisible({ timeout: 15000 });
   await page.locator('#onboarding-username').fill(displayUsername);
-  await page.getByRole('button', { name: 'Save Username' }).click();
+  await page.getByRole('button', { name: 'Save Display Name' }).click();
 }
 
 /**

--- a/apps/web/e2e/visual-regression.spec.ts
+++ b/apps/web/e2e/visual-regression.spec.ts
@@ -52,13 +52,13 @@ test.describe('Visual Regression', () => {
     });
   });
 
-  test('onboarding (choose username) form', async ({ page }) => {
+  test('onboarding (choose display name) form', async ({ page }) => {
     await resetPlatform(page);
     await page.goto('/');
     await expect(page.locator('.login-container')).toBeVisible({ timeout: 15000 });
     await page.locator('#dev-username').fill('local-admin');
     await page.getByRole('button', { name: 'Dev Login' }).click();
-    await expect(page.getByText('Choose Username')).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText('Choose Display Name')).toBeVisible({ timeout: 15000 });
 
     // Snapshot the onboarding card, not the full page.
     const card = page.locator('main, [data-testid="onboarding-card"], .onboarding').first();


### PR DESCRIPTION
Closes the last two Sprint 2 issues that were blocked behind the
permissions sprint. **Sprint 2 is done after this merges.**

## Issue #38 — Server Permissions Persistence (verified fixed, no code change)

> "When editing and saving Server Permissions changes, the changes
> do not get applied."

The permissions sprint rewrote the storage layer end-to-end:
P2.b moved per-tier access into normalized rules tables, and
P2.cleanup dropped the legacy `*_access` columns and the bridging
trigger. Both the read path (`getServerSettings`) and the write
path (`updateServerSettings`) flow through the rules table now.

Added a focused integration test: PATCH all six audience tiers to
non-default values, then assert
1. the rules table contains the new values, and
2. GET `/v1/servers/:id/settings` round-trips them back.

The test passes. **#38 is fixed.**

## Issue #34 — Onboarding Display Name

> "When a new user is being onboarded, they are instructed to
> choose a 'Username' when they are actually choosing a 'Display
> Name', we should update the form to reflect that. Also, Display
> Names should allow spaces, and currently fail with a 'Request
> Validation Failed' error."

Two real changes:

**Frontend** (`auth-overlay.tsx`)
- Title "Choose Username" → "Choose Display Name".
- Field label "Username" → "Display Name".
- Helper text + submit button copy aligned.
- Input `pattern` widened to `^[\p{L}\p{N}._\- ]+$`.
- The HTML `id`, React state name, and POST body key (`username`)
  stay put — back-compat with the existing
  `/auth/onboarding/username` route. Only user-visible labels
  change.

**Backend** (`/auth/onboarding/username`)
- Regex widened to match: `^[\p{L}\p{N}._\- ]+$/u`.
- Trim now collapses internal whitespace runs to a single space.
- Inputs that pass `min(3)` and the regex but trim to `<3` chars
  (e.g. three spaces) are rejected with
  `code: "display_name_too_short"`.

**E2E helper** (`apps/web/e2e/helpers/auth.ts`) — updated for the
renamed labels.

**New tests:**
- "Issue #34: onboarding accepts display names with spaces" —
  POSTs `"Alice Smith"`, asserts 204 and that the value is
  persisted in `preferred_username`.
- "Issue #34: onboarding rejects whitespace-only display names" —
  POSTs three spaces, asserts the trim-edge 400 fires.

### Storage-column note

The DB column is still `identity_mappings.preferred_username`. The
UI rebrands the field to "Display Name" without renaming the
column — surgical change. The separate per-identity `display_name`
column added by #9 (OIDC display-name capture) is unchanged and
still feeds the topbar fallback (`preferredUsername ??
displayName ?? "Guest"`).

A future cleanup could rename the storage column, but it would be
a bigger migration with little payoff.

## Test plan

- [x] `pnpm --filter @skerry/shared test` — 16/16.
- [x] `pnpm --filter @skerry/web test` — 12/12.
- [x] **`pnpm --filter @skerry/control-plane test` — 141/141** on
      the live test stack (3 new — 1 for #38, 2 for #34).
- [x] Typecheck clean for both packages.
- [ ] **Pangolin walk-through** — light-touch since the change is
      tightly scoped:
      1. Sign up a fresh user; confirm the onboarding screen says
         "Choose Display Name" / "Save Display Name".
      2. Submit `"Alice Smith"` (with a space); confirm the topbar
         shows it after onboarding.
      3. Submit `"   "` (three spaces); confirm a clear validation
         error.
      4. Open Space Settings → Permissions; flip the
         "Space Moderators" tier to `read`; save; reload the page;
         confirm the value persisted.

## Sprint 2 wrap

| #   | Issue                                  | Where                                 |
| --- | -------------------------------------- | ------------------------------------- |
| 9   | OIDC Display Name                      | PR #91 (merged)                       |
| 23  | Invite Link Buttons (3 slices)         | PR #92 (merged)                       |
| —   | Permissions sprint (5 slices)          | PR #99 (merged via integration branch)|
| 34  | Onboarding Display Name                | **this PR**                           |
| 38  | Server Permissions Persistence         | **this PR (verified, no code change)**|

Once this merges, all four Sprint 2 issues are closed.
