### PR TITLE
feat(#78): pinned messages drawer with modal overlay

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1309,6 +1309,142 @@ textarea:focus-visible,
   font-size: 0.72rem;
 }
 
+/* #78 — Pinned messages drawer (modal overlay) */
+
+.pinned-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(4px);
+  z-index: 1999;
+}
+
+.pinned-drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 360px;
+  max-width: 100vw;
+  background: #1e1f22;
+  border-left: 1px solid rgba(255, 255, 255, 0.07);
+  display: flex;
+  flex-direction: column;
+  z-index: 2000;
+  box-shadow: -8px 0 32px rgba(0, 0, 0, 0.5);
+  animation: pinned-slide-in 0.2s ease;
+}
+
+@keyframes pinned-slide-in {
+  from { transform: translateX(100%); }
+  to   { transform: translateX(0); }
+}
+
+.pinned-drawer__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  background: #2b2d31;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+  flex-shrink: 0;
+}
+
+.pinned-drawer__header h2 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #f2f3f5;
+}
+
+.pinned-drawer__close {
+  background: none;
+  border: none;
+  color: #b5bac1;
+  font-size: 1rem;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 4px;
+}
+
+.pinned-drawer__close:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: #f2f3f5;
+}
+
+.pinned-drawer__status {
+  margin: 0;
+  padding: 16px 20px;
+  color: #b5bac1;
+  font-size: 0.85rem;
+  text-align: center;
+}
+
+.pinned-drawer__status--error {
+  color: #d04545;
+}
+
+.pinned-drawer__list {
+  list-style: none;
+  margin: 0;
+  padding: 12px 12px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.pinned-drawer__item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: #2b2d31;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  border-radius: 6px;
+  padding: 10px 12px;
+  cursor: pointer;
+  color: inherit;
+  font: inherit;
+  transition: background 0.12s, border-color 0.12s;
+}
+
+.pinned-drawer__item:hover {
+  background: #35373c;
+  border-color: rgba(255, 255, 255, 0.1);
+}
+
+.pinned-drawer__item-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+  margin-bottom: 4px;
+}
+
+.pinned-drawer__item-header strong {
+  font-size: 0.88rem;
+  color: #f2f3f5;
+}
+
+.pinned-drawer__item-header time {
+  color: #72767d;
+  font-size: 0.72rem;
+  flex-shrink: 0;
+}
+
+.pinned-drawer__item-content {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #b5bac1;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
 .message-meta-error {
   color: #8f1e1e;
 }

--- a/apps/web/components/chat-client.tsx
+++ b/apps/web/components/chat-client.tsx
@@ -6,6 +6,7 @@ import { useChat, ChatHandlersProvider, MessageItem, ModalType } from "../contex
 import { AuthOverlay } from "./auth-overlay";
 import { Sidebar } from "./sidebar";
 import { ChatWindow } from "./chat-window";
+import { PinnedMessagesDrawer } from "./pinned-messages-drawer";
 import { ErrorBoundary } from "./error-boundary";
 import { ClientTopbar } from "./layout/ClientTopbar";
 import { ClientModals } from "./modals/ClientModals";
@@ -969,6 +970,20 @@ export function ChatClient() {
             )}
           </div >
         </section >
+      )}
+
+      {state.isPinnedDrawerOpen && activeChannelData && (
+        <ErrorBoundary>
+          <PinnedMessagesDrawer
+            channelId={activeChannelData.id}
+            channelName={getChannelName(activeChannelData, viewer?.productUserId, members)}
+            onClose={() => dispatch({ type: "SET_PINNED_DRAWER_OPEN", payload: false })}
+            onJumpToMessage={(messageId) => {
+              dispatch({ type: "SET_PINNED_DRAWER_OPEN", payload: false });
+              void refreshChatState(activeChannelData.serverId, activeChannelData.id, messageId, true);
+            }}
+          />
+        </ErrorBoundary>
       )}
 
       <ModalManager />

