### PR TITLE
fix: @-escaping now runs outside if(guild) block, always applied before webhook

### DIFF
--- a/apps/control-plane/src/services/discord-bot-client.ts
+++ b/apps/control-plane/src/services/discord-bot-client.ts
@@ -692,12 +692,14 @@ export async function relayMatrixMessageToDiscord(input: {
                     }
                 }
             }
-
-            // Escape unconverted @-signs to prevent Discord webhook rejection.
-            // Mentions already replaced with <@id> above; this catches stray @
-            // characters that Discord would otherwise interpret as failed mentions.
-            content = content.replace(/@(?!everyone|here)/g, "@\u200B");
         }
+
+        // Escape unconverted @-signs to prevent Discord webhook rejection.
+        // Mentions already replaced with <@id> above (when guild is available);
+        // this catches stray @ characters that Discord would otherwise
+        // interpret as failed mentions. Runs outside the guild block so it
+        // always applies — even when the guild or emoji isn't available.
+        content = content.replace(/@(?!everyone|here)/g, "@\u200B");
 
         if (skerryEmoji) {
             content = `${skerryEmoji} ${content}`;


### PR DESCRIPTION
## Root cause

The `@`-escaping logic was nested inside the `if (guild)` block. When the guild couldn't be fetched (e.g. the bot wasn't in that server, or guild data was unavailable), raw `@` characters passed through to the Discord webhook. Discord rejected the message → fallback triggered the legacy `SkerryBot [Matrix]` name plaque format instead of the proper `Username :skerry:` webhook format.

## Fix

Moved `content.replace(/@(?!everyone|here)/g, "@\u200B")` outside the `if (guild)` block so it always runs before the webhook send, regardless of guild availability.

### Verification
- ✅ `pnpm --filter @skerry/control-plane typecheck` — clean