### PR TITLE
fix: emoji shortcodes, Discord bridge, light mode for overlays

### DIFF
--- a/apps/control-plane/src/services/discord-bot-client.ts
+++ b/apps/control-plane/src/services/discord-bot-client.ts
@@ -697,8 +697,9 @@ export async function relayMatrixMessageToDiscord(input: {
             // Mentions already replaced with <@id> above; this catches stray @
             // characters that Discord would otherwise interpret as failed mentions.
             content = content.replace(/@(?!everyone|here)/g, "@\u200B");
+        }
 
-            if (skerryEmoji) {
+        if (skerryEmoji) {
             content = `${skerryEmoji} ${content}`;
         }
 

--- a/apps/control-plane/src/services/discord-bot-client.ts
+++ b/apps/control-plane/src/services/discord-bot-client.ts
@@ -692,9 +692,13 @@ export async function relayMatrixMessageToDiscord(input: {
                     }
                 }
             }
-        }
 
-        if (skerryEmoji) {
+            // Escape unconverted @-signs to prevent Discord webhook rejection.
+            // Mentions already replaced with <@id> above; this catches stray @
+            // characters that Discord would otherwise interpret as failed mentions.
+            content = content.replace(/@(?!everyone|here)/g, "@\u200B");
+
+            if (skerryEmoji) {
             content = `${skerryEmoji} ${content}`;
         }
 

--- a/apps/web/components/edit-history-popover.tsx
+++ b/apps/web/components/edit-history-popover.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import type { MessageRevision } from "@skerry/shared";
 import { fetchRevisions } from "../lib/control-plane";
+import { useChat } from "../context/chat-context";
 
 interface Props {
   channelId: string;
@@ -12,6 +13,8 @@ interface Props {
 }
 
 export function EditHistoryPopover({ channelId, messageId, currentContent, onClose }: Props) {
+  const { state } = useChat();
+  const isDark = state.theme !== "light";
   const [revisions, setRevisions] = useState<MessageRevision[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -118,10 +121,10 @@ export function EditHistoryPopover({ channelId, messageId, currentContent, onClo
           width: 360px;
           max-width: 95vw;
           max-height: 80vh;
-          background: #1e1f22;
-          border: 1px solid rgba(255, 255, 255, 0.1);
+          background: ${isDark ? "#1e1f22" : "#ffffff"};
+          border: 1px solid ${isDark ? "rgba(255, 255, 255, 0.1)" : "rgba(0, 0, 0, 0.12)"};
           border-radius: 8px;
-          box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+          box-shadow: 0 8px 32px rgba(0, 0, 0, ${isDark ? "0.6" : "0.15"});
           display: flex;
           flex-direction: column;
           overflow: hidden;
@@ -132,28 +135,28 @@ export function EditHistoryPopover({ channelId, messageId, currentContent, onClo
           align-items: center;
           justify-content: space-between;
           padding: 12px 16px;
-          background: #2b2d31;
-          border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+          background: ${isDark ? "#2b2d31" : "#f2f3f5"};
+          border-bottom: 1px solid ${isDark ? "rgba(255, 255, 255, 0.07)" : "rgba(0, 0, 0, 0.08)"};
           flex-shrink: 0;
         }
 
         .eh-title {
           font-size: 0.9rem;
           font-weight: 700;
-          color: #f2f3f5;
+          color: ${isDark ? "#f2f3f5" : "#313338"};
         }
 
         .eh-close {
           background: none;
           border: none;
-          color: #b5bac1;
+          color: ${isDark ? "#b5bac1" : "#5c5e66"};
           font-size: 1rem;
           cursor: pointer;
           padding: 4px 8px;
           border-radius: 4px;
         }
         .eh-close:hover {
-          background: rgba(255, 255, 255, 0.08);
+          background: ${isDark ? "rgba(255, 255, 255, 0.08)" : "rgba(0, 0, 0, 0.06)"};
         }
 
         .eh-body {
@@ -163,7 +166,7 @@ export function EditHistoryPopover({ channelId, messageId, currentContent, onClo
         }
 
         .eh-status {
-          color: #b5bac1;
+          color: ${isDark ? "#b5bac1" : "#5c5e66"};
           font-size: 0.85rem;
           text-align: center;
           padding: 16px 0;
@@ -181,17 +184,17 @@ export function EditHistoryPopover({ channelId, messageId, currentContent, onClo
         }
 
         .eh-nav-btn {
-          background: #2b2d31;
-          border: 1px solid rgba(255, 255, 255, 0.08);
+          background: ${isDark ? "#2b2d31" : "#f2f3f5"};
+          border: 1px solid ${isDark ? "rgba(255, 255, 255, 0.08)" : "rgba(0, 0, 0, 0.1)"};
           border-radius: 4px;
-          color: #b5bac1;
+          color: ${isDark ? "#b5bac1" : "#5c5e66"};
           padding: 4px 12px;
           cursor: pointer;
           font-size: 0.85rem;
         }
         .eh-nav-btn:hover:not(:disabled) {
-          background: #35373c;
-          color: #f2f3f5;
+          background: ${isDark ? "#35373c" : "#e3e5e8"};
+          color: ${isDark ? "#f2f3f5" : "#313338"};
         }
         .eh-nav-btn:disabled {
           opacity: 0.35;
@@ -200,13 +203,13 @@ export function EditHistoryPopover({ channelId, messageId, currentContent, onClo
 
         .eh-position {
           font-size: 0.8rem;
-          color: #72767d;
+          color: ${isDark ? "#72767d" : "#94999e"};
           min-width: 60px;
           text-align: center;
         }
 
         .eh-revision {
-          background: #2b2d31;
+          background: ${isDark ? "#2b2d31" : "#f2f3f5"};
           border-radius: 6px;
           padding: 10px 12px;
         }
@@ -214,14 +217,14 @@ export function EditHistoryPopover({ channelId, messageId, currentContent, onClo
         .eh-time {
           display: block;
           font-size: 0.72rem;
-          color: #72767d;
+          color: ${isDark ? "#72767d" : "#94999e"};
           margin-bottom: 8px;
         }
 
         .eh-content {
           margin: 0;
           font-size: 0.85rem;
-          color: #b5bac1;
+          color: ${isDark ? "#b5bac1" : "#5c5e66"};
           white-space: pre-wrap;
           word-wrap: break-word;
           font-family: inherit;
@@ -230,7 +233,7 @@ export function EditHistoryPopover({ channelId, messageId, currentContent, onClo
         .eh-current-hint {
           margin-top: 8px;
           font-size: 0.72rem;
-          color: #72767d;
+          color: ${isDark ? "#72767d" : "#94999e"};
           text-align: center;
         }
       `}</style>

--- a/apps/web/components/masquerade-drawer.tsx
+++ b/apps/web/components/masquerade-drawer.tsx
@@ -34,6 +34,7 @@ function needsServer(role: Role) {
 
 export function MasqueradeDrawer() {
   const { state, dispatch } = useChat();
+  const isDark = state.theme !== "light";
   const { servers, viewerRoles } = state;
   const { showToast } = useToast();
 
@@ -161,6 +162,7 @@ export function MasqueradeDrawer() {
                     <RoleCard
                       key={r.value}
                       {...r}
+                      isDark={isDark}
                       selected={role === r.value}
                       onSelect={() => setRole(r.value)}
                     />
@@ -173,6 +175,7 @@ export function MasqueradeDrawer() {
                 <RoleCard
                   key={r.value}
                   {...r}
+                  isDark={isDark}
                   selected={role === r.value}
                   onSelect={() => setRole(r.value)}
                 />
@@ -279,8 +282,8 @@ export function MasqueradeDrawer() {
           bottom: 0;
           width: 360px;
           max-width: 100vw;
-          background: #1e1f22;
-          border-left: 1px solid rgba(255, 255, 255, 0.07);
+          background: ${isDark ? "#1e1f22" : "#ffffff"};
+          border-left: 1px solid ${isDark ? "rgba(255, 255, 255, 0.07)" : "rgba(0, 0, 0, 0.08)"};
           display: flex;
           flex-direction: column;
           z-index: 2000;
@@ -299,8 +302,8 @@ export function MasqueradeDrawer() {
           align-items: center;
           justify-content: space-between;
           padding: 16px 20px;
-          background: #2b2d31;
-          border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+          background: ${isDark ? "#2b2d31" : "#f2f3f5"};
+          border-bottom: 1px solid ${isDark ? "rgba(255, 255, 255, 0.07)" : "rgba(0, 0, 0, 0.08)"};
           flex-shrink: 0;
         }
         .mq-header-title {
@@ -309,7 +312,7 @@ export function MasqueradeDrawer() {
           gap: 10px;
           font-size: 1rem;
           font-weight: 700;
-          color: #f2f3f5;
+          color: ${isDark ? "#f2f3f5" : "#313338"};
         }
         .mq-icon {
           font-size: 1.25rem;
@@ -317,15 +320,15 @@ export function MasqueradeDrawer() {
         .mq-close {
           background: none;
           border: none;
-          color: #b5bac1;
+          color: ${isDark ? "#b5bac1" : "#5c5e66"};
           font-size: 1rem;
           cursor: pointer;
           padding: 4px 8px;
           border-radius: 4px;
         }
         .mq-close:hover {
-          background: rgba(255, 255, 255, 0.08);
-          color: #f2f3f5;
+          background: ${isDark ? "rgba(255, 255, 255, 0.08)" : "rgba(0, 0, 0, 0.06)"};
+          color: ${isDark ? "#f2f3f5" : "#313338"};
         }
 
         /* Body */
@@ -340,7 +343,7 @@ export function MasqueradeDrawer() {
         /* Sections */
         .mq-section {
           padding: 16px 20px;
-          border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+          border-bottom: 1px solid ${isDark ? "rgba(255, 255, 255, 0.06)" : "rgba(0, 0, 0, 0.06)"};
         }
         .mq-section-collapsible {
           opacity: 0.4;
@@ -356,7 +359,7 @@ export function MasqueradeDrawer() {
           font-weight: 800;
           text-transform: uppercase;
           letter-spacing: 0.06em;
-          color: #b5bac1;
+          color: ${isDark ? "#b5bac1" : "#5c5e66"};
           margin-bottom: 10px;
         }
         .mq-section-label-row {
@@ -386,7 +389,7 @@ export function MasqueradeDrawer() {
           font-weight: 700;
           text-transform: uppercase;
           letter-spacing: 0.05em;
-          color: #72767d;
+          color: ${isDark ? "#72767d" : "#94999e"};
           margin: 8px 0 4px;
         }
         .mq-role-group-title:first-child {
@@ -394,7 +397,7 @@ export function MasqueradeDrawer() {
         }
         .mq-divider {
           height: 1px;
-          background: rgba(255, 255, 255, 0.06);
+          background: ${isDark ? "rgba(255, 255, 255, 0.06)" : "rgba(0, 0, 0, 0.06)"};
           margin: 8px 0;
         }
 
@@ -408,18 +411,18 @@ export function MasqueradeDrawer() {
           display: flex;
           align-items: center;
           justify-content: space-between;
-          background: #2b2d31;
+          background: ${isDark ? "#2b2d31" : "#f2f3f5"};
           border: 2px solid transparent;
           border-radius: 6px;
           padding: 8px 12px;
           cursor: pointer;
-          color: #f2f3f5;
+          color: ${isDark ? "#f2f3f5" : "#313338"};
           font-size: 0.9rem;
           text-align: left;
           transition: border-color 0.12s, background 0.12s;
         }
         .mq-server-item:hover:not(:disabled) {
-          background: #35373c;
+          background: ${isDark ? "#35373c" : "#e3e5e8"};
         }
         .mq-server-item-selected {
           border-color: #5865f2;
@@ -447,16 +450,16 @@ export function MasqueradeDrawer() {
           display: flex;
           flex-direction: column;
           align-items: flex-start;
-          background: #2b2d31;
+          background: ${isDark ? "#2b2d31" : "#f2f3f5"};
           border: 2px solid transparent;
           border-radius: 6px;
           padding: 6px 10px;
           cursor: pointer;
-          color: #f2f3f5;
+          color: ${isDark ? "#f2f3f5" : "#313338"};
           transition: border-color 0.12s, background 0.12s;
         }
         .mq-badge-chip:hover:not(:disabled) {
-          background: #35373c;
+          background: ${isDark ? "#35373c" : "#e3e5e8"};
         }
         .mq-badge-chip-selected {
           border-color: #5865f2;
@@ -471,7 +474,7 @@ export function MasqueradeDrawer() {
         }
         .mq-badge-rank {
           font-size: 0.7rem;
-          color: #b5bac1;
+          color: ${isDark ? "#b5bac1" : "#5c5e66"};
         }
 
         .mq-toggle-all {
@@ -490,7 +493,7 @@ export function MasqueradeDrawer() {
 
         .mq-empty {
           font-size: 0.82rem;
-          color: #72767d;
+          color: ${isDark ? "#72767d" : "#94999e"};
           margin: 0;
           padding: 4px 0;
         }
@@ -499,8 +502,8 @@ export function MasqueradeDrawer() {
         .mq-footer {
           flex-shrink: 0;
           padding: 16px 20px;
-          background: #2b2d31;
-          border-top: 1px solid rgba(255, 255, 255, 0.07);
+          background: ${isDark ? "#2b2d31" : "#f2f3f5"};
+          border-top: 1px solid ${isDark ? "rgba(255, 255, 255, 0.07)" : "rgba(0, 0, 0, 0.08)"};
           display: flex;
           flex-direction: column;
           gap: 10px;
@@ -509,25 +512,25 @@ export function MasqueradeDrawer() {
           display: flex;
           align-items: baseline;
           gap: 6px;
-          background: #111214;
+          background: ${isDark ? "#111214" : "#e3e5e8"};
           border-radius: 6px;
           padding: 8px 12px;
           font-size: 0.82rem;
           min-height: 34px;
         }
         .mq-preview-label {
-          color: #72767d;
+          color: ${isDark ? "#72767d" : "#94999e"};
           font-weight: 700;
           flex-shrink: 0;
         }
         .mq-preview-value {
-          color: #f2f3f5;
+          color: ${isDark ? "#f2f3f5" : "#313338"};
           font-weight: 500;
           word-break: break-word;
         }
         .mq-footer-note {
           font-size: 0.72rem;
-          color: #72767d;
+          color: ${isDark ? "#72767d" : "#94999e"};
           text-align: center;
         }
         .mq-launch-btn {
@@ -559,9 +562,10 @@ interface RoleCardProps {
   description: string;
   selected: boolean;
   onSelect: () => void;
+  isDark: boolean;
 }
 
-function RoleCard({ label, description, selected, onSelect }: RoleCardProps) {
+function RoleCard({ label, description, selected, onSelect, isDark }: RoleCardProps) {
   return (
     <button
       type="button"
@@ -575,19 +579,19 @@ function RoleCard({ label, description, selected, onSelect }: RoleCardProps) {
           display: flex;
           flex-direction: column;
           align-items: flex-start;
-          background: #2b2d31;
+          background: ${isDark ? "#2b2d31" : "#f2f3f5"};
           border: 2px solid transparent;
           border-radius: 6px;
           padding: 8px 12px;
           cursor: pointer;
-          color: #f2f3f5;
+          color: ${isDark ? "#f2f3f5" : "#313338"};
           text-align: left;
           width: 100%;
           transition: border-color 0.12s, background 0.12s;
           gap: 2px;
         }
         .mq-role-card:hover {
-          background: #35373c;
+          background: ${isDark ? "#35373c" : "#e3e5e8"};
         }
         .mq-role-card-selected {
           border-color: #5865f2;
@@ -599,7 +603,7 @@ function RoleCard({ label, description, selected, onSelect }: RoleCardProps) {
         }
         .mq-role-card-desc {
           font-size: 0.75rem;
-          color: #b5bac1;
+          color: ${isDark ? "#b5bac1" : "#5c5e66"};
           line-height: 1.3;
         }
       `}</style>

--- a/apps/web/components/pinned-messages-drawer.tsx
+++ b/apps/web/components/pinned-messages-drawer.tsx
@@ -16,6 +16,7 @@ interface Props {
 
 export function PinnedMessagesDrawer({ channelId, channelName, onClose, onJumpToMessage }: Props) {
   const { state } = useChat();
+  const isDark = state.theme !== "light";
   const [pins, setPins] = useState<ChatMessage[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -113,6 +114,48 @@ export function PinnedMessagesDrawer({ channelId, channelName, onClose, onJumpTo
           ))}
         </ul>
       </aside>
+
+      <style jsx>{`
+        .pinned-drawer {
+          background: ${isDark ? "#1e1f22" : "#ffffff"} !important;
+          border-left-color: ${isDark ? "rgba(255, 255, 255, 0.07)" : "rgba(0, 0, 0, 0.08)"} !important;
+        }
+        .pinned-drawer__header {
+          background: ${isDark ? "#2b2d31" : "#f2f3f5"} !important;
+          border-bottom-color: ${isDark ? "rgba(255, 255, 255, 0.07)" : "rgba(0, 0, 0, 0.08)"} !important;
+        }
+        .pinned-drawer__header h2 {
+          color: ${isDark ? "#f2f3f5" : "#313338"} !important;
+        }
+        .pinned-drawer__close {
+          color: ${isDark ? "#b5bac1" : "#5c5e66"} !important;
+        }
+        .pinned-drawer__close:hover {
+          background: ${isDark ? "rgba(255, 255, 255, 0.08)" : "rgba(0, 0, 0, 0.06)"} !important;
+          color: ${isDark ? "#f2f3f5" : "#313338"} !important;
+        }
+        .pinned-drawer__status {
+          color: ${isDark ? "#b5bac1" : "#5c5e66"} !important;
+        }
+        .pinned-drawer__item {
+          background: ${isDark ? "#2b2d31" : "#f2f3f5"} !important;
+          border-color: ${isDark ? "rgba(255, 255, 255, 0.04)" : "rgba(0, 0, 0, 0.06)"} !important;
+          color: ${isDark ? "inherit" : "#313338"} !important;
+        }
+        .pinned-drawer__item:hover {
+          background: ${isDark ? "#35373c" : "#e3e5e8"} !important;
+          border-color: ${isDark ? "rgba(255, 255, 255, 0.1)" : "rgba(0, 0, 0, 0.12)"} !important;
+        }
+        .pinned-drawer__item-header strong {
+          color: ${isDark ? "#f2f3f5" : "#313338"} !important;
+        }
+        .pinned-drawer__item-header time {
+          color: ${isDark ? "#72767d" : "#94999e"} !important;
+        }
+        .pinned-drawer__item-content {
+          color: ${isDark ? "#b5bac1" : "#5c5e66"} !important;
+        }
+      `}</style>
     </>
   );
 }

--- a/apps/web/lib/composer-autocomplete/emoji-index.ts
+++ b/apps/web/lib/composer-autocomplete/emoji-index.ts
@@ -33,6 +33,13 @@ function canonicalToShortcode(name: string): string {
   return name.toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
 }
 
+// Overrides for emoji-picker-react canonical names that differ from
+// cross-compatible shortcode names (Discord, Twitch, GitHub, etc.).
+const CANONICAL_OVERRIDES: Record<string, string> = {
+  mexican: "taco",
+  face: "fox"
+};
+
 // Compact aliases preserved from the legacy chat-window shortcode map so users
 // who already type :smile:/:heart:/etc. still get glyphs after the rename.
 const LEGACY_ALIASES: Record<string, string> = {
@@ -54,9 +61,12 @@ function buildIndex(): { entries: EmojiEntry[]; shortcodeToGlyph: Map<string, st
 
   for (const [, list] of Object.entries((emojiData as RawEmojiData).emojis)) {
     for (const raw of list) {
-      const canonical = raw.n[raw.n.length - 1];
+      // n[last] is emoji-picker-react's canonical name. Correct most
+      // emojis, but some (🌮→"mexican", 🦊→"face") need overrides.
+      let canonical = raw.n[raw.n.length - 1];
       if (!canonical) continue;
-      const shortcode = canonicalToShortcode(canonical);
+      let shortcode = canonicalToShortcode(canonical);
+      if (CANONICAL_OVERRIDES[shortcode]) shortcode = CANONICAL_OVERRIDES[shortcode]!;
       if (!shortcode) continue;
       const glyph = codepointToGlyph(raw.u);
       const keywords = raw.n.slice(0, -1).map((k) => k.toLowerCase());


### PR DESCRIPTION
## Bugfixes for post-merge issues

### 1. Emoji autocomplete returns wrong shortcodes
`:taco:` was resolving to `:mexican:` and `:fox:` to `:face:` — Discord rejected these.
**Fix:** `CANONICAL_OVERRIDES` map in `emoji-index.ts` patches emoji-picker-react data where the canonical name differs from cross-compatible shortcodes.

### 2. Discord bridge breaks on `@` characters
Messages containing `@` caused webhook rejection → fallback to legacy name plaque format.
**Fix:** Escape unconverted `@` with zero-width space after mention processing.

### 3. EditHistoryPopover, MasqueradeDrawer, PinnedMessagesDrawer don't respect light mode
All three overlay components used hardcoded dark Discord colors.
**Fix:** Read `state.theme` from chat context, swap full color palette for light mode.

### Verification
- ✅ `pnpm typecheck` — clean
- ✅ `pnpm test` — 49/49 pass