--- a/apps/web/components/chat-window.tsx
+++ b/apps/web/components/chat-window.tsx
@@ -1076,6 +1076,15 @@ export function ChatWindow({
 
                     <button
                         type="button"
+                        data-testid="toggle-pinned-drawer"
+                        className={`icon-button ${state.isPinnedDrawerOpen ? "active-toggle" : ""}`}
+                        title={state.isPinnedDrawerOpen ? "Hide Pinned Messages" : "Show Pinned Messages"}
+                        onClick={() => dispatch({ type: "SET_PINNED_DRAWER_OPEN", payload: !state.isPinnedDrawerOpen })}
+                    >
+                        📌
+                    </button>
+                    <button
+                        type="button"
                         data-testid="toggle-member-list"
                         className={`icon-button ${isDetailsOpen ? "active-toggle" : ""}`}
                         title={isDetailsOpen ? "Hide Member List" : "Show Member List"}
@@ -1171,7 +1180,15 @@ export function ChatWindow({
                                             </span>
                                         )}
                                     </header>
-                                ) : null}
+                                ) : (
+                                    message.isPinned && (
+                                        <div style={{ display: "flex", justifyContent: "flex-end" }}>
+                                            <span className="pinned-indicator" title="Pinned Message" style={{ fontSize: "0.8rem", opacity: 0.6 }}>
+                                                📌
+                                            </span>
+                                        </div>
+                                    )
+                                )}
                                 <div className="message-content-wrapper" style={{ position: "relative" }}>
                                     {/* Hover action bar */}
                                     <div className="message-hover-actions">

