### PR TITLE
feat(#42, #43): @-mention and :emoji: autocomplete in the composer

### DIFF
--- a/apps/control-plane/src/services/chat/channel-service.ts
+++ b/apps/control-plane/src/services/chat/channel-service.ts
@@ -346,6 +346,7 @@ export async function deleteChannel(input: { channelId: string; serverId: string
 export async function listChannelMembers(channelId: string, viewerUserId?: string): Promise<{
   productUserId: string;
   displayName: string;
+  preferredUsername: string | null;
   avatarUrl?: string;
   isOnline: boolean;
   lastSeenAt?: string;
@@ -426,6 +427,7 @@ export async function listChannelMembers(channelId: string, viewerUserId?: strin
     const localMembers = localUserRows.rows.map(r => ({
       productUserId: r.product_user_id,
       displayName: r.preferred_username ?? r.email?.split('@')[0] ?? `user-${r.product_user_id.slice(0, 8)}`,
+      preferredUsername: r.preferred_username,
       avatarUrl: r.avatar_url ?? undefined,
       isOnline: r.last_seen_at ? (now - new Date(r.last_seen_at).getTime() < ONLINE_THRESHOLD_MS) : false,
       lastSeenAt: r.last_seen_at ?? undefined,
@@ -473,6 +475,7 @@ export async function listChannelMembers(channelId: string, viewerUserId?: strin
           bridgedMembers.push({
             productUserId: `discord_${discordId}`,
             displayName: p.displayName || p.username,
+            preferredUsername: null,
             avatarUrl: p.avatarUrl ?? undefined,
             isOnline: true,
             bridgedUserStatus: p.status,
@@ -508,6 +511,7 @@ export async function listChannelMembers(channelId: string, viewerUserId?: strin
       externalOfflineMembers.push({
         productUserId: `discord_${discordId}`,
         displayName: row.external_author_name ?? row.author_display_name,
+        preferredUsername: null,
         avatarUrl: row.external_author_avatar_url ?? undefined,
         isOnline: false,
         isBridged: true,

--- a/apps/control-plane/src/services/chat/server-service.ts
+++ b/apps/control-plane/src/services/chat/server-service.ts
@@ -255,6 +255,7 @@ export async function deleteServer(serverId: string): Promise<void> {
 export async function listServerMembers(serverId: string): Promise<{
   productUserId: string;
   displayName: string;
+  preferredUsername: string | null;
   avatarUrl?: string;
   isOnline: boolean;
   isBridged?: boolean;
@@ -300,6 +301,7 @@ export async function listServerMembers(serverId: string): Promise<{
     const localMembers = localUserRows.rows.map(r => ({
       productUserId: r.product_user_id,
       displayName: r.preferred_username ?? r.email?.split('@')[0] ?? `user-${r.product_user_id.slice(0, 8)}`,
+      preferredUsername: r.preferred_username,
       avatarUrl: r.avatar_url ?? undefined,
       isOnline: r.last_seen_at ? (now - new Date(r.last_seen_at).getTime() < ONLINE_THRESHOLD_MS) : false,
       isBridged: false
@@ -313,6 +315,7 @@ export async function listServerMembers(serverId: string): Promise<{
     let bridgedMembers: {
       productUserId: string;
       displayName: string;
+      preferredUsername: string | null;
       avatarUrl?: string;
       isOnline: boolean;
       isBridged: boolean;
@@ -338,6 +341,7 @@ export async function listServerMembers(serverId: string): Promise<{
             bridgedMembers.push({
               productUserId: `discord_${id}`,
               displayName: member.displayName,
+              preferredUsername: null,
               avatarUrl: member.user.displayAvatarURL() ?? undefined,
               isOnline: member.presence?.status ? member.presence.status !== "offline" : false,
               isBridged: true,

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1436,6 +1436,72 @@ textarea:focus-visible,
   font-size: 0.74rem;
 }
 
+.autocomplete-popover {
+  position: absolute;
+  bottom: calc(100% + 0.25rem);
+  left: 0;
+  right: 0;
+  max-height: 16rem;
+  overflow-y: auto;
+  z-index: 20;
+  border-radius: 6px;
+  padding: 0.25rem 0;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+}
+
+.autocomplete-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.6rem;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  color: inherit;
+  font: inherit;
+  width: 100%;
+}
+
+.autocomplete-item.is-selected {
+  background: var(--bg-strong);
+}
+
+.autocomplete-item.is-disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.autocomplete-glyph {
+  font-size: 1.15rem;
+  width: 1.25rem;
+  text-align: center;
+  flex-shrink: 0;
+}
+
+.autocomplete-avatar {
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+}
+
+.autocomplete-primary {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.autocomplete-secondary {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  flex-shrink: 0;
+}
+
 .context {
   min-height: 0;
 }

--- a/apps/web/components/chat-window.tsx
+++ b/apps/web/components/chat-window.tsx
@@ -20,6 +20,9 @@ import { LandingJoinButton } from "./landing-join-button";
 import { LandingPageView } from "./landing-page-view";
 import { GifPlayer } from "./gif-player";
 import { useIntersectionObserver } from "../hooks/use-intersection-observer";
+import { useComposerAutocomplete } from "../hooks/use-composer-autocomplete";
+import { AutocompletePopover } from "./composer/autocomplete-popover";
+import { shortcodeToGlyph } from "../lib/composer-autocomplete/emoji-index";
 
 
 
@@ -169,24 +172,13 @@ function MessageContent({ message, hiddenUrls = [] }: { message: MessageItem; hi
             return `![:${name}:](https://cdn.discordapp.com/emojis/${id}.webp${query})`;
         });
 
-        // 2. Handle common standard shortcodes (minimal set for demo, or could use a library)
-        const commonShortcodes: Record<string, string> = {
-            ":smile:": "🙂",
-            ":smiley:": "😃",
-            ":grinning:": "😀",
-            ":blush:": "😊",
-            ":wink:": "😉",
-            ":heart:": "❤️",
-            ":thumbsup:": "👍",
-            ":ok_hand:": "👌",
-            ":fire:": "🔥",
-            ":rocket:": "🚀"
-        };
-        
-        // We only convert these to Unicode if they are standalone
-        Object.entries(commonShortcodes).forEach(([code, unicode]) => {
-            const escapedCode = code.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-            processedText = processedText.replace(new RegExp(escapedCode, 'g'), unicode);
+        // 2. Resolve any remaining `:name:` shortcodes against the full
+        // unicode emoji index. Custom emojis (Skerry server emojis, bridged
+        // Discord emojis) were already rewritten to `![:name:](url)` by the
+        // server's `enrichContentWithEmojis`, so they don't match this regex.
+        processedText = processedText.replace(/:([a-z0-9_+-]+):/gi, (full, name: string) => {
+            const glyph = shortcodeToGlyph(name.toLowerCase());
+            return glyph ?? full;
         });
 
         return (
@@ -347,6 +339,30 @@ export function ChatWindow({
     const [contextMenu, setContextMenu] = useState<{ x: number; y: number; message: MessageItem | null } | null>(null);
     const [userContextMenu, setUserContextMenu] = useState<{ x: number; y: number; userId: string; displayName: string } | null>(null);
     const [showEmojiPicker, setShowEmojiPicker] = useState(false);
+    const [composerCursor, setComposerCursor] = useState(0);
+    const pendingCursorRef = useRef<number | null>(null);
+    const autocomplete = useComposerAutocomplete({
+        value: draftMessage,
+        cursorPos: composerCursor,
+        members,
+        setValue: (next) => setDraftMessage(next),
+        setCursorPos: (pos) => {
+            pendingCursorRef.current = pos;
+            setComposerCursor(pos);
+        }
+    });
+
+    useEffect(() => {
+        if (pendingCursorRef.current === null) return;
+        const ta = messageInputRef.current;
+        if (!ta) return;
+        const target = pendingCursorRef.current;
+        pendingCursorRef.current = null;
+        requestAnimationFrame(() => {
+            ta.focus();
+            ta.setSelectionRange(target, target);
+        });
+    }, [draftMessage, messageInputRef]);
     const [editingMessageId, setEditingMessageId] = useState<string | null>(null);
     const [editContent, setEditContent] = useState("");
     const [lightboxUrl, setLightboxUrl] = useState<string | null>(null);
@@ -1516,13 +1532,29 @@ export function ChatWindow({
                             ))}
                         </div>
                     )}
+                    {autocomplete.items.length > 0 && (
+                        <AutocompletePopover
+                            items={autocomplete.items}
+                            selectedIdx={autocomplete.selectedIdx}
+                            onSelect={autocomplete.selectItem}
+                            onHover={autocomplete.setSelectedIdx}
+                        />
+                    )}
                     <textarea
                         id="message-input"
                         ref={messageInputRef}
                         value={draftMessage}
-                        onChange={(event) => setDraftMessage(event.target.value)}
+                        onChange={(event) => {
+                            setDraftMessage(event.target.value);
+                            setComposerCursor(event.target.selectionStart ?? event.target.value.length);
+                        }}
+                        onSelect={(event) => {
+                            const ta = event.target as HTMLTextAreaElement;
+                            setComposerCursor(ta.selectionStart ?? ta.value.length);
+                        }}
                         onPaste={handlePaste}
                         onKeyDown={(event) => {
+                            if (autocomplete.handleKeyDown(event)) return;
                             if (event.key === "Enter" && !event.shiftKey) {
                                 event.preventDefault();
                                 if (draftMessage.trim() || attachments.length > 0) {

--- a/apps/web/components/composer/autocomplete-popover.tsx
+++ b/apps/web/components/composer/autocomplete-popover.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import React from "react";
+import type { AutocompleteItem } from "../../lib/composer-autocomplete/providers";
+
+interface Props {
+  items: AutocompleteItem[];
+  selectedIdx: number;
+  onSelect: (item: AutocompleteItem) => void;
+  onHover: (idx: number) => void;
+}
+
+export function AutocompletePopover({ items, selectedIdx, onSelect, onHover }: Props) {
+  if (items.length === 0) return null;
+  return (
+    <div
+      className="autocomplete-popover panel"
+      role="listbox"
+      aria-label="Autocomplete suggestions"
+      onMouseDown={(e) => e.preventDefault()}
+    >
+      {items.map((item, idx) => (
+        <button
+          key={item.key}
+          type="button"
+          role="option"
+          aria-selected={idx === selectedIdx}
+          className={`autocomplete-item${idx === selectedIdx ? " is-selected" : ""}${item.disabled ? " is-disabled" : ""}`}
+          onMouseEnter={() => onHover(idx)}
+          onClick={() => !item.disabled && onSelect(item)}
+          title={item.disabledReason}
+          disabled={item.disabled}
+        >
+          {item.glyph && <span className="autocomplete-glyph" aria-hidden="true">{item.glyph}</span>}
+          {item.avatarUrl && (
+            <img className="autocomplete-avatar" src={item.avatarUrl} alt="" aria-hidden="true" />
+          )}
+          <span className="autocomplete-primary">{item.primary}</span>
+          {item.secondary && <span className="autocomplete-secondary">{item.secondary}</span>}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/context/chat-context.tsx
+++ b/apps/web/context/chat-context.tsx
@@ -38,6 +38,7 @@ export interface MessageItem extends ChatMessage {
 export interface ChatMember {
     productUserId: string;
     displayName: string;
+    preferredUsername: string | null;
     avatarUrl?: string;
     isOnline: boolean;
     lastSeenAt?: string;

--- a/apps/web/hooks/use-composer-autocomplete.ts
+++ b/apps/web/hooks/use-composer-autocomplete.ts
@@ -1,0 +1,122 @@
+"use client";
+
+import { useCallback, useMemo, useState, useEffect } from "react";
+import type { ChatMember } from "../context/chat-context";
+import { detectActiveTrigger, applyCompletion, type ActiveTrigger } from "../lib/composer-autocomplete/triggers";
+import { mentionItems, emojiItems, type AutocompleteItem } from "../lib/composer-autocomplete/providers";
+
+interface UseComposerAutocompleteParams {
+  value: string;
+  cursorPos: number;
+  members: ChatMember[];
+  setValue: (next: string) => void;
+  setCursorPos: (pos: number) => void;
+}
+
+export interface ComposerAutocompleteState {
+  items: AutocompleteItem[];
+  active: ActiveTrigger | null;
+  selectedIdx: number;
+  setSelectedIdx: (idx: number) => void;
+  selectItem: (item: AutocompleteItem) => void;
+  selectActiveItem: () => boolean;
+  dismiss: () => void;
+  handleKeyDown: (e: React.KeyboardEvent<HTMLTextAreaElement>) => boolean;
+}
+
+export function useComposerAutocomplete({
+  value,
+  cursorPos,
+  members,
+  setValue,
+  setCursorPos
+}: UseComposerAutocompleteParams): ComposerAutocompleteState {
+  const [selectedIdx, setSelectedIdx] = useState(0);
+  const [dismissedTrigger, setDismissedTrigger] = useState<string | null>(null);
+
+  const active = useMemo(() => detectActiveTrigger(value, cursorPos), [value, cursorPos]);
+
+  const triggerKey = active ? `${active.kind}@${active.startIdx}` : null;
+  const isDismissed = triggerKey !== null && dismissedTrigger === triggerKey;
+
+  const items = useMemo<AutocompleteItem[]>(() => {
+    if (!active || isDismissed) return [];
+    if (active.kind === "mention") return mentionItems(active.query, members);
+    if (active.kind === "emoji") return emojiItems(active.query);
+    return [];
+  }, [active, members, isDismissed]);
+
+  useEffect(() => {
+    setSelectedIdx(0);
+  }, [triggerKey, items.length]);
+
+  useEffect(() => {
+    if (dismissedTrigger && triggerKey !== dismissedTrigger) {
+      setDismissedTrigger(null);
+    }
+  }, [triggerKey, dismissedTrigger]);
+
+  const selectItem = useCallback(
+    (item: AutocompleteItem) => {
+      if (!active || item.disabled || !item.insertText) return;
+      const { text, cursorPos: nextCursor } = applyCompletion(value, active, item.insertText);
+      setValue(text);
+      setCursorPos(nextCursor);
+    },
+    [active, value, setValue, setCursorPos]
+  );
+
+  const selectActiveItem = useCallback((): boolean => {
+    const item = items[selectedIdx];
+    if (!item || item.disabled || !item.insertText) return false;
+    selectItem(item);
+    return true;
+  }, [items, selectedIdx, selectItem]);
+
+  const dismiss = useCallback(() => {
+    if (triggerKey) setDismissedTrigger(triggerKey);
+  }, [triggerKey]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>): boolean => {
+      if (items.length === 0) return false;
+      switch (e.key) {
+        case "ArrowDown":
+          e.preventDefault();
+          setSelectedIdx((idx) => (idx + 1) % items.length);
+          return true;
+        case "ArrowUp":
+          e.preventDefault();
+          setSelectedIdx((idx) => (idx - 1 + items.length) % items.length);
+          return true;
+        case "Enter":
+        case "Tab": {
+          const handled = selectActiveItem();
+          if (handled) {
+            e.preventDefault();
+            return true;
+          }
+          return false;
+        }
+        case "Escape":
+          e.preventDefault();
+          dismiss();
+          return true;
+        default:
+          return false;
+      }
+    },
+    [items.length, selectActiveItem, dismiss]
+  );
+
+  return {
+    items,
+    active,
+    selectedIdx,
+    setSelectedIdx,
+    selectItem,
+    selectActiveItem,
+    dismiss,
+    handleKeyDown
+  };
+}

--- a/apps/web/lib/composer-autocomplete/emoji-index.ts
+++ b/apps/web/lib/composer-autocomplete/emoji-index.ts
@@ -1,0 +1,102 @@
+// The data source is emoji-picker-react's bundled English locale JSON. Importing
+// from `dist/data/...` is a deep import that may break across major version
+// upgrades of emoji-picker-react — if that happens, swap in `node-emoji` or
+// `@emoji-mart/data` here.
+import emojiData from "emoji-picker-react/dist/data/emojis-en.json";
+
+export interface EmojiEntry {
+  shortcode: string;
+  glyph: string;
+  keywords: string[];
+}
+
+interface RawEmoji {
+  n: string[];
+  u: string;
+  a: string;
+}
+
+interface RawEmojiData {
+  emojis: Record<string, RawEmoji[]>;
+}
+
+let cache: { entries: EmojiEntry[]; shortcodeToGlyph: Map<string, string> } | null = null;
+
+function codepointToGlyph(hex: string): string {
+  return hex
+    .split("-")
+    .map((p) => String.fromCodePoint(parseInt(p, 16)))
+    .join("");
+}
+
+function canonicalToShortcode(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+}
+
+// Compact aliases preserved from the legacy chat-window shortcode map so users
+// who already type :smile:/:heart:/etc. still get glyphs after the rename.
+const LEGACY_ALIASES: Record<string, string> = {
+  smile: "🙂",
+  smiley: "😃",
+  grinning: "😀",
+  blush: "😊",
+  wink: "😉",
+  heart: "❤️",
+  thumbsup: "👍",
+  ok_hand: "👌",
+  fire: "🔥",
+  rocket: "🚀"
+};
+
+function buildIndex(): { entries: EmojiEntry[]; shortcodeToGlyph: Map<string, string> } {
+  const entries: EmojiEntry[] = [];
+  const shortcodeToGlyph = new Map<string, string>();
+
+  for (const [, list] of Object.entries((emojiData as RawEmojiData).emojis)) {
+    for (const raw of list) {
+      const canonical = raw.n[raw.n.length - 1];
+      if (!canonical) continue;
+      const shortcode = canonicalToShortcode(canonical);
+      if (!shortcode) continue;
+      const glyph = codepointToGlyph(raw.u);
+      const keywords = raw.n.slice(0, -1).map((k) => k.toLowerCase());
+      entries.push({ shortcode, glyph, keywords });
+      if (!shortcodeToGlyph.has(shortcode)) shortcodeToGlyph.set(shortcode, glyph);
+    }
+  }
+
+  for (const [alias, glyph] of Object.entries(LEGACY_ALIASES)) {
+    if (!shortcodeToGlyph.has(alias)) shortcodeToGlyph.set(alias, glyph);
+  }
+
+  return { entries, shortcodeToGlyph };
+}
+
+function getIndex() {
+  if (!cache) cache = buildIndex();
+  return cache;
+}
+
+export function searchEmojis(query: string, limit = 8): EmojiEntry[] {
+  const q = query.toLowerCase();
+  if (!q) return [];
+  const { entries } = getIndex();
+
+  const exact: EmojiEntry[] = [];
+  const prefix: EmojiEntry[] = [];
+  const sub: EmojiEntry[] = [];
+
+  for (const entry of entries) {
+    if (entry.shortcode === q) exact.push(entry);
+    else if (entry.shortcode.startsWith(q)) prefix.push(entry);
+    else if (entry.shortcode.includes(q) || entry.keywords.some((k) => k.includes(q))) sub.push(entry);
+    if (exact.length + prefix.length + sub.length >= limit * 3) break;
+  }
+
+  return [...exact, ...prefix, ...sub].slice(0, limit);
+}
+
+export function shortcodeToGlyph(shortcode: string): string | null {
+  const { shortcodeToGlyph: map } = getIndex();
+  return map.get(shortcode) ?? null;
+}

--- a/apps/web/lib/composer-autocomplete/providers.ts
+++ b/apps/web/lib/composer-autocomplete/providers.ts
@@ -1,0 +1,67 @@
+import type { ChatMember } from "../../context/chat-context";
+import type { TriggerKind } from "./triggers";
+import { searchEmojis, type EmojiEntry } from "./emoji-index";
+
+export interface AutocompleteItem {
+  key: string;
+  kind: TriggerKind;
+  primary: string;
+  secondary?: string;
+  glyph?: string;
+  avatarUrl?: string;
+  insertText: string;
+  disabled?: boolean;
+  disabledReason?: string;
+}
+
+export function mentionItems(query: string, members: ChatMember[], limit = 8): AutocompleteItem[] {
+  const q = query.toLowerCase();
+  const seen = new Set<string>();
+  const out: AutocompleteItem[] = [];
+  const exact: AutocompleteItem[] = [];
+  const prefix: AutocompleteItem[] = [];
+  const sub: AutocompleteItem[] = [];
+
+  for (const m of members) {
+    if (seen.has(m.productUserId)) continue;
+    seen.add(m.productUserId);
+
+    const handle = m.preferredUsername;
+    const name = m.displayName.toLowerCase();
+    const handleLc = handle?.toLowerCase() ?? "";
+
+    const matchesEmpty = q.length === 0;
+    const matches = matchesEmpty || name.includes(q) || handleLc.includes(q);
+    if (!matches) continue;
+
+    const item: AutocompleteItem = {
+      key: m.productUserId,
+      kind: "mention",
+      primary: m.displayName,
+      secondary: handle ? `@${handle}` : "Bridged user — not yet mentionable",
+      avatarUrl: m.avatarUrl,
+      insertText: handle ? `@${handle} ` : "",
+      disabled: !handle,
+      disabledReason: handle ? undefined : "Bridged users cannot be @-mentioned yet"
+    };
+
+    if (matchesEmpty) sub.push(item);
+    else if (handleLc === q || name === q) exact.push(item);
+    else if (handleLc.startsWith(q) || name.startsWith(q)) prefix.push(item);
+    else sub.push(item);
+  }
+
+  out.push(...exact, ...prefix, ...sub);
+  return out.slice(0, limit);
+}
+
+export function emojiItems(query: string, limit = 8): AutocompleteItem[] {
+  const results: EmojiEntry[] = searchEmojis(query, limit);
+  return results.map((e) => ({
+    key: e.shortcode,
+    kind: "emoji" as const,
+    primary: `:${e.shortcode}:`,
+    glyph: e.glyph,
+    insertText: `:${e.shortcode}:`
+  }));
+}

--- a/apps/web/lib/composer-autocomplete/triggers.ts
+++ b/apps/web/lib/composer-autocomplete/triggers.ts
@@ -1,0 +1,53 @@
+export type TriggerKind = "mention" | "emoji";
+
+export interface ActiveTrigger {
+  kind: TriggerKind;
+  query: string;
+  startIdx: number;
+  endIdx: number;
+}
+
+const TRIGGER_CHARS: Record<TriggerKind, string> = {
+  mention: "@",
+  emoji: ":"
+};
+
+const QUERY_PATTERNS: Record<TriggerKind, RegExp> = {
+  mention: /^[\p{L}\p{N}._-]*$/u,
+  emoji: /^[a-z0-9_+-]*$/i
+};
+
+export function detectActiveTrigger(text: string, cursorPos: number): ActiveTrigger | null {
+  let i = cursorPos - 1;
+  while (i >= 0) {
+    const ch = text[i]!;
+    if (/\s/.test(ch)) return null;
+
+    let kind: TriggerKind | null = null;
+    if (ch === TRIGGER_CHARS.mention) kind = "mention";
+    else if (ch === TRIGGER_CHARS.emoji) kind = "emoji";
+
+    if (kind) {
+      const atWordStart = i === 0 || /\s/.test(text[i - 1]!);
+      if (!atWordStart) return null;
+
+      const query = text.slice(i + 1, cursorPos);
+      if (!QUERY_PATTERNS[kind].test(query)) return null;
+
+      if (kind === "emoji" && query.length === 0) return null;
+
+      return { kind, query, startIdx: i, endIdx: cursorPos };
+    }
+    i--;
+  }
+  return null;
+}
+
+export function applyCompletion(
+  text: string,
+  trigger: ActiveTrigger,
+  insertion: string
+): { text: string; cursorPos: number } {
+  const next = text.slice(0, trigger.startIdx) + insertion + text.slice(trigger.endIdx);
+  return { text: next, cursorPos: trigger.startIdx + insertion.length };
+}

--- a/apps/web/lib/control-plane.ts
+++ b/apps/web/lib/control-plane.ts
@@ -638,6 +638,7 @@ export async function listChannelMembers(
 ): Promise<{
   productUserId: string;
   displayName: string;
+  preferredUsername: string | null;
   avatarUrl?: string;
   isOnline: boolean;
   lastSeenAt?: string;
@@ -648,6 +649,7 @@ export async function listChannelMembers(
     items: {
       productUserId: string;
       displayName: string;
+      preferredUsername: string | null;
       avatarUrl?: string;
       isOnline: boolean;
       lastSeenAt?: string;
@@ -1414,6 +1416,7 @@ export async function listHubMembers(hubId: string): Promise<IdentityMapping[]> 
 export async function listServerMembers(serverId: string): Promise<{
   productUserId: string;
   displayName: string;
+  preferredUsername: string | null;
   avatarUrl?: string;
   isOnline: boolean;
   isBridged?: boolean;
@@ -1423,6 +1426,7 @@ export async function listServerMembers(serverId: string): Promise<{
     items: {
       productUserId: string;
       displayName: string;
+      preferredUsername: string | null;
       avatarUrl?: string;
       isOnline: boolean;
       isBridged?: boolean;

--- a/apps/web/test/composer-autocomplete.test.ts
+++ b/apps/web/test/composer-autocomplete.test.ts
@@ -1,0 +1,124 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { detectActiveTrigger, applyCompletion } from "../lib/composer-autocomplete/triggers";
+import { searchEmojis, shortcodeToGlyph } from "../lib/composer-autocomplete/emoji-index";
+import { mentionItems, emojiItems } from "../lib/composer-autocomplete/providers";
+import type { ChatMember } from "../context/chat-context";
+
+function makeMember(p: Partial<ChatMember>): ChatMember {
+  return {
+    productUserId: "usr_a",
+    displayName: "Alice",
+    preferredUsername: "alice",
+    isOnline: true,
+    ...p
+  };
+}
+
+// --- triggers ---
+
+test("detectActiveTrigger: @ at start of input", () => {
+  const t = detectActiveTrigger("@al", 3);
+  assert.deepEqual(t, { kind: "mention", query: "al", startIdx: 0, endIdx: 3 });
+});
+
+test("detectActiveTrigger: @ after a space", () => {
+  const t = detectActiveTrigger("hello @al", 9);
+  assert.deepEqual(t, { kind: "mention", query: "al", startIdx: 6, endIdx: 9 });
+});
+
+test("detectActiveTrigger: ignores @ embedded in a word (email-like)", () => {
+  const t = detectActiveTrigger("user@example.com", 16);
+  assert.equal(t, null);
+});
+
+test("detectActiveTrigger: dismisses after whitespace", () => {
+  const t = detectActiveTrigger("@alice ", 7);
+  assert.equal(t, null);
+});
+
+test("detectActiveTrigger: : with empty query is not active", () => {
+  const t = detectActiveTrigger("hello :", 7);
+  assert.equal(t, null);
+});
+
+test("detectActiveTrigger: :emoji with query", () => {
+  const t = detectActiveTrigger("hello :sm", 9);
+  assert.deepEqual(t, { kind: "emoji", query: "sm", startIdx: 6, endIdx: 9 });
+});
+
+test("detectActiveTrigger: cursor before active char does not match", () => {
+  const t = detectActiveTrigger("hello @alice", 5); // cursor at 'o' in hello
+  assert.equal(t, null);
+});
+
+test("applyCompletion replaces the trigger range and reports new cursor", () => {
+  const trigger = { kind: "mention" as const, query: "al", startIdx: 6, endIdx: 9 };
+  const out = applyCompletion("hello @al world", trigger, "@alice ");
+  assert.equal(out.text, "hello @alice  world");
+  assert.equal(out.cursorPos, 6 + "@alice ".length);
+});
+
+// --- emoji index ---
+
+test("searchEmojis: empty query returns no results", () => {
+  assert.deepEqual(searchEmojis(""), []);
+});
+
+test("searchEmojis: 'smi' returns matches with glyphs", () => {
+  const out = searchEmojis("smi", 5);
+  assert.ok(out.length > 0, "expected at least one match for 'smi'");
+  for (const e of out) {
+    assert.ok(e.shortcode.length > 0);
+    assert.ok(e.glyph.length > 0);
+  }
+});
+
+test("shortcodeToGlyph: legacy alias :smile: still resolves", () => {
+  assert.equal(shortcodeToGlyph("smile"), "🙂");
+});
+
+test("shortcodeToGlyph: unknown name returns null", () => {
+  assert.equal(shortcodeToGlyph("not_a_real_emoji_name_xyz"), null);
+});
+
+// --- mention provider ---
+
+test("mentionItems: ranks exact > prefix > substring", () => {
+  const members = [
+    makeMember({ productUserId: "u1", displayName: "Talia", preferredUsername: "tal" }), // substring "ali" in "Talia"
+    makeMember({ productUserId: "u2", displayName: "Charlie", preferredUsername: "alistair" }), // prefix "alistair"
+    makeMember({ productUserId: "u3", displayName: "Alice", preferredUsername: "ali" }) // exact handle match
+  ];
+  const items = mentionItems("ali", members);
+  assert.equal(items[0]!.key, "u3"); // exact
+  assert.equal(items[1]!.key, "u2"); // prefix
+  assert.equal(items[2]!.key, "u1"); // substring
+});
+
+test("mentionItems: bridged users without preferredUsername are disabled", () => {
+  const members = [
+    makeMember({ productUserId: "discord_1", displayName: "Bridged Bob", preferredUsername: null, isBridged: true })
+  ];
+  const items = mentionItems("bo", members);
+  assert.equal(items.length, 1);
+  assert.equal(items[0]!.disabled, true);
+  assert.equal(items[0]!.insertText, "");
+});
+
+test("mentionItems: mentionable user inserts '@handle ' with trailing space", () => {
+  const members = [makeMember({ productUserId: "u1", displayName: "Alice", preferredUsername: "alice" })];
+  const items = mentionItems("ali", members);
+  assert.equal(items[0]!.insertText, "@alice ");
+});
+
+// --- emoji provider ---
+
+test("emojiItems: returns AutocompleteItems with glyph + insertText", () => {
+  const items = emojiItems("rocket");
+  assert.ok(items.length > 0);
+  const rocket = items.find((i) => i.key === "rocket");
+  assert.ok(rocket, "expected :rocket: in results");
+  assert.equal(rocket!.glyph, "🚀");
+  assert.equal(rocket!.insertText, ":rocket:");
+});

--- a/packages/shared/src/domain/contracts.ts
+++ b/packages/shared/src/domain/contracts.ts
@@ -641,6 +641,7 @@ export interface FollowedAnnouncement {
 export interface ChannelMemberFull {
     productUserId: string;
     displayName: string;
+    preferredUsername: string | null;
     avatarUrl?: string;
     isOnline: boolean;
     lastSeenAt?: string;


### PR DESCRIPTION
## Summary
- Adds a shared composer autocomplete primitive (trigger detection, provider-driven suggestions, keyboard nav, popover anchored above the textarea) used by both issues.
- **#42** — `@`-mention autocomplete against channel members. Inserts `@<preferredUsername> ` (single-token Skerry handle, what the existing native mention parser matches). Bridged Discord members surface as **disabled** with a "not yet mentionable" tooltip rather than getting silently dropped.
- **#43** — `:emoji:` autocomplete with substring search across ~1500 unicode emoji names. Inserts `:name:`.
- Replaces the inline 10-entry shortcode map in `MessageContent` with a full unicode lookup, so `:taco:` (and any other typed standard shortcode) renders as a glyph. Custom emoji are unaffected — the server's `enrichContentWithEmojis` already pre-rewrites them as `![:name:](url)` before this regex runs.
- Backend: `ChannelMemberFull` / `listChannelMembers` / `listServerMembers` now expose `preferredUsername: string | null`. Bridged → `null`.

## Test plan
- [x] Unit: 16 new cases in [composer-autocomplete.test.ts](apps/web/test/composer-autocomplete.test.ts) — trigger edge cases (email-like `@`, post-whitespace dismissal, empty-emoji guard), completion application, emoji search + glyph lookup, mention ranking, disabled bridged users, insert format. Suite 31/31.
- [x] Typecheck: clean on `@skerry/web` + `@skerry/control-plane`.
- [ ] Manual: type `@al`, see member popover, ArrowDown + Enter inserts `@alice `.
- [ ] Manual: type `:smi`, see emoji popover, Enter inserts `:smile:`. Send. Rendered message shows 🙂.
- [ ] Manual: type `:taco:` directly (no autocomplete), send. Rendered shows 🌮.
- [ ] Manual: with a Discord-bridged channel, see bridged member in popover with "not yet mentionable" tooltip and disabled state.
- [ ] Manual: server custom emoji `:my_emoji:` typed manually still renders as the custom image (not regressed by the new shortcode pass).

## Deliberately deferred (follow-up tickets)
- Bridged Discord users mentionable by `display_name` (cross-platform mention parity).
- Structured `<@usr_xxx>` wire format for full Discord-parity (immune to handle renames).
- Caret-anchored popover positioning (currently anchored above the composer, Slack-style).
- Auto-suggesting server custom emoji + bridged Discord emoji in the popover. Typing them manually already works.

## Notes
- No E2E added. Composer autocomplete doesn't touch the real-time loop, so the mandatory-E2E rule from `AGENTS.md` doesn't apply. Pure-logic coverage is in the unit suite.
- `emoji-index.ts` deep-imports `emoji-picker-react/dist/data/emojis-en.json`. The file has a comment flagging this as fragile across major version bumps; swap to `node-emoji` or `@emoji-mart/data` if it breaks.

Closes #42.
Closes #43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)