### PR TITLE
feat(#80): persist per-channel drafts to localStorage

### DIFF
--- a/.agent-shared/ARCHIVE.md
+++ b/.agent-shared/ARCHIVE.md
@@ -8,6 +8,18 @@ This file contains historical context, handoff notes, and chat logs moved out of
 
 ## Historical Plan Notes (from current-plan.md)
 
+### 2026-05-09 — Sprint 2 closeout
+Sprint 2 fully closed. PR #100 (`fix/sprint-2-tail`) merged 2026-05-09,
+landing #34 (onboarding "Display Name" rename + widened validation
+regex + 2 new control-plane tests) and #38 (verified already fixed by
+the permissions sprint; 6-tier round-trip integration test added).
+Follow-up commit `2ede4c0` aligned `accessibility.spec.ts` and
+`visual-regression.spec.ts` with the renamed onboarding heading
+("Choose Username" → "Choose Display Name") after a CI miss. Issues
+#34 and #38 closed and moved to Done on Project #2. Sprint 2 final
+status: ✅ #9, ✅ #23, ✅ permissions sprint (PRs #94/#95/#96/#97/#98
+under #99), ✅ #34, ✅ #38.
+
 ### 2026-05-07 19:44 — P1 (Role enum cleanup)
 Permissions sprint P1 (Role enum cleanup) landed on feat/permissions-sprint-p1-role-cleanup. Migration 034 backfills hub_members for non-bridged identities with role='user' bindings and drops every role='user' / role='visitor' binding. Bridged Discord identities are protected via the matrix_user_id NOT LIKE '@discord_%' guard. Role enum reduced to 5 values; INVITE_BAKEABLE_ROLES reduced to two; useHubInvite no longer writes a role binding when defaultRole is null (plain hub membership covers it). All suites green: shared 16/16, web 12/12, control-plane 129/129 (run on the live test stack).
 

--- a/.agent-shared/TODO.md
+++ b/.agent-shared/TODO.md
@@ -1,30 +1,36 @@
 # Skerry Active Tasks
 
-## Current Goal: Sprint 2
-Land remaining Sprint 2 issues. **No batching, one PR per issue.**
+## Current Goal: Sprint 3
+Land all Sprint 3 issues from GitHub Project #2. **One PR per
+isolated issue; closely coupled issues may be batched.**
 
 ## Tasks
-- [x] **Issue #9**: OIDC Display Name (`fix/issue-9-oidc-display-name`).
-- [x] **Issue #23**: Invite Link Generation (`fix/issue-23-unauth-invite-redeem`).
-- [/] **Permissions Sprint**:
-    - [x] **P1**: Role enum cleanup.
-    - [x] **P3**: Default Space Owner = Hub
-      (`feat/permissions-sprint-p3-default-space-owner`).
-    - [x] **P2**: Audience tiers, cascade, and capability split.
-        - [x] **P2.a**: Capability split.
-        - [x] **P2.b**: Normalized access-rules tables + tier
-          expansion + cascade.
-        - [x] **P2.cleanup**: Drop legacy `*_access` columns +
-          DB triggers. Branch
-          `feat/permissions-sprint-p2cleanup-drop-legacy-access`.
-- [x] **Issue #34**: Onboarding Display Name. Branch
-  `fix/sprint-2-tail`.
-- [x] **Issue #38**: Server Permissions Persistence — verified
-  fixed by P2.b's resolver + P2.cleanup's storage rewrite.
-  Regression test added on `fix/sprint-2-tail`.
+- [ ] **Issue #80**: Drafts per channel — preserve typed content
+  across channel switches. localStorage-backed; restore on mount,
+  clear on send. Frontend-only.
+- [ ] **Issues #42 + #43** (batched — shared autocomplete popover):
+    - **#42**: `@-mention` autocomplete using channel-member display
+      names.
+    - **#43**: `:emoji:` autocomplete by emoji name.
+- [ ] **Issue #79**: Read receipts / persistent last-read divider.
+  Per-(user, channel) `last_read_message_id` (verify existing
+  unread-badge schema first); sticky divider in message list;
+  update on unfocus / explicit mark-read / scroll-to-bottom.
+- [ ] **Issue #78**: Pinned messages drawer. Side drawer scoped to
+  channel, newest-first, click-through to source. Backend pin
+  functionality already exists (Phase 15).
+- [ ] **Issue #44**: Restyle small square buttons. Common design
+  language for emoji-icon buttons. Sequenced late so it can absorb
+  any new buttons added by earlier issues.
+- [ ] **Issue #77**: Message edit history with diff/timestamp on
+  hover. Schema migration for revision rows, fetch endpoint, diff
+  popover, retention policy. Heaviest — last in sprint.
 
 ## Open Questions
