### PR TITLE
feat(#79): last-read divider (all rooms) + DM read receipts

### DIFF
--- a/apps/control-plane/src/routes/channel-routes.ts
+++ b/apps/control-plane/src/routes/channel-routes.ts
@@ -23,8 +23,11 @@ import {
 } from "../services/chat/channel-service.js";
 import {
   listChannelReadStates,
+  listChannelReadStatesForChannel,
   upsertChannelReadState
 } from "../services/chat/read-state-service.js";
+import { publishHubEvent } from "../services/chat-realtime.js";
+import { withDb } from "../db/client.js";
 import {
   getChannelSettings,
   updateChannelSettings
@@ -200,6 +203,13 @@ export async function registerChannelRoutes(app: FastifyInstance): Promise<void>
     };
   });
 
+  app.get("/v1/channels/:channelId/read-states", initializedAuthHandlers, async (request) => {
+    const params = z.object({ channelId: z.string().min(1) }).parse(request.params);
+    return {
+      items: await listChannelReadStatesForChannel(params.channelId)
+    };
+  });
+
   app.put("/v1/channels/:channelId/read-state", initializedAuthHandlers, async (request) => {
     const params = z.object({ channelId: z.string().min(1) }).parse(request.params);
     const payload = z
@@ -210,11 +220,34 @@ export async function registerChannelRoutes(app: FastifyInstance): Promise<void>
       })
       .parse(request.body ?? {});
 