--- a/apps/web/components/pinned-messages-drawer.tsx
+++ b/apps/web/components/pinned-messages-drawer.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type { ChatMessage } from "@skerry/shared";
+import { listPins } from "../lib/control-plane";
+import { applyPinUpdate } from "../lib/pins";
+import { useChat } from "../context/chat-context";
+import { formatMessageTime } from "../lib/control-plane";
+
+interface Props {
+  channelId: string;
+  channelName: string;
+  onClose: () => void;
+  onJumpToMessage: (messageId: string) => void;
+}
+
+export function PinnedMessagesDrawer({ channelId, channelName, onClose, onJumpToMessage }: Props) {
+  const { state } = useChat();
+  const [pins, setPins] = useState<ChatMessage[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const lastPinStateRef = useRef<Map<string, boolean>>(new Map());
+
+  useEffect(() => {
+    let cancelled = false;
+    setIsLoading(true);
+    setError(null);
+    listPins(channelId)
+      .then((items) => {
+        if (cancelled) return;
+        setPins(items);
+        const initial = new Map<string, boolean>();
+        for (const m of items) initial.set(m.id, true);
+        lastPinStateRef.current = initial;
+        setIsLoading(false);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : "Failed to load pinned messages.");
+        setIsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [channelId]);
+
+  // Keep the list in sync with optimistic local pin/unpin events. We watch
+  // `state.messages` for entries whose `isPinned` flipped since the last
+  // tick and feed them through the same merge that handles the SSE path.
+  useEffect(() => {
+    let next = pins;
+    for (const m of state.messages) {
+      if (m.channelId !== channelId) continue;
+      const prevPinned = lastPinStateRef.current.get(m.id);
+      const currentPinned = !!m.isPinned;
+      if (prevPinned !== currentPinned) {
+        next = applyPinUpdate(next, m);
+        lastPinStateRef.current.set(m.id, currentPinned);
+      }
+    }
+    if (next !== pins) setPins(next);
+  }, [state.messages, channelId, pins]);
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="pinned-backdrop"
+        onClick={onClose}
+        data-testid="pinned-drawer-backdrop"
+      />
+
+      {/* Drawer */}
+      <aside
+        className="pinned-drawer"
+        aria-label={`Pinned messages in ${channelName}`}
+        data-testid="pinned-messages-drawer"
+      >
+        <header className="pinned-drawer__header">
+          <h2>📌 Pinned in #{channelName}</h2>
+          <button
+            type="button"
+            className="pinned-drawer__close"
+            onClick={onClose}
+            aria-label="Close pinned messages"
+          >
+            ✕
+          </button>
+        </header>
+
+        {isLoading && <p className="pinned-drawer__status">Loading…</p>}
+        {error && <p className="pinned-drawer__status pinned-drawer__status--error">{error}</p>}
+        {!isLoading && !error && pins.length === 0 && (
+          <p className="pinned-drawer__status">No messages pinned in this channel yet.</p>
+        )}
+
+        <ul className="pinned-drawer__list">
+          {pins.map((m) => (
+            <li key={m.id}>
+              <button
+                type="button"
+                className="pinned-drawer__item"
+                onClick={() => onJumpToMessage(m.id)}
+                data-testid="pinned-message-item"
+              >
+                <div className="pinned-drawer__item-header">
+                  <strong>{m.externalAuthorName ?? m.authorDisplayName}</strong>
+                  <time dateTime={m.createdAt}>{formatMessageTime(m.createdAt)}</time>
+                </div>
+                <p className="pinned-drawer__item-content">{m.content}</p>
+              </button>
+            </li>
+          ))}
+        </ul>
+      </aside>
+    </>
+  );
+}

--- a/apps/web/context/chat-context.tsx
+++ b/apps/web/context/chat-context.tsx
@@ -93,6 +93,7 @@ export interface ChatState {
     allowedActions: PrivilegedAction[];
     activeModal: ModalType;
     isDetailsOpen: boolean;
+    isPinnedDrawerOpen: boolean;
     isSidebarOpen: boolean;
     isAddMenuOpen: boolean;
     theme: "light" | "dark";
@@ -201,6 +202,7 @@ type ChatAction =
     | { type: "SET_ALLOWED_ACTIONS"; payload: PrivilegedAction[] }
     | { type: "SET_ACTIVE_MODAL"; payload: ModalType }
     | { type: "SET_DETAILS_OPEN"; payload: boolean }
+    | { type: "SET_PINNED_DRAWER_OPEN"; payload: boolean }
     | { type: "SET_SIDEBAR_OPEN"; payload: boolean }
     | { type: "SET_ADD_MENU_OPEN"; payload: boolean }
     | { type: "SET_THEME"; payload: "light" | "dark" }
@@ -314,6 +316,7 @@ export const initialState: ChatState = {
     allowedActions: [],
     activeModal: null,
     isDetailsOpen: true,
+    isPinnedDrawerOpen: false,
     isSidebarOpen: false,
     isAddMenuOpen: false,
     theme: "light",
@@ -429,6 +432,8 @@ export function chatReducer(state: ChatState, action: ChatAction): ChatState {
             return { ...state, activeModal: action.payload };
         case "SET_DETAILS_OPEN":
             return { ...state, isDetailsOpen: action.payload };
+        case "SET_PINNED_DRAWER_OPEN":
+            return { ...state, isPinnedDrawerOpen: action.payload };
         case "SET_SIDEBAR_OPEN":
             return { ...state, isSidebarOpen: action.payload };
         case "SET_ADD_MENU_OPEN":

--- a/apps/web/lib/control-plane.ts
+++ b/apps/web/lib/control-plane.ts
@@ -463,6 +463,13 @@ export async function unpinMessage(channelId: string, messageId: string): Promis
   });
 }
 
+export async function listPins(channelId: string): Promise<ChatMessage[]> {
+  const json = await apiFetch<{ items: ChatMessage[] }>(
+    `/v1/channels/${encodeURIComponent(channelId)}/pins`
+  );
+  return json.items;
+}
+
 export async function sendTypingStatus(channelId: string, isTyping: boolean): Promise<void> {
   await apiFetch(`/v1/channels/${encodeURIComponent(channelId)}/typing`, {
     method: "POST",

--- a/apps/web/lib/pins.ts
+++ b/apps/web/lib/pins.ts
@@ -1,0 +1,27 @@
+interface PinnedMessageLike {
+  id: string;
+  isPinned?: boolean;
+  createdAt: string;
+}
+
+/**
+ * Apply a single message update (pin / unpin / edit) to the in-memory pin
+ * list, keeping it sorted newest-first. Pure so the drawer stays in sync
+ * with optimistic local updates and incoming `message.updated` SSE events
+ * without a server round-trip.
+ *
+ * - If the update marks the message pinned and it's not already in the
+ *   list, insert it in createdAt-descending position.
+ * - If it marks the message unpinned (or omitted from `isPinned`), remove
+ *   any matching entry.
+ * - If it's already in the list and still pinned, replace the entry in
+ *   place (e.g. a content edit on a pinned message).
+ */
+export function applyPinUpdate<T extends PinnedMessageLike>(pins: ReadonlyArray<T>, update: T): T[] {
+  const without = pins.filter((p) => p.id !== update.id);
+  if (!update.isPinned) return without;
+  const updateTime = new Date(update.createdAt).getTime();
+  const insertIdx = without.findIndex((p) => new Date(p.createdAt).getTime() < updateTime);
+  if (insertIdx === -1) return [...without, update];
+  return [...without.slice(0, insertIdx), update, ...without.slice(insertIdx)];
+}

--- a/apps/web/test/pins.test.ts
+++ b/apps/web/test/pins.test.ts
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { applyPinUpdate } from "../lib/pins";
+
+function pin(id: string, ts: string, isPinned = true) {
+  return { id, isPinned, createdAt: ts };
+}
+
+test("applyPinUpdate: inserts a newly-pinned message in createdAt-desc order", () => {
+  const pins = [pin("m3", "2026-05-09T15:00:00Z"), pin("m1", "2026-05-09T13:00:00Z")];
+  const next = applyPinUpdate(pins, pin("m2", "2026-05-09T14:00:00Z"));
+  assert.deepEqual(next.map((p) => p.id), ["m3", "m2", "m1"]);
+});
+
+test("applyPinUpdate: prepends when the new message is the newest", () => {
+  const pins = [pin("m1", "2026-05-09T12:00:00Z")];
+  const next = applyPinUpdate(pins, pin("m2", "2026-05-09T14:00:00Z"));
+  assert.deepEqual(next.map((p) => p.id), ["m2", "m1"]);
+});
+
+test("applyPinUpdate: appends when the new message is the oldest", () => {
+  const pins = [pin("m1", "2026-05-09T14:00:00Z")];
+  const next = applyPinUpdate(pins, pin("m2", "2026-05-09T12:00:00Z"));
+  assert.deepEqual(next.map((p) => p.id), ["m1", "m2"]);
+});
+
+test("applyPinUpdate: removes the entry when isPinned flips false", () => {
+  const pins = [pin("m1", "2026-05-09T14:00:00Z"), pin("m2", "2026-05-09T12:00:00Z")];
+  const next = applyPinUpdate(pins, pin("m1", "2026-05-09T14:00:00Z", false));
+  assert.deepEqual(next.map((p) => p.id), ["m2"]);
+});
+
+test("applyPinUpdate: replaces in place when an already-pinned message is edited", () => {
+  const original = { id: "m1", isPinned: true, createdAt: "2026-05-09T14:00:00Z", content: "old" };
+  const edited = { id: "m1", isPinned: true, createdAt: "2026-05-09T14:00:00Z", content: "new" };
+  const next = applyPinUpdate([original], edited);
+  assert.equal(next.length, 1);
+  assert.equal((next[0] as any).content, "new");
+});
+
+test("applyPinUpdate: no-op when an unpinned message arrives that wasn't in the list", () => {
+  const pins = [pin("m1", "2026-05-09T14:00:00Z")];
+  const next = applyPinUpdate(pins, pin("m_new", "2026-05-09T13:00:00Z", false));
+  assert.deepEqual(next.map((p) => p.id), ["m1"]);
+});


### PR DESCRIPTION
## Summary

Adds a pinned messages drawer per channel — view all pinned messages, click to jump to source.

### What's included

- **PinnedMessagesDrawer** component — fetches pins from the control plane, stays in sync with optimistic local pin/unpin events via the message store
- **applyPinUpdate** — pure function for inserting/removing/replacing pins in createdAt-descending order, with unit tests (6 cases)
- **Modal overlay** — drawer renders as a fixed-position panel (360px, right-anchored) with blurred backdrop and slide-in animation, matching the Masquerade drawer pattern. No layout displacement.
- **Pin indicator fix** — the 📌 icon now shows on ALL pinned messages, including those without a username plaque (previously hidden inside the conditional header block)

### Files changed

| File | What |
|------|------|
| `apps/web/components/pinned-messages-drawer.tsx` | New — drawer component with backdrop overlay |
| `apps/web/lib/pins.ts` | New — `applyPinUpdate` merge function |
| `apps/web/test/pins.test.ts` | New — 6 unit tests for pin list merging |
| `apps/web/components/chat-client.tsx` | Render drawer outside chat-shell grid (no displacement) |
| `apps/web/components/chat-window.tsx` | Pin indicator shows on headerless messages too |
| `apps/web/app/globals.css` | Fixed overlay CSS replacing inline panel styles |
| `apps/web/context/chat-context.tsx` | `isPinnedDrawerOpen` state + `SET_PINNED_DRAWER_OPEN` action |
| `apps/web/lib/control-plane.ts` | `listPins` API client |

### Verification

- ✅ `pnpm typecheck` — clean
- ✅ `pnpm test` — 49/49 pass
- ✅ `pnpm lint` — no new warnings
- ✅ `pnpm build` — all pages generated

Closes #78