-- None.
+- **#44 design language**: confirm the target style with the user
+  before cutting the PR (icon set, border-radius, hover states).
+- **#77 retention policy**: keep all revisions, or cap (e.g. last 5)?
+  Decide before the schema migration.
 
 ---
 *For historical notes and completed sprint logs, see [ARCHIVE.md](./ARCHIVE.md).*

--- a/apps/web/components/chat-client.tsx
+++ b/apps/web/components/chat-client.tsx
@@ -123,6 +123,8 @@ export function ChatClient() {
   const messagesRef = useRef<HTMLOListElement>(null);
   const messageInputRef = useRef<HTMLTextAreaElement>(null);
   const [draftMessage, setDraftMessage] = useState("");
+  const draftMessageRef = useRef("");
+  draftMessageRef.current = draftMessage;
 
   const {
     urlServerId,
@@ -152,6 +154,7 @@ export function ChatClient() {
     markChannelAsRead,
     messagesRef,
     setDraftMessage,
+    draftMessageRef,
     lastSyncedUrlRef,
     setTargetUrl: (url: string | null) => {
       targetUrlSelectionRef.current = url;
@@ -191,6 +194,20 @@ export function ChatClient() {
   } = settings;
 
   const isBootstrappingRef = useRef(false);
+
+  // Debounced persistence of the in-progress draft to the per-channel store.
+  // Channel-switch and send paths flush synchronously (in their own handlers)
+  // — this effect just covers the typed-then-refresh case.
+  useEffect(() => {
+    const channelId = state.selectedChannelId;
+    if (!channelId) return;
+    const current = state.draftMessagesByChannel[channelId] ?? "";
+    if (current === draftMessage) return;
+    const t = setTimeout(() => {
+      originalDispatch({ type: "SET_CHANNEL_DRAFT", payload: { channelId, draft: draftMessage } });
+    }, 400);
+    return () => clearTimeout(t);
+  }, [draftMessage, state.selectedChannelId, state.draftMessagesByChannel, originalDispatch]);
 
   const handleUpdateRoomTopic = useCallback((topic: string) => {
     if (!state.selectedChannelId) return Promise.resolve();

--- a/apps/web/context/chat-context.tsx
+++ b/apps/web/context/chat-context.tsx
@@ -233,6 +233,7 @@ type ChatAction =
     | { type: "CLEAR_NOTIFICATIONS"; payload: { channelId: string } }
     | { type: "SET_CHANNEL_SCROLL_POSITION"; payload: { channelId: string; position: number } }
     | { type: "SET_CHANNEL_DRAFT"; payload: { channelId: string; draft: string } }
+    | { type: "LOAD_CHANNEL_DRAFTS"; payload: Record<string, string> }
     | { type: "UPSERT_CHANNEL"; payload: Channel }
     | { type: "DELETE_CHANNEL"; payload: string }
     | { type: "UPSERT_CATEGORY"; payload: Category }
@@ -560,14 +561,17 @@ export function chatReducer(state: ChatState, action: ChatAction): ChatState {
                     [action.payload.channelId]: action.payload.preference
                 }
             };
-        case "SET_CHANNEL_DRAFT":
-            return {
-                ...state,
-                draftMessagesByChannel: {
-                    ...state.draftMessagesByChannel,
-                    [action.payload.channelId]: action.payload.draft
-                }
-            };
+        case "SET_CHANNEL_DRAFT": {
+            const next = { ...state.draftMessagesByChannel };
+            if (action.payload.draft) {
+                next[action.payload.channelId] = action.payload.draft;
+            } else {
+                delete next[action.payload.channelId];
+            }
+            return { ...state, draftMessagesByChannel: next };
+        }
+        case "LOAD_CHANNEL_DRAFTS":
+            return { ...state, draftMessagesByChannel: action.payload };
         case "UPSERT_CHANNEL": {
             const exists = state.channels.some(c => c.id === action.payload.id);
             const nextChannels = exists 
@@ -738,8 +742,11 @@ interface ChatContextType {
 
 const ChatContext = createContext<ChatContextType | undefined>(undefined);
 
+const CHANNEL_DRAFTS_STORAGE_KEY = "skerry:channelDrafts";
+
 export function ChatProvider({ children }: { children: ReactNode }) {
     const [state, dispatch] = useReducer(chatReducer, initialState);
+    const draftsHydratedRef = React.useRef(false);
 
     React.useEffect(() => {
         const interval = setInterval(() => {
@@ -747,6 +754,37 @@ export function ChatProvider({ children }: { children: ReactNode }) {
         }, 5000);
         return () => clearInterval(interval);
     }, []);
+
+    React.useEffect(() => {
+        try {
+            const raw = localStorage.getItem(CHANNEL_DRAFTS_STORAGE_KEY);
+            if (raw) {
+                const parsed = JSON.parse(raw);
+                if (parsed && typeof parsed === "object") {
+                    const cleaned: Record<string, string> = {};
+                    for (const [k, v] of Object.entries(parsed)) {
+                        if (typeof v === "string" && v.length > 0) cleaned[k] = v;
+                    }
+                    dispatch({ type: "LOAD_CHANNEL_DRAFTS", payload: cleaned });
+                }
+            }
+        } catch {
+            // Corrupt JSON or storage unavailable — ignore.
+        }
+        draftsHydratedRef.current = true;
+    }, []);
+
+    React.useEffect(() => {
+        if (!draftsHydratedRef.current) return;
+        try {
+            localStorage.setItem(
+                CHANNEL_DRAFTS_STORAGE_KEY,
+                JSON.stringify(state.draftMessagesByChannel)
+            );
+        } catch {
+            // Quota exceeded or storage unavailable — drafts stay in memory.
+        }
+    }, [state.draftMessagesByChannel]);
 
     return (
         <ChatContext.Provider value={{ state, dispatch }}>

--- a/apps/web/hooks/use-chat-initialization.ts
+++ b/apps/web/hooks/use-chat-initialization.ts
@@ -28,6 +28,7 @@ interface UseChatInitializationProps {
   markChannelAsRead: (channelId: string) => Promise<void>;
   messagesRef: React.RefObject<HTMLOListElement>;
   setDraftMessage: (msg: string) => void;
+  draftMessageRef: React.MutableRefObject<string>;
   lastSyncedUrlRef: React.MutableRefObject<string>;
   setTargetUrl?: (url: string | null) => void;
 }
@@ -40,6 +41,7 @@ export function useChatInitialization({
   markChannelAsRead,
   messagesRef,
   setDraftMessage,
+  draftMessageRef,
   lastSyncedUrlRef,
   setTargetUrl
 }: UseChatInitializationProps) {
@@ -241,6 +243,12 @@ export function useChatInitialization({
         const targetUrl = `${nextServerId}:${nextChannelId ?? "null"}:${finalMessageId ?? "null"}`;
         lastSyncedUrlRef.current = targetUrl;
         if (setTargetUrl) setTargetUrl(targetUrl);
+        if (selectedChannelId && selectedChannelId !== nextChannelId) {
+          dispatch({
+            type: "SET_CHANNEL_DRAFT",
+            payload: { channelId: selectedChannelId, draft: draftMessageRef.current }
+          });
+        }
         setDraftMessage(draftMessagesByChannel[nextChannelId] ?? "");
 
         // Track last channel by server
@@ -306,7 +314,7 @@ export function useChatInitialization({
       dispatch({ type: "SET_SWITCHING_SERVER", payload: false });
       setUrlSelection(nextServerId, null);
     }
-  }, [urlServerId, urlChannelId, urlMessageId, selectedServerId, selectedChannelId, dispatch, setUrlSelection, lastSyncedUrlRef, setDraftMessage, draftMessagesByChannel, channelScrollPositions, messagesRef, markChannelAsRead, setTargetUrl, state.channels, state.categories, state.allDmChannels]);
+  }, [urlServerId, urlChannelId, urlMessageId, selectedServerId, selectedChannelId, dispatch, setUrlSelection, lastSyncedUrlRef, setDraftMessage, draftMessageRef, draftMessagesByChannel, channelScrollPositions, messagesRef, markChannelAsRead, setTargetUrl, state.channels, state.categories, state.allDmChannels]);
 
   const handleServerChange = useCallback(async (serverId: string, channelId?: string): Promise<void> => {
     const targetChannelId = channelId ?? state.lastChannelByServer[serverId];
@@ -330,6 +338,12 @@ export function useChatInitialization({
     if (setTargetUrl) setTargetUrl(targetUrl);
     lastSyncedUrlRef.current = targetUrl;
 
+    if (selectedChannelId && selectedChannelId !== channelId) {
+      dispatch({
+        type: "SET_CHANNEL_DRAFT",
+        payload: { channelId: selectedChannelId, draft: draftMessageRef.current }
+      });
+    }
     setDraftMessage(draftMessagesByChannel[channelId] ?? "");
 
     try {
@@ -338,7 +352,7 @@ export function useChatInitialization({
     } catch (cause) {
       dispatch({ type: "SET_ERROR", payload: cause instanceof Error ? cause.message : "Failed to load channel." });
     }
-  }, [selectedServerId, dispatch, setUrlSelection, lastSyncedUrlRef, setDraftMessage, draftMessagesByChannel, refreshChatState]);
+  }, [selectedServerId, selectedChannelId, dispatch, setUrlSelection, lastSyncedUrlRef, setDraftMessage, draftMessageRef, draftMessagesByChannel, refreshChatState]);
 
   const initialize = useCallback(async (): Promise<void> => {
     dispatch({ type: "SET_LOADING", payload: true });

--- a/apps/web/hooks/use-chat-messaging.ts
+++ b/apps/web/hooks/use-chat-messaging.ts
@@ -116,6 +116,7 @@ export function useChatMessaging({
     }
 
     setDraftMessage("");
+    dispatch({ type: "SET_CHANNEL_DRAFT", payload: { channelId: selectedChannelId, draft: "" } });
     messageInputRef.current?.focus();
     const replyToId = state.quotingMessage?.id;
     if (state.quotingMessage) {

--- a/apps/web/test/chat-context-reducer.test.ts
+++ b/apps/web/test/chat-context-reducer.test.ts
@@ -136,3 +136,55 @@ test("ADD_DM_CHANNEL leaves state.channels untouched when a non-DM server is act
   assert.equal(next.channels[0]!.id, "chn_general");
   assert.equal(next.allDmChannels[0]!.id, "chn_dm_new");
 });
+
+// #80 — Drafts per channel: SET_CHANNEL_DRAFT writes a draft for one channel
+// without disturbing other channels' drafts.
+test("SET_CHANNEL_DRAFT stores a draft scoped to the given channel", () => {
+  const state = {
+    ...initialState,
+    draftMessagesByChannel: { "chn_a": "older draft for A" },
+  };
+
+  const next = chatReducer(state, {
+    type: "SET_CHANNEL_DRAFT",
+    payload: { channelId: "chn_b", draft: "fresh draft for B" }
+  });
+
+  assert.equal(next.draftMessagesByChannel["chn_a"], "older draft for A");
+  assert.equal(next.draftMessagesByChannel["chn_b"], "fresh draft for B");
+});
+
+// #80 — Sending a message clears its draft. Empty drafts should be removed
+// from the map so localStorage doesn't accumulate empty entries forever.
+test("SET_CHANNEL_DRAFT with empty string deletes the entry", () => {
+  const state = {
+    ...initialState,
+    draftMessagesByChannel: { "chn_a": "draft", "chn_b": "other" },
+  };
+
+  const next = chatReducer(state, {
+    type: "SET_CHANNEL_DRAFT",
+    payload: { channelId: "chn_a", draft: "" }
+  });
+
+  assert.equal("chn_a" in next.draftMessagesByChannel, false);
+  assert.equal(next.draftMessagesByChannel["chn_b"], "other");
+});
+
+// #80 — Hydration from localStorage replaces the whole map in one shot.
+test("LOAD_CHANNEL_DRAFTS replaces the drafts map", () => {
+  const state = {
+    ...initialState,
+    draftMessagesByChannel: { "chn_stale": "stale" },
+  };
+
+  const next = chatReducer(state, {
+    type: "LOAD_CHANNEL_DRAFTS",
+    payload: { "chn_a": "from storage A", "chn_b": "from storage B" }
+  });
+
+  assert.deepEqual(next.draftMessagesByChannel, {
+    "chn_a": "from storage A",
+    "chn_b": "from storage B"
+  });
+});


### PR DESCRIPTION
## Summary
- Channel composer drafts now survive both channel switches and page reloads, scoped per channel and persisted to `localStorage["skerry:channelDrafts"]`.
- The reducer already had `draftMessagesByChannel` + `SET_CHANNEL_DRAFT` scaffolded; this wires up the writes, debounced persistence, channel-switch flush, send-clears-draft, and storage hydration.
- `SET_CHANNEL_DRAFT` now deletes the entry when the draft is empty, so the localStorage map doesn't accumulate empty strings.

## Test plan
- [x] Web reducer suite — 3 new cases (scoped writes, empty clearing, hydration replacement). 9/9 pass.
- [x] Typecheck clean (after `pnpm --filter @skerry/shared build`).
- [ ] Manual: type in channel A → switch to B → switch back → A's draft restored.
- [ ] Manual: type → reload page → draft restored.
- [ ] Manual: type → send → draft cleared from both UI and localStorage.
- [ ] Manual: type in two channels → confirm independent storage.

## Notes
- No E2E added. Drafts don't touch the real-time loop, so the mandatory-E2E rule from `AGENTS.md` doesn't apply. Reducer-level tests + manual exercise cover this.
- Skipped the issue's optional cross-device sync via user record — the spec explicitly marks it optional and says the backend round-trip isn't needed.

Closes #80.

🤖 Generated with [Claude Code](https://claude.com/claude-code)