-    return upsertChannelReadState({
+    const result = await upsertChannelReadState({
       productUserId: request.auth!.productUserId,
       channelId: params.channelId,
       ...payload
     });
+
+    // Broadcast via the channel's hub. The realtime stream is hub-scoped
+    // today, so this payload is visible to all hub subscribers — the
+    // frontend filters by channel + viewer participation. Per-user
+    // fan-out is the proper fix and is on the post-Sprint-1 follow-up
+    // list; until then we accept the same wire-leak shape that
+    // `channel.created` already has for DMs.
+    const hubRow = await withDb(async (db) =>
+      db.query<{ hub_id: string }>(
+        "select s.hub_id from channels c join servers s on s.id = c.server_id where c.id = $1",
+        [params.channelId]
+      )
+    );
+    const hubId = hubRow.rows[0]?.hub_id;
+    if (hubId) {
+      publishHubEvent(hubId, "channel.read", {
+        channelId: params.channelId,
+        productUserId: request.auth!.productUserId,
+        lastReadAt: result.lastReadAt
+      });
+    }
+
+    return result;
   });
 
   app.patch("/v1/channels/:channelId/controls", initializedAuthHandlers, async (request, reply) => {

--- a/apps/control-plane/src/services/chat-realtime.ts
+++ b/apps/control-plane/src/services/chat-realtime.ts
@@ -15,7 +15,8 @@ type ChatEvent =
   | "category.created"
   | "category.updated"
   | "category.deleted"
-  | "dm.left";
+  | "dm.left"
+  | "channel.read";
 type ChatListener = (event: ChatEvent, payload: any) => void;
 
 const channelListeners = new Map<string, Set<ChatListener>>();

--- a/apps/control-plane/src/services/chat/read-state-service.ts
+++ b/apps/control-plane/src/services/chat/read-state-service.ts
@@ -57,6 +57,45 @@ export async function listChannelReadStates(input: {
   });
 }
 
+/**
+ * List read states for every participant of a channel. DM-only by design —
+ * for non-DM channels we return an empty list, since exposing every server
+ * member's last_read_at would be a privacy leak with no UX upside (the
+ * divider for shared channels is driven solely by the requester's own row).
+ */
+export async function listChannelReadStatesForChannel(channelId: string): Promise<ChannelReadState[]> {
+  return withDb(async (db) => {
+    const channel = await db.query<{ type: string }>(
+      "select type from channels where id = $1",
+      [channelId]
+    );
+    if (channel.rows[0]?.type !== "dm") return [];
+
+    const rows = await db.query<{
+      channel_id: string;
+      product_user_id: string;
+      last_read_at: string;
+      is_muted: boolean;
+      notification_preference: "all" | "mentions" | "none";
+      updated_at: string;
+    }>(
+      `select channel_id, product_user_id, last_read_at, is_muted, notification_preference, updated_at
+         from channel_read_states
+        where channel_id = $1`,
+      [channelId]
+    );
+
+    return rows.rows.map((row) => ({
+      channelId: row.channel_id,
+      userId: row.product_user_id,
+      lastReadAt: row.last_read_at,
+      isMuted: row.is_muted,
+      notificationPreference: row.notification_preference,
+      updatedAt: row.updated_at
+    }));
+  });
+}
+
 export async function getChannelReadState(channelId: string, productUserId: string): Promise<ChannelReadState | null> {
   return withDb(async (db) => {
     const rows = await db.query<{

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1275,6 +1275,40 @@ textarea:focus-visible,
   font-size: 0.78rem;
 }
 
+/* #79 — "New messages" divider */
+.first-unread-divider {
+  position: relative;
+  text-align: center;
+  margin: 0.4rem 0;
+}
+
+.first-unread-divider::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 50%;
+  border-top: 1px solid #d04545;
+}
+
+.first-unread-divider span {
+  position: relative;
+  padding: 0 0.5rem;
+  background: var(--surface);
+  color: #d04545;
+  font-size: 0.74rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+/* #79 — DM "Seen" indicator */
+.seen-indicator {
+  margin: 0.1rem 0 0.3rem 2.6rem;
+  color: var(--text-muted);
+  font-size: 0.72rem;
+}
+
 .message-meta-error {
   color: #8f1e1e;
 }

--- a/apps/web/components/chat-window.tsx
+++ b/apps/web/components/chat-window.tsx
@@ -468,6 +468,9 @@ export function ChatWindow({
         [allowedActions]
     );
 
+    const activeChannelPeerReadStates = activeChannelData
+        ? state.peerReadStateByChannel[activeChannelData.id]
+        : undefined;
     const renderedMessages = useMemo(() => {
         const grouped: Array<{
             message: MessageItem;
@@ -488,9 +491,8 @@ export function ChatWindow({
         // for hypothetical group DMs we just use the maximum lastReadAt
         // across peers as the "seen by anyone" cutoff.
         let lastSeenOwnId: string | null = null;
-        if (activeChannelData?.type === "dm") {
-            const peerStates = state.peerReadStateByChannel[activeChannelData.id] ?? {};
-            const peerCutoffs = Object.values(peerStates);
+        if (activeChannelData?.type === "dm" && activeChannelPeerReadStates) {
+            const peerCutoffs = Object.values(activeChannelPeerReadStates);
             if (peerCutoffs.length > 0) {
                 const maxLastReadAt = peerCutoffs.reduce((a, b) => (a > b ? a : b));
                 lastSeenOwnId = latestSeenOwnMessageId(rootMessages, maxLastReadAt, viewer?.productUserId ?? null);
@@ -523,7 +525,7 @@ export function ChatWindow({
         }
 
         return grouped;
-    }, [messages, state.pendingActionIds, state.activeChannelLastReadAt, state.peerReadStateByChannel, activeChannelData, viewer?.productUserId]);
+    }, [messages, state.pendingActionIds, state.activeChannelLastReadAt, activeChannelPeerReadStates, activeChannelData, viewer?.productUserId]);
 
     useEffect(() => {
         setIsEditingTopic(false);

--- a/apps/web/components/chat-window.tsx
+++ b/apps/web/components/chat-window.tsx
@@ -23,6 +23,7 @@ import { useIntersectionObserver } from "../hooks/use-intersection-observer";
 import { useComposerAutocomplete } from "../hooks/use-composer-autocomplete";
 import { AutocompletePopover } from "./composer/autocomplete-popover";
 import { shortcodeToGlyph } from "../lib/composer-autocomplete/emoji-index";
+import { firstUnreadMessageId, latestSeenOwnMessageId } from "../lib/read-state";
 
 
 
@@ -472,10 +473,29 @@ export function ChatWindow({
             message: MessageItem;
             showHeader: boolean;
             showDateDivider: boolean;
+            showFirstUnreadDivider: boolean;
+            showSeenIndicator: boolean;
         }> = [];
 
         // Only show root messages in the main window
         const rootMessages = messages.filter(m => !m.parentId && !state.pendingActionIds.has(m.id));
+
+        const firstUnreadId = firstUnreadMessageId(rootMessages, state.activeChannelLastReadAt, viewer?.productUserId ?? null);
+
+        // #79 — DM read receipts: pick the most recent message authored by
+        // the viewer that any peer has read. We render the "Seen" indicator
+        // under that one message. With a 2-person DM this is unambiguous;
+        // for hypothetical group DMs we just use the maximum lastReadAt
+        // across peers as the "seen by anyone" cutoff.
+        let lastSeenOwnId: string | null = null;
+        if (activeChannelData?.type === "dm") {
+            const peerStates = state.peerReadStateByChannel[activeChannelData.id] ?? {};
+            const peerCutoffs = Object.values(peerStates);
+            if (peerCutoffs.length > 0) {
+                const maxLastReadAt = peerCutoffs.reduce((a, b) => (a > b ? a : b));
+                lastSeenOwnId = latestSeenOwnMessageId(rootMessages, maxLastReadAt, viewer?.productUserId ?? null);
+            }
+        }
 
         for (let index = 0; index < rootMessages.length; index += 1) {
             const message = rootMessages[index]!
@@ -496,12 +516,14 @@ export function ChatWindow({
             grouped.push({
                 message,
                 showHeader,
-                showDateDivider
+                showDateDivider,
+                showFirstUnreadDivider: message.id === firstUnreadId,
+                showSeenIndicator: message.id === lastSeenOwnId
             });
         }
 
         return grouped;
-    }, [messages, state.pendingActionIds]);
+    }, [messages, state.pendingActionIds, state.activeChannelLastReadAt, state.peerReadStateByChannel, activeChannelData, viewer?.productUserId]);
 
     useEffect(() => {
         setIsEditingTopic(false);
@@ -1088,11 +1110,16 @@ export function ChatWindow({
 
 
                     <ol className="messages" ref={messagesRef} onScroll={handleMessageListScroll}>
-                        {[...renderedMessages].reverse().map(({ message, showHeader, showDateDivider }, index) => {
+                        {[...renderedMessages].reverse().map(({ message, showHeader, showDateDivider, showFirstUnreadDivider, showSeenIndicator }, index) => {
                             const mediaUrls = extractMediaUrls(message.content);
 
                             return (
                                 <li key={message.id} id={`message-${message.id}`} className={state.highlightedMessageId === message.id ? "highlighted-message" : ""}>
+                            {showFirstUnreadDivider ? (
+                                <div className="first-unread-divider" role="separator" aria-label="New messages below">
+                                    <span>New messages</span>
+                                </div>
+                            ) : null}
                             {showDateDivider ? (
                                 <div className="date-divider">
                                     <span>{new Date(message.createdAt).toLocaleDateString()}</span>
@@ -1444,6 +1471,9 @@ export function ChatWindow({
                                     </small>
                                 ) : null}
                             </article>
+                            {showSeenIndicator ? (
+                                <div className="seen-indicator" aria-label="Seen by recipient">Seen</div>
+                            ) : null}
                         </li>
                     );
                 })}

--- a/apps/web/context/chat-context.tsx
+++ b/apps/web/context/chat-context.tsx
@@ -103,6 +103,15 @@ export interface ChatState {
     switchingServer?: boolean;
     // UI states that might be useful globally
     lastReadByChannel: Record<string, string>;
+    // #79 — snapshot of `last_read_at` captured at the moment the active
+    // channel was opened. Used to anchor the "new messages" divider while
+    // the user is reading; not updated as new messages arrive in this
+    // session.
+    activeChannelLastReadAt: string | null;
+    // #79 — per-channel, per-user `last_read_at` for read-receipt rendering.
+    // Populated only for DMs (the backend returns empty for non-DM
+    // channels). Updated via the `channel.read` SSE event.
+    peerReadStateByChannel: Record<string, Record<string, string>>;
     mentionCountByChannel: Record<string, number>;
     unreadCountByChannel: Record<string, number>;
     muteStatusByChannel: Record<string, boolean>;
@@ -280,8 +289,11 @@ type ChatAction =
             highlightedMessageId?: string | null;
             error?: string | null;
             hubs?: Hub[];
-        } 
-      };
+            activeChannelLastReadAt?: string | null;
+        }
+      }
+    | { type: "LOAD_PEER_READ_STATES"; payload: { channelId: string; states: Array<{ userId: string; lastReadAt: string }> } }
+    | { type: "UPDATE_PEER_READ_STATE"; payload: { channelId: string; userId: string; lastReadAt: string } };
 
 
 export const initialState: ChatState = {
@@ -309,6 +321,8 @@ export const initialState: ChatState = {
     discordMappings: [],
     discordConnection: null,
     lastReadByChannel: {},
+    activeChannelLastReadAt: null,
+    peerReadStateByChannel: {},
     mentionCountByChannel: {},
     unreadCountByChannel: {},
     muteStatusByChannel: {},
@@ -729,8 +743,33 @@ export function chatReducer(state: ChatState, action: ChatAction): ChatState {
                 ...(action.payload.permissions !== undefined && { allowedActions: action.payload.permissions }),
                 ...(action.payload.highlightedMessageId !== undefined && { highlightedMessageId: action.payload.highlightedMessageId }),
                 ...(action.payload.error !== undefined && { error: action.payload.error }),
-                ...(action.payload.hubs !== undefined && { hubs: action.payload.hubs })
+                ...(action.payload.hubs !== undefined && { hubs: action.payload.hubs }),
+                ...(action.payload.activeChannelLastReadAt !== undefined && { activeChannelLastReadAt: action.payload.activeChannelLastReadAt })
             };
+        case "LOAD_PEER_READ_STATES": {
+            const next: Record<string, string> = {};
+            for (const s of action.payload.states) next[s.userId] = s.lastReadAt;
+            return {
+                ...state,
+                peerReadStateByChannel: {
+                    ...state.peerReadStateByChannel,
+                    [action.payload.channelId]: next
+                }
+            };
+        }
+        case "UPDATE_PEER_READ_STATE": {
+            const existing = state.peerReadStateByChannel[action.payload.channelId] ?? {};
+            return {
+                ...state,
+                peerReadStateByChannel: {
+                    ...state.peerReadStateByChannel,
+                    [action.payload.channelId]: {
+                        ...existing,
+                        [action.payload.userId]: action.payload.lastReadAt
+                    }
+                }
+            };
+        }
         default:
             return state;
     }

--- a/apps/web/hooks/use-chat-initialization.ts
+++ b/apps/web/hooks/use-chat-initialization.ts
@@ -17,6 +17,7 @@ import {
   updateUserTheme,
   controlPlaneBaseUrl,
   fetchChannelInit,
+  listChannelPeerReadStates,
   type ChatMessage
 } from "../lib/control-plane";
 
@@ -233,10 +234,31 @@ export function useChatInitialization({
             members: initData.members,
             permissions: initData.permissions,
             highlightedMessageId: preferredMessageId ?? urlMessageId ?? null,
-            error: null
+            error: null,
+            // #79 — snapshot the read pointer BEFORE we call markChannelAsRead
+            // below; the divider needs to anchor on where the user was when
+            // they last visited, not on "now".
+            activeChannelLastReadAt: initData.readState?.lastReadAt ?? null
           }
         });
         dispatch({ type: "SET_SWITCHING_SERVER", payload: false });
+
+        // #79 — DM read receipts: fetch peer read states for DM channels
+        // only. The endpoint returns [] for non-DM channels.
+        if (initData.channel.type === "dm") {
+          const viewerId = state.viewer?.productUserId;
+          void listChannelPeerReadStates(nextChannelId).then((items) => {
+            dispatch({
+              type: "LOAD_PEER_READ_STATES",
+              payload: {
+                channelId: nextChannelId!,
+                states: items
+                  .filter((s) => s.userId !== viewerId)
+                  .map((s) => ({ userId: s.userId, lastReadAt: s.lastReadAt }))
+              }
+            });
+          }).catch((err) => console.warn("[#79] peer read states fetch failed", err));
+        }
 
         const finalMessageId = preferredMessageId ?? urlMessageId ?? null;
         setUrlSelection(nextServerId, nextChannelId, finalMessageId);

--- a/apps/web/hooks/use-chat-realtime.ts
+++ b/apps/web/hooks/use-chat-realtime.ts
@@ -285,6 +285,19 @@ export function useChatRealtime() {
       }
     });
 
+    // #79 — DM read receipts. The `channel.read` event fires whenever any
+    // user in this hub bumps their read pointer; we only act on it when
+    // (a) it's about a channel the viewer is currently subscribed to and
+    // (b) it's another user, not the viewer themselves.
+    source.addEventListener("channel.read", (event: any) => {
+      const data = JSON.parse(event.data) as { channelId: string; productUserId: string; lastReadAt: string };
+      if (data.productUserId === viewer?.productUserId) return;
+      dispatch({
+        type: "UPDATE_PEER_READ_STATE",
+        payload: { channelId: data.channelId, userId: data.productUserId, lastReadAt: data.lastReadAt }
+      });
+    });
+
     source.addEventListener("typing.start", (event: any) => {
       const data = JSON.parse(event.data);
       dispatch({ type: "SET_TYPING_USER", payload: { ...data, isTyping: true } });

--- a/apps/web/lib/control-plane.ts
+++ b/apps/web/lib/control-plane.ts
@@ -771,6 +771,13 @@ export async function listChannelReadStates(serverId: string): Promise<ChannelRe
   return json.items;
 }
 
+export async function listChannelPeerReadStates(channelId: string): Promise<ChannelReadState[]> {
+  const json = await apiFetch<{ items: ChannelReadState[] }>(
+    `/v1/channels/${encodeURIComponent(channelId)}/read-states`
+  );
+  return json.items;
+}
+
 export async function upsertChannelReadState(
   channelId: string,
   payload?: {

--- a/apps/web/lib/read-state.ts
+++ b/apps/web/lib/read-state.ts
@@ -1,0 +1,54 @@
+interface MessageLike {
+  id: string;
+  authorUserId: string;
+  createdAt: string;
+}
+
+/**
+ * Returns the id of the first unread message — the one to render the
+ * "new messages" divider above — or `null` if there is no divider to
+ * show. Rules:
+ *   - `lastReadAt` is the snapshot captured when the user opened the
+ *     channel; messages strictly newer than it are unread.
+ *   - Messages authored by the viewer themselves are skipped — we don't
+ *     mark "new messages" above your own outgoing message.
+ *   - Returns null if `lastReadAt` is missing (first-time open) or no
+ *     message qualifies.
+ */
+export function firstUnreadMessageId(
+  messages: ReadonlyArray<MessageLike>,
+  lastReadAt: string | null,
+  viewerUserId: string | null | undefined
+): string | null {
+  if (!lastReadAt) return null;
+  const cutoff = new Date(lastReadAt).getTime();
+  if (Number.isNaN(cutoff)) return null;
+  for (const m of messages) {
+    if (m.authorUserId === viewerUserId) continue;
+    if (new Date(m.createdAt).getTime() > cutoff) return m.id;
+  }
+  return null;
+}
+
+/**
+ * Returns the id of the latest message authored by the viewer that has
+ * been read by the given peer (peer's `lastReadAt` >= message.createdAt).
+ * Used to render the DM "Seen" indicator under the most recent outgoing
+ * message the peer has caught up with. `null` means none of the
+ * viewer's messages have been seen yet.
+ */
+export function latestSeenOwnMessageId(
+  messages: ReadonlyArray<MessageLike>,
+  peerLastReadAt: string | null | undefined,
+  viewerUserId: string | null | undefined
+): string | null {
+  if (!peerLastReadAt || !viewerUserId) return null;
+  const cutoff = new Date(peerLastReadAt).getTime();
+  if (Number.isNaN(cutoff)) return null;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i]!;
+    if (m.authorUserId !== viewerUserId) continue;
+    if (new Date(m.createdAt).getTime() <= cutoff) return m.id;
+  }
+  return null;
+}

--- a/apps/web/test/chat-context-reducer.test.ts
+++ b/apps/web/test/chat-context-reducer.test.ts
@@ -188,3 +188,64 @@ test("LOAD_CHANNEL_DRAFTS replaces the drafts map", () => {
     "chn_b": "from storage B"
   });
 });
+
+// #79 — DM read receipts: LOAD_PEER_READ_STATES replaces the per-channel
+// peer map and is scoped to a single channel without disturbing others.
+test("LOAD_PEER_READ_STATES replaces the per-channel peer map", () => {
+  const state = {
+    ...initialState,
+    peerReadStateByChannel: {
+      "chn_dm_a": { "usr_old": "2026-05-08T00:00:00Z" },
+      "chn_dm_b": { "usr_other": "2026-05-08T00:00:00Z" }
+    }
+  };
+
+  const next = chatReducer(state, {
+    type: "LOAD_PEER_READ_STATES",
+    payload: {
+      channelId: "chn_dm_a",
+      states: [{ userId: "usr_peer", lastReadAt: "2026-05-09T12:00:00Z" }]
+    }
+  });
+
+  assert.deepEqual(next.peerReadStateByChannel["chn_dm_a"], {
+    "usr_peer": "2026-05-09T12:00:00Z"
+  });
+  // chn_dm_b must be untouched.
+  assert.deepEqual(next.peerReadStateByChannel["chn_dm_b"], {
+    "usr_other": "2026-05-08T00:00:00Z"
+  });
+});
+
+// #79 — UPDATE_PEER_READ_STATE merges into the existing per-channel map
+// and works even when the channel has no prior peer entries (SSE event
+// arrives before the initial fetch completes).
+test("UPDATE_PEER_READ_STATE merges into existing channel map", () => {
+  const state = {
+    ...initialState,
+    peerReadStateByChannel: {
+      "chn_dm_a": { "usr_a": "2026-05-09T12:00:00Z" }
+    }
+  };
+
+  const next = chatReducer(state, {
+    type: "UPDATE_PEER_READ_STATE",
+    payload: { channelId: "chn_dm_a", userId: "usr_b", lastReadAt: "2026-05-09T13:00:00Z" }
+  });
+
+  assert.deepEqual(next.peerReadStateByChannel["chn_dm_a"], {
+    "usr_a": "2026-05-09T12:00:00Z",
+    "usr_b": "2026-05-09T13:00:00Z"
+  });
+});
+
+test("UPDATE_PEER_READ_STATE creates a fresh channel map when none exists", () => {
+  const next = chatReducer(initialState, {
+    type: "UPDATE_PEER_READ_STATE",
+    payload: { channelId: "chn_dm_new", userId: "usr_b", lastReadAt: "2026-05-09T13:00:00Z" }
+  });
+
+  assert.deepEqual(next.peerReadStateByChannel["chn_dm_new"], {
+    "usr_b": "2026-05-09T13:00:00Z"
+  });
+});

--- a/apps/web/test/read-state.test.ts
+++ b/apps/web/test/read-state.test.ts
@@ -1,0 +1,78 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { firstUnreadMessageId, latestSeenOwnMessageId } from "../lib/read-state";
+
+const VIEWER = "usr_viewer";
+const PEER = "usr_peer";
+
+function msg(id: string, author: string, ts: string) {
+  return { id, authorUserId: author, createdAt: ts };
+}
+
+// --- firstUnreadMessageId ---
+
+test("firstUnreadMessageId: returns null when lastReadAt is missing (first-time open)", () => {
+  const messages = [msg("m1", PEER, "2026-05-09T12:00:00Z")];
+  assert.equal(firstUnreadMessageId(messages, null, VIEWER), null);
+});
+
+test("firstUnreadMessageId: returns null when no message is newer than lastReadAt", () => {
+  const messages = [msg("m1", PEER, "2026-05-09T12:00:00Z")];
+  assert.equal(firstUnreadMessageId(messages, "2026-05-09T13:00:00Z", VIEWER), null);
+});
+
+test("firstUnreadMessageId: returns the first message strictly newer than lastReadAt", () => {
+  const messages = [
+    msg("m1", PEER, "2026-05-09T12:00:00Z"),
+    msg("m2", PEER, "2026-05-09T13:00:00Z"),
+    msg("m3", PEER, "2026-05-09T14:00:00Z")
+  ];
+  assert.equal(firstUnreadMessageId(messages, "2026-05-09T12:30:00Z", VIEWER), "m2");
+});
+
+test("firstUnreadMessageId: skips messages authored by the viewer", () => {
+  const messages = [
+    msg("m1", VIEWER, "2026-05-09T13:00:00Z"), // viewer's own message — skipped
+    msg("m2", PEER, "2026-05-09T13:30:00Z") // first unread from peer
+  ];
+  assert.equal(firstUnreadMessageId(messages, "2026-05-09T12:30:00Z", VIEWER), "m2");
+});
+
+test("firstUnreadMessageId: returns null when only the viewer's own messages are newer", () => {
+  const messages = [msg("m1", VIEWER, "2026-05-09T13:00:00Z")];
+  assert.equal(firstUnreadMessageId(messages, "2026-05-09T12:00:00Z", VIEWER), null);
+});
+
+// --- latestSeenOwnMessageId ---
+
+test("latestSeenOwnMessageId: returns null when peer has no read state", () => {
+  const messages = [msg("m1", VIEWER, "2026-05-09T12:00:00Z")];
+  assert.equal(latestSeenOwnMessageId(messages, null, VIEWER), null);
+  assert.equal(latestSeenOwnMessageId(messages, undefined, VIEWER), null);
+});
+
+test("latestSeenOwnMessageId: returns the most recent own message older-or-equal to peer's lastReadAt", () => {
+  const messages = [
+    msg("m1", VIEWER, "2026-05-09T12:00:00Z"),
+    msg("m2", PEER, "2026-05-09T12:30:00Z"),
+    msg("m3", VIEWER, "2026-05-09T13:00:00Z"),
+    msg("m4", VIEWER, "2026-05-09T14:00:00Z") // peer hasn't read this one
+  ];
+  assert.equal(latestSeenOwnMessageId(messages, "2026-05-09T13:30:00Z", VIEWER), "m3");
+});
+
+test("latestSeenOwnMessageId: returns null when none of the viewer's messages have been read yet", () => {
+  const messages = [
+    msg("m1", PEER, "2026-05-09T12:00:00Z"),
+    msg("m2", VIEWER, "2026-05-09T14:00:00Z")
+  ];
+  assert.equal(latestSeenOwnMessageId(messages, "2026-05-09T13:00:00Z", VIEWER), null);
+});
+
+test("latestSeenOwnMessageId: ignores peer-authored messages even if older than the cutoff", () => {
+  const messages = [
+    msg("m1", PEER, "2026-05-09T12:00:00Z"),
+    msg("m2", PEER, "2026-05-09T13:00:00Z")
+  ];
+  assert.equal(latestSeenOwnMessageId(messages, "2026-05-09T14:00:00Z", VIEWER), null);
+});


### PR DESCRIPTION
## Summary
Both halves of #79 in one PR — they share the underlying `channel_read_states` plumbing and conceptually live together.

**Last-read divider (all channel types)**
- Snapshot `initData.readState.lastReadAt` at channel-open into `activeChannelLastReadAt` *before* the existing `markChannelAsRead` bumps the backend pointer to "now". Divider anchors on the snapshot for the visit.
- `firstUnreadMessageId()` helper in [`lib/read-state.ts`](apps/web/lib/read-state.ts) drives a `showFirstUnreadDivider` flag on each rendered message. Skips viewer-authored messages — no divider above your own outgoing message.
- Red "NEW MESSAGES" separator inline in the message list.

**DM read receipts**
- New backend service `listChannelReadStatesForChannel(channelId)` and route `GET /v1/channels/:id/read-states`. DM-only by design; returns `[]` for non-DM (privacy + wire weight).
- `PUT /v1/channels/:id/read-state` now publishes a `channel.read` SSE event via `publishHubEvent` after the upsert. Hub-scoped per agreed scope (option C1 from the design); the per-user fan-out is on the existing follow-up list and would close a pre-existing leak that already affects `channel.created` for DMs.
- Frontend subscribes to `channel.read`, filters out self, and maintains `peerReadStateByChannel` state.
- `latestSeenOwnMessageId()` helper picks the most recent own message any peer has caught up with. "Seen" indicator renders under it (DMs only).

## Test plan
- [x] Web unit suite: 43/43 (9 new for `firstUnreadMessageId` / `latestSeenOwnMessageId`; 3 new for `LOAD_PEER_READ_STATES` / `UPDATE_PEER_READ_STATE` reducer behavior).
- [x] Control-plane suite: 141/141.
- [x] Typecheck clean: `@skerry/web` + `@skerry/control-plane` (after `pnpm --filter @skerry/shared build`).
- [ ] Manual: open a channel with unread messages → red "NEW MESSAGES" divider above the first one you haven't seen. Switch away and back later → divider repositions to the next first-unread.
- [ ] Manual: in a DM, send a message. Other user reads → "Seen" indicator appears under your latest message in real time.
- [ ] Manual: in a DM, send a message while the other user is offline → no "Seen" until they open the channel.
- [ ] Manual: open a channel for the first time (no prior read state) → no divider shown.
- [ ] Manual: confirm divider does NOT appear above your own outgoing message even if `lastReadAt` predates it.
- [ ] Manual: in a non-DM server room, no "Seen" indicator appears anywhere.

## Decisions baked in (per design discussion)
- **A1** — Snapshot at channel-open; current immediate-mark-read behavior preserved.
- **B1** — One "Seen" indicator under the latest own message; not per-message ticks.
- **C1** — Hub-scoped publish for `channel.read`; per-user fan-out deferred.
- **D1** — Single PR for both halves of #79.

## Deferred (separate tickets / follow-ups)
- Per-user SSE fan-out (pre-existing follow-up; would close a latent leak that already affects `channel.created`).
- Mark-read deferral until scroll-to-bottom / unfocus (option A2). Current behavior is fine for now; revisit if it produces UX complaints.

Closes #79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)