### PR TITLE
feat(#44): replace Unicode emoji icons with lucide-react SVG icons

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -216,7 +216,7 @@ body {
   font-weight: 600;
 }
 
-.topbar-meta .icon-button {
+.topbar-meta .btn-icon--outline {
   background: var(--surface-alt);
   color: var(--text);
   border: 1px solid var(--border);
@@ -417,7 +417,7 @@ body {
   font-weight: 500;
 }
 
-.topbar-meta .icon-button:hover {
+.topbar-meta .btn-icon--outline:hover {
   background: var(--surface);
 }
 
@@ -1128,6 +1128,95 @@ textarea:focus-visible,
   background: transparent;
 }
 
+/* ── Unified icon button system (Sprint 3 #44) ── */
+
+.btn-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease, transform 0.1s ease;
+  flex-shrink: 0;
+}
+
+.btn-icon:active:not(:disabled) {
+  transform: scale(0.95);
+}
+
+.btn-icon:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.btn-icon:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* Ghost: no border/background, used in hover action bars */
+.btn-icon--ghost {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+}
+
+.btn-icon--ghost:hover:not(:disabled) {
+  background: var(--accent);
+  color: #fff;
+}
+
+/* Outline: bordered with background, used in channel headers and toolbars */
+.btn-icon--outline {
+  background: var(--surface-alt);
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+}
+
+.btn-icon--outline:hover:not(:disabled):not(.btn-icon--active) {
+  background: var(--surface);
+  color: var(--text);
+}
+
+.btn-icon--outline.btn-icon--active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
+.btn-icon--outline.btn-icon--danger:hover:not(:disabled) {
+  background: var(--danger);
+  border-color: var(--danger);
+  color: #fff;
+}
+
+/* Pill: rounded-full, for reaction badges and counters */
+.btn-icon--pill {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  color: var(--text);
+  border-radius: 9999px;
+  padding: 1px 8px;
+  width: auto;
+  height: auto;
+  min-height: 24px;
+  font-size: 0.85rem;
+  gap: 0.25rem;
+}
+
+.btn-icon--pill:hover:not(:disabled) {
+  background: var(--surface-alt);
+}
+
+.btn-icon--pill.btn-icon--active {
+  background: var(--accent-soft);
+  border-color: var(--accent);
+}
+
+/* Legacy: keep interaction-btn as an alias for pill variant during migration */
 .interaction-btn {
   color: var(--text);
   background: var(--surface);
@@ -1182,27 +1271,6 @@ textarea:focus-visible,
   opacity: 1;
   pointer-events: auto;
   transform: translateY(0);
-}
-
-.hover-action-item {
-  background: none !important;
-  border: none !important;
-  cursor: pointer;
-  padding: 4px 8px !important;
-  min-width: 32px !important;
-  height: 28px !important;
-  border-radius: 4px !important;
-  font-size: 14px !important;
-  display: flex !important;
-  align-items: center;
-  justify-content: center;
-  transition: all 0.2s !important;
-  color: var(--text-muted) !important;
-}
-
-.hover-action-item:hover {
-  background: var(--accent) !important;
-  color: #fff !important;
 }
 
 .message-item-container:hover .thread-reply-btn {
@@ -1711,8 +1779,9 @@ textarea:focus-visible,
 }
 
 .active-toggle {
-  background: #d9e9ff;
-  border-color: #8db0e1;
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
 }
 
 .audit-list {
@@ -1826,30 +1895,6 @@ textarea:focus-visible,
 .list-item:hover .inline-mgmt,
 .inline-mgmt.persistent {
   opacity: 1;
-}
-
-.icon-button {
-  width: 24px;
-  height: 24px;
-  padding: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 0.9rem;
-  background: var(--surface-alt);
-  color: var(--text-muted);
-  border: 1px solid var(--border);
-  border-radius: 4px;
-}
-
-.icon-button:hover {
-  background: var(--surface);
-  color: var(--text);
-}
-
-.icon-button.danger:hover {
-  background: var(--danger);
-  color: #fff;
 }
 
 .category-header {
@@ -2890,8 +2935,8 @@ textarea:focus-visible,
 }
 
 .active-toggle {
-    background: var(--accent) !important;
-    color: white !important;
+    background: var(--accent);
+    color: white;
 }
 
 .voice-error {

--- a/apps/web/app/settings/layout.tsx
+++ b/apps/web/app/settings/layout.tsx
@@ -4,6 +4,7 @@ import React, { useMemo } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useChat } from "../../context/chat-context";
+import Icon from "../../components/icon";
 
 export default function SettingsLayout({
   children,
@@ -27,38 +28,38 @@ export default function SettingsLayout({
   ), [viewerRoles, selectedServerId]);
 
   const navItems = [
-    { label: "User Settings", href: "/settings", icon: "👤" },
-    { label: "Hub Settings", href: "/settings/hub", icon: "⚙️", hidden: !canManageHub },
-    { label: "Hub Members", href: "/settings/hub/members", icon: "👥", hidden: !canManageHub },
-    { label: "Hub Invites", href: "/settings/hub/invites", icon: "🔗", hidden: !canManageHub },
+    { label: "User Settings", href: "/settings", icon: "user" },
+    { label: "Hub Settings", href: "/settings/hub", icon: "settings", hidden: !canManageHub },
+    { label: "Hub Members", href: "/settings/hub/members", icon: "users", hidden: !canManageHub },
+    { label: "Hub Invites", href: "/settings/hub/invites", icon: "link", hidden: !canManageHub },
     { 
       label: "Space Settings", 
       href: `/settings/spaces/${selectedServerId}`, 
-      icon: "🏠", 
+      icon: "home", 
       hidden: !canManageCurrentSpace || !selectedServerId 
     },
     { 
       label: "Space Members", 
       href: `/settings/spaces/${selectedServerId}/members`, 
-      icon: "🛡️", 
+      icon: "shield", 
       hidden: !canManageCurrentSpace || !selectedServerId 
     },
     { 
       label: "Space Badges", 
       href: `/settings/spaces/${selectedServerId}/badges`, 
-      icon: "🏅", 
+      icon: "award", 
       hidden: !canManageCurrentSpace || !selectedServerId 
     },
     { 
       label: "Audit Log", 
       href: `/settings/spaces/${selectedServerId}/audit-log`, 
-      icon: "📜", 
+      icon: "scroll-text", 
       hidden: !canManageCurrentSpace || !selectedServerId 
     },
     { 
       label: "Room Settings", 
       href: `/settings/rooms/${selectedChannelId}`, 
-      icon: "💬", 
+      icon: "message-square", 
       hidden: !canManageCurrentSpace || !selectedChannelId 
     },
   ];
@@ -68,7 +69,7 @@ export default function SettingsLayout({
       <header className="topbar">
         <div className="header-left">
           <Link href="/" className="back-button" title="Back to Chat">
-            ←
+            <Icon name="arrow-left" size={16} />
           </Link>
           <h1 style={{ marginLeft: '0.5rem' }}>Settings</h1>
         </div>
@@ -91,7 +92,7 @@ export default function SettingsLayout({
                   pathname === item.href ? "active" : ""
                 }`}
               >
-                <span style={{ fontSize: '1.2rem' }}>{item.icon}</span>
+                <Icon name={item.icon} size={18} />
                 {item.label}
               </Link>
             ))}

--- a/apps/web/components/chat-window.tsx
+++ b/apps/web/components/chat-window.tsx
@@ -1032,6 +1032,7 @@ export function ChatWindow({
                                 className={`btn-icon btn-icon--outline ${voiceMuted ? "btn-icon--active" : ""}`}
                                 onClick={() => handleToggleMuteDeafen(!voiceMuted, voiceDeafened)}
                                 title={voiceMuted ? "Unmute" : "Mute"}
+                                aria-label={voiceMuted ? "Unmute microphone" : "Mute microphone"}
                             >
                                 <Icon name={voiceMuted ? "mic-off" : "mic"} size={16} />
                             </button>
@@ -1040,6 +1041,7 @@ export function ChatWindow({
                                 className={`btn-icon btn-icon--outline ${voiceDeafened ? "btn-icon--active" : ""}`}
                                 onClick={() => handleToggleMuteDeafen(voiceMuted, !voiceDeafened)}
                                 title={voiceDeafened ? "Undeafen" : "Deafen"}
+                                aria-label={voiceDeafened ? "Undeafen audio" : "Deafen audio"}
                             >
                                 <Icon name={voiceDeafened ? "volume-1" : "headphones"} size={16} />
                             </button>
@@ -1048,6 +1050,7 @@ export function ChatWindow({
                                 className={`btn-icon btn-icon--outline ${voiceVideoEnabled ? "btn-icon--active" : ""}`}
                                 onClick={() => handleToggleVideo(!voiceVideoEnabled)}
                                 title={voiceVideoEnabled ? "Disable Video" : "Enable Video"}
+                                aria-label={voiceVideoEnabled ? "Turn off camera" : "Turn on camera"}
                             >
                                 <Icon name={voiceVideoEnabled ? "video" : "camera"} size={16} />
                             </button>
@@ -1056,6 +1059,7 @@ export function ChatWindow({
                                 className={`btn-icon btn-icon--outline ${voiceScreenShareEnabled ? "btn-icon--active" : ""}`}
                                 onClick={() => handleToggleScreenShare(!voiceScreenShareEnabled)}
                                 title={voiceScreenShareEnabled ? "Stop Sharing" : "Share Screen"}
+                                aria-label={voiceScreenShareEnabled ? "Stop screen sharing" : "Start screen sharing"}
                             >
                                 <Icon name="video" size={16} />
                             </button>
@@ -1064,6 +1068,7 @@ export function ChatWindow({
                                 className="btn-icon btn-icon--outline"
                                 onClick={() => dispatch({ type: "SET_ACTIVE_MODAL", payload: "voice-settings" })}
                                 title="Voice Settings"
+                                aria-label="Open voice settings"
                             >
                                 <Icon name="settings" size={16} />
                             </button>
@@ -1072,6 +1077,7 @@ export function ChatWindow({
                                 className="btn-icon btn-icon--outline btn-icon--danger"
                                 onClick={() => handleLeaveVoice()}
                                 title="Leave Voice"
+                                aria-label="Disconnect from voice"
                             >
                                 <Icon name="phone-off" size={16} />
                             </button>
@@ -1215,6 +1221,7 @@ export function ChatWindow({
                                                 setReactionTargetMessageId(message.id);
                                             }}
                                             title="Add Reaction"
+                                            aria-label="React with emoji"
                                         >
                                             <Icon name="smile-plus" size={16} />
                                         </button>
@@ -1229,6 +1236,7 @@ export function ChatWindow({
                                                 }
                                             }}
                                             title="Reply"
+                                            aria-label="Quote reply"
                                         >
                                             <Icon name="reply" size={16} />
                                         </button>
@@ -1246,6 +1254,7 @@ export function ChatWindow({
                                                     setEditContent(message.content);
                                                 }}
                                                 title="Edit"
+                                                aria-label="Edit"
                                             >
                                                 <Icon name="pen-line" size={16} />
                                             </button>

--- a/apps/web/components/chat-window.tsx
+++ b/apps/web/components/chat-window.tsx
@@ -25,6 +25,7 @@ import { AutocompletePopover } from "./composer/autocomplete-popover";
 import { shortcodeToGlyph } from "../lib/composer-autocomplete/emoji-index";
 import { firstUnreadMessageId, latestSeenOwnMessageId } from "../lib/read-state";
 import { EditHistoryPopover } from "./edit-history-popover";
+import Icon from "./icon";
 
 
 
@@ -411,7 +412,7 @@ export function ChatWindow({
                 setShowEmojiPicker(false);
             }
             // Handle reaction picker
-            if (reactionTargetMessageId && !target.closest(".emoji-picker-container") && !target.closest(".hover-action-item") && !target.closest(".interaction-btn")) {
+            if (reactionTargetMessageId && !target.closest(".emoji-picker-container") && !target.closest(".btn-icon--ghost") && !target.closest(".interaction-btn")) {
                 setReactionTargetMessageId(null);
                 setReactionPickerPos(null);
             }
@@ -611,7 +612,7 @@ export function ChatWindow({
         const items: ContextMenuItem[] = [
             {
                 label: "Add Reaction",
-                icon: "😀",
+                icon: "smile-plus",
                 onClick: () => {
                     if (contextMenu.message) {
                         setReactionPickerPos({ x: contextMenu.x, y: contextMenu.y });
@@ -621,7 +622,7 @@ export function ChatWindow({
             },
             {
                 label: "Copy Text",
-                icon: "📋",
+                icon: "clipboard",
                 onClick: () => {
                     const rawContent = contextMenu.message?.content || "";
                     // Transform ![:name:](url) -> :name: for clipboard
@@ -631,7 +632,7 @@ export function ChatWindow({
             },
             {
                 label: "Reply in Thread",
-                icon: "💬",
+                icon: "message-square",
                 onClick: () => {
                     if (contextMenu.message) {
                         dispatch({ type: "SET_THREAD_PARENT_ID", payload: contextMenu.message.id });
@@ -643,7 +644,7 @@ export function ChatWindow({
         if (isAuthor) {
             items.push({
                 label: "Edit Message",
-                icon: "✏️",
+                icon: "pen-line",
                 onClick: () => {
                     setEditingMessageId(contextMenu.message?.id || null);
                     setEditContent(contextMenu.message?.content || "");
@@ -654,7 +655,7 @@ export function ChatWindow({
         if (isModerator || isAuthor) {
             items.push({
                 label: "Delete Message",
-                icon: "🗑️",
+                icon: "trash-2",
                 danger: true,
                 onClick: () => {
                     dispatch({
@@ -708,7 +709,7 @@ export function ChatWindow({
         if (isModerator && !isAuthor) {
             items.push({
                 label: "Moderate User...",
-                icon: "🛡️",
+                icon: "shield",
                 danger: true,
                 onClick: () => {
                     dispatch({
@@ -724,7 +725,7 @@ export function ChatWindow({
             });
             items.push({
                 label: "Timeout User (Shadow Mute)",
-                icon: "⏳",
+                icon: "hourglass",
                 danger: true,
                 onClick: () => {
                     const isMasquerade = !!sessionStorage.getItem("masquerade_token");
@@ -744,7 +745,7 @@ export function ChatWindow({
             });
             items.push({
                 label: "Kick User",
-                icon: "👢",
+                icon: "ban",
                 danger: true,
                 onClick: () => {
                     const isMasquerade = !!sessionStorage.getItem("masquerade_token");
@@ -767,7 +768,7 @@ export function ChatWindow({
             const isPinned = contextMenu.message.isPinned;
             items.push({
                 label: isPinned ? "Unpin Message" : "Pin Message",
-                icon: "📌",
+                icon: "pin",
                 onClick: async () => {
                     const isMasquerade = !!sessionStorage.getItem("masquerade_token");
                     if (isMasquerade) {
@@ -810,7 +811,7 @@ export function ChatWindow({
         const items: ContextMenuItem[] = [
             {
                 label: "View Profile",
-                icon: "👤",
+                icon: "user",
                 onClick: () => {
                     dispatch({ type: "SET_PROFILE_USER_ID", payload: userContextMenu.userId });
                     dispatch({ type: "SET_ACTIVE_MODAL", payload: "profile" });
@@ -818,7 +819,7 @@ export function ChatWindow({
             },
             {
                 label: "Direct Message",
-                icon: "💬",
+                icon: "message-square",
                 onClick: () => {
                     console.log("DM user", userContextMenu.userId);
                 }
@@ -828,7 +829,7 @@ export function ChatWindow({
         if (!isSelf) {
             items.push({
                 label: "Ignore / Block",
-                icon: "🚫",
+                icon: "ban",
                 onClick: () => {
                     console.log("Block user", userContextMenu.userId);
                 }
@@ -838,7 +839,7 @@ export function ChatWindow({
         if (isModerator && !isSelf) {
             items.push({
                 label: "Timeout (Shadow Mute)",
-                icon: "⏳",
+                icon: "hourglass",
                 danger: true,
                 onClick: () => {
                     const isMasquerade = !!sessionStorage.getItem("masquerade_token");
@@ -857,7 +858,7 @@ export function ChatWindow({
             });
             items.push({
                 label: "Kick",
-                icon: "👢",
+                icon: "ban",
                 danger: true,
                 onClick: () => {
                     const isMasquerade = !!sessionStorage.getItem("masquerade_token");
@@ -955,12 +956,12 @@ export function ChatWindow({
                 <div style={{ display: "flex", alignItems: "center", gap: "0.75rem" }}>
                     <button
                         type="button"
-                        className="icon-button mobile-only"
+                        className="btn-icon btn-icon--outline mobile-only"
                         onClick={() => dispatch({ type: "SET_SIDEBAR_OPEN", payload: !state.isSidebarOpen })}
                         aria-label="Toggle Sidebar"
                         style={{ display: "none" }} /* Hidden by CSS for desktop */
                     >
-                        ☰
+                        <Icon name="menu" size={18} />
                     </button>
                     <div>
                         <h2>
@@ -994,14 +995,14 @@ export function ChatWindow({
                         <div className="dm-controls inline-buttons">
                             <button
                                 type="button"
-                                className="icon-button"
+                                className="btn-icon btn-icon--outline"
                                 onClick={() => {
                                     setNewTopic(activeChannel.topic || "");
                                     setIsEditingTopic(true);
                                 }}
                                 title="Set DM Topic"
                             >
-                                📝
+                                <Icon name="pencil" size={16} />
                             </button>
                         </div>
                     )}
@@ -1028,51 +1029,51 @@ export function ChatWindow({
                         <div className="voice-controls inline-buttons">
                             <button
                                 type="button"
-                                className={`icon-button ${voiceMuted ? "active-toggle" : ""}`}
+                                className={`btn-icon btn-icon--outline ${voiceMuted ? "btn-icon--active" : ""}`}
                                 onClick={() => handleToggleMuteDeafen(!voiceMuted, voiceDeafened)}
                                 title={voiceMuted ? "Unmute" : "Mute"}
                             >
-                                {voiceMuted ? "🔇" : "🎤"}
+                                <Icon name={voiceMuted ? "mic-off" : "mic"} size={16} />
                             </button>
                             <button
                                 type="button"
-                                className={`icon-button ${voiceDeafened ? "active-toggle" : ""}`}
+                                className={`btn-icon btn-icon--outline ${voiceDeafened ? "btn-icon--active" : ""}`}
                                 onClick={() => handleToggleMuteDeafen(voiceMuted, !voiceDeafened)}
                                 title={voiceDeafened ? "Undeafen" : "Deafen"}
                             >
-                                {voiceDeafened ? "🔈" : "🎧"}
+                                <Icon name={voiceDeafened ? "volume-1" : "headphones"} size={16} />
                             </button>
                             <button
                                 type="button"
-                                className={`icon-button ${voiceVideoEnabled ? "active-toggle" : ""}`}
+                                className={`btn-icon btn-icon--outline ${voiceVideoEnabled ? "btn-icon--active" : ""}`}
                                 onClick={() => handleToggleVideo(!voiceVideoEnabled)}
                                 title={voiceVideoEnabled ? "Disable Video" : "Enable Video"}
                             >
-                                {voiceVideoEnabled ? "📹" : "📷"}
+                                <Icon name={voiceVideoEnabled ? "video" : "camera"} size={16} />
                             </button>
                             <button
                                 type="button"
-                                className={`icon-button ${voiceScreenShareEnabled ? "active-toggle" : ""}`}
+                                className={`btn-icon btn-icon--outline ${voiceScreenShareEnabled ? "btn-icon--active" : ""}`}
                                 onClick={() => handleToggleScreenShare(!voiceScreenShareEnabled)}
                                 title={voiceScreenShareEnabled ? "Stop Sharing" : "Share Screen"}
                             >
-                                📺
+                                <Icon name="video" size={16} />
                             </button>
                             <button
                                 type="button"
-                                className="icon-button"
+                                className="btn-icon btn-icon--outline"
                                 onClick={() => dispatch({ type: "SET_ACTIVE_MODAL", payload: "voice-settings" })}
                                 title="Voice Settings"
                             >
-                                ⚙️
+                                <Icon name="settings" size={16} />
                             </button>
                             <button
                                 type="button"
-                                className="icon-button danger"
+                                className="btn-icon btn-icon--outline btn-icon--danger"
                                 onClick={() => handleLeaveVoice()}
                                 title="Leave Voice"
                             >
-                                📞
+                                <Icon name="phone-off" size={16} />
                             </button>
                         </div>
                     )}
@@ -1080,20 +1081,20 @@ export function ChatWindow({
                     <button
                         type="button"
                         data-testid="toggle-pinned-drawer"
-                        className={`icon-button ${state.isPinnedDrawerOpen ? "active-toggle" : ""}`}
+                        className={`btn-icon btn-icon--outline ${state.isPinnedDrawerOpen ? "btn-icon--active" : ""}`}
                         title={state.isPinnedDrawerOpen ? "Hide Pinned Messages" : "Show Pinned Messages"}
                         onClick={() => dispatch({ type: "SET_PINNED_DRAWER_OPEN", payload: !state.isPinnedDrawerOpen })}
                     >
-                        📌
+                        <Icon name="pin" size={16} />
                     </button>
                     <button
                         type="button"
                         data-testid="toggle-member-list"
-                        className={`icon-button ${isDetailsOpen ? "active-toggle" : ""}`}
+                        className={`btn-icon btn-icon--outline ${isDetailsOpen ? "btn-icon--active" : ""}`}
                         title={isDetailsOpen ? "Hide Member List" : "Show Member List"}
                         onClick={() => dispatch({ type: "SET_DETAILS_OPEN", payload: !isDetailsOpen })}
                     >
-                        👥
+                        <Icon name="users" size={16} />
                     </button>
                 </div>
             </header>
@@ -1202,7 +1203,7 @@ export function ChatWindow({
                                     <div className="message-hover-actions">
                                         <button
                                             type="button"
-                                            className="hover-action-item"
+                                            className="btn-icon btn-icon--ghost"
                                             onClick={(e) => {
                                                 const isMasquerade = !!sessionStorage.getItem("masquerade_token");
                                                 if (isMasquerade) {
@@ -1215,11 +1216,11 @@ export function ChatWindow({
                                             }}
                                             title="Add Reaction"
                                         >
-                                            😀
+                                            <Icon name="smile-plus" size={16} />
                                         </button>
                                         <button
                                             type="button"
-                                            className="hover-action-item"
+                                            className="btn-icon btn-icon--ghost"
                                             onClick={() => {
                                                 if ((activeChannelData?.type as string) === "forum") {
                                                     dispatch({ type: "SET_THREAD_PARENT_ID", payload: message.id });
@@ -1229,12 +1230,12 @@ export function ChatWindow({
                                             }}
                                             title="Reply"
                                         >
-                                            ↩️
+                                            <Icon name="reply" size={16} />
                                         </button>
                                         {message.authorUserId === viewer?.productUserId && (
                                             <button
                                                 type="button"
-                                                className="hover-action-item"
+                                                className="btn-icon btn-icon--ghost"
                                                 onClick={() => {
                                                     const isMasquerade = !!sessionStorage.getItem("masquerade_token");
                                                     if (isMasquerade) {
@@ -1246,7 +1247,7 @@ export function ChatWindow({
                                                 }}
                                                 title="Edit"
                                             >
-                                                ✏️
+                                                <Icon name="pen-line" size={16} />
                                             </button>
                                         )}
                                     </div>
@@ -1782,7 +1783,7 @@ export function ChatWindow({
 
             {lightboxUrl && (
                 <div className="lightbox-overlay" onClick={() => setLightboxUrl(null)}>
-                    <button className="lightbox-close" onClick={() => setLightboxUrl(null)}>×</button>
+                    <button className="lightbox-close" onClick={() => setLightboxUrl(null)}><Icon name="x" size={16} /></button>
                     <div className="lightbox-content" onClick={(e) => e.stopPropagation()}>
                         <GifPlayer src={lightboxUrl} className="lightbox-image" alt="Full size" style={{ maxWidth: "90vw", maxHeight: "90vh" }} />
                     </div>

--- a/apps/web/components/confirmation-modal.tsx
+++ b/apps/web/components/confirmation-modal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
+import Icon from "../components/icon";
 import { useChat } from "../context/chat-context";
 
 export function ConfirmationModal() {
@@ -45,7 +46,7 @@ export function ConfirmationModal() {
             <div className="modal-card glass-modal" onClick={(e) => e.stopPropagation()}>
                 <div className="modal-header">
                     <h2 className={danger ? 'danger' : ''}>{title}</h2>
-                    <button className="close-button" onClick={handleCancel}>✕</button>
+                    <button className="close-button" onClick={handleCancel}><Icon name="x" size={16} /></button>
                 </div>
                 
                 <div className="modal-body">

--- a/apps/web/components/context-menu.tsx
+++ b/apps/web/components/context-menu.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import React, { useEffect, useRef } from "react";
+import Icon, { type IconName } from "./icon";
 
 export interface ContextMenuItem {
   label?: string;
-  icon?: string;
+  icon?: string; // lucide IconName or raw string (e.g. "@")
   onClick?: () => void;
   danger?: boolean;
   type?: "item" | "header" | "separator";
@@ -15,6 +16,11 @@ interface ContextMenuProps {
   y: number;
   items: ContextMenuItem[];
   onClose: () => void;
+}
+
+function isIconName(s: string): s is IconName {
+  // IconName values are all lowercase kebab-case strings
+  return /^[a-z][a-z0-9-]*$/.test(s);
 }
 
 export function ContextMenu({ x, y, items, onClose }: ContextMenuProps) {
@@ -78,7 +84,15 @@ export function ContextMenu({ x, y, items, onClose }: ContextMenuProps) {
               onClose();
             }}
           >
-            {item.icon && <span>{item.icon}</span>}
+            {item.icon && (
+              <span>
+                {isIconName(item.icon) ? (
+                  <Icon name={item.icon} size={16} />
+                ) : (
+                  item.icon
+                )}
+              </span>
+            )}
             {item.label}
           </button>
         );

--- a/apps/web/components/dm-picker-modal.tsx
+++ b/apps/web/components/dm-picker-modal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
+import Icon from "./icon";
 import { useChat, useChatHandlers } from "../context/chat-context";
 import { searchUsers, createDirectMessage } from "../lib/control-plane";
 import { IdentityMapping } from "../lib/control-plane";
@@ -68,7 +69,7 @@ export function DMPickerModal() {
             <div className="modal-content dm-picker-modal" onClick={(e) => e.stopPropagation()}>
                 <header className="modal-header">
                     <h2>New Direct Message</h2>
-                    <button className="close-button" onClick={() => dispatch({ type: "SET_ACTIVE_MODAL", payload: null })}>×</button>
+                    <button className="close-button" onClick={() => dispatch({ type: "SET_ACTIVE_MODAL", payload: null })}><Icon name="x" size={16} /></button>
                 </header>
 
                 <div className="modal-body">

--- a/apps/web/components/edit-history-popover.tsx
+++ b/apps/web/components/edit-history-popover.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import type { MessageRevision } from "@skerry/shared";
 import { fetchRevisions } from "../lib/control-plane";
+import Icon from "./icon";
 import { useChat } from "../context/chat-context";
 
 interface Props {
@@ -59,7 +60,7 @@ export function EditHistoryPopover({ channelId, messageId, currentContent, onClo
       <div className="eh-popover" role="dialog" aria-label="Edit history" data-testid="edit-history-popover">
         <div className="eh-header">
           <span className="eh-title">Edit History</span>
-          <button className="eh-close" onClick={onClose} aria-label="Close">✕</button>
+          <button className="eh-close" onClick={onClose} aria-label="Close"><Icon name="x" size={16} /></button>
         </div>
 
         <div className="eh-body">

--- a/apps/web/components/icon.tsx
+++ b/apps/web/components/icon.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import type { LucideIcon } from "lucide-react";
+import {
+  AlertTriangle,
+  ArrowLeft,
+  AtSign,
+  Award,
+  Ban,
+  Bell,
+  Camera,
+  Clipboard,
+  Headphones,
+  Home,
+  Hourglass,
+  Link,
+  Lock,
+  Menu,
+  MessageSquare,
+  MessageSquareDot,
+  Mic,
+  MicOff,
+  Moon,
+  Paperclip,
+  PenLine,
+  PhoneOff,
+  Pin,
+  Plus,
+  Reply,
+  ScrollText,
+  Search,
+  Settings,
+  Shield,
+  SmilePlus,
+  Sun,
+  Trash2,
+  User,
+  Users,
+  Video,
+  Volume1,
+  Pencil,
+  X,
+} from "lucide-react";
+
+const iconMap: Record<string, LucideIcon> = {
+  "alert-triangle": AlertTriangle,
+  "arrow-left": ArrowLeft,
+  "at-sign": AtSign,
+  award: Award,
+  ban: Ban,
+  bell: Bell,
+  camera: Camera,
+  clipboard: Clipboard,
+  headphones: Headphones,
+  home: Home,
+  hourglass: Hourglass,
+  link: Link,
+  lock: Lock,
+  menu: Menu,
+  "message-square": MessageSquare,
+  "message-square-dot": MessageSquareDot,
+  mic: Mic,
+  "mic-off": MicOff,
+  moon: Moon,
+  paperclip: Paperclip,
+  "pen-line": PenLine,
+  "phone-off": PhoneOff,
+  pin: Pin,
+  plus: Plus,
+  reply: Reply,
+  "scroll-text": ScrollText,
+  search: Search,
+  settings: Settings,
+  shield: Shield,
+  "smile-plus": SmilePlus,
+  sun: Sun,
+  "trash-2": Trash2,
+  user: User,
+  users: Users,
+  video: Video,
+  "volume-1": Volume1,
+  pencil: Pencil,
+  x: X,
+};
+
+export type IconName = keyof typeof iconMap;
+
+interface IconProps {
+  name: IconName;
+  size?: number;
+  className?: string;
+  "aria-label"?: string;
+  strokeWidth?: number;
+}
+
+export default function Icon({
+  name,
+  size = 18,
+  className,
+  "aria-label": ariaLabel,
+  strokeWidth = 2,
+}: IconProps) {
+  const LucideComponent = iconMap[name];
+  if (!LucideComponent) {
+    console.warn(`Icon "${name}" not found`);
+    return null;
+  }
+  return (
+    <LucideComponent
+      size={size}
+      className={className}
+      aria-label={ariaLabel}
+      strokeWidth={strokeWidth}
+    />
+  );
+}

--- a/apps/web/components/layout/ClientTopbar.tsx
+++ b/apps/web/components/layout/ClientTopbar.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import type { ViewerSession } from "../../lib/control-plane";
 import { NotificationsPanel } from "../notifications-panel";
+import Icon from "../icon";
 
 interface ClientTopbarProps {
   dispatch: (action: any) => void;
@@ -46,24 +47,24 @@ export function ClientTopbar({
         <div className="topbar-meta">
           <button
             type="button"
-            className="icon-button"
+            className="btn-icon btn-icon--outline"
             title={theme === "light" ? "Switch to Dark Mode" : "Switch to Light Mode"}
             aria-label={theme === "light" ? "Switch to Dark Mode" : "Switch to Light Mode"}
             onClick={toggleTheme}
           >
-            {theme === "light" ? "🌙" : "☀️"}
+            <Icon name={theme === "light" ? "moon" : "sun"} size={16} />
           </button>
           <button
             type="button"
-            className="icon-button"
+            className="btn-icon btn-icon--outline"
             title="Search Messages"
             onClick={() => dispatch({ type: "SET_ACTIVE_MODAL", payload: "search" })}
           >
-            🔍
+            <Icon name="search" size={16} />
           </button>
           <NotificationsPanel />
-          <Link href="/settings" className="icon-button" title="User Settings" aria-label="User Settings">
-            ⚙️
+          <Link href="/settings" className="btn-icon btn-icon--outline" title="User Settings" aria-label="User Settings">
+            <Icon name="settings" size={16} />
           </Link>
           <span className="status-pill" data-state={realtimeState}>
             {realtimeState === "live" ? "Live" : realtimeState === "polling" ? "Polling" : "Offline"}

--- a/apps/web/components/masquerade-drawer.tsx
+++ b/apps/web/components/masquerade-drawer.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect, useMemo } from "react";
 import { useChat } from "../context/chat-context";
+import Icon from "./icon";
 import { getMasqueradeToken, fetchBadges } from "../lib/control-plane";
 import { useToast } from "./toast-provider";
 import type { Role, Badge } from "@skerry/shared";

--- a/apps/web/components/masquerade-modal.tsx
+++ b/apps/web/components/masquerade-modal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
+import Icon from "./icon";
 import { useChat } from "../context/chat-context";
 import { getMasqueradeToken, fetchBadges } from "../lib/control-plane";
 import { useToast } from "./toast-provider";
@@ -66,7 +67,7 @@ export function MasqueradeModal() {
       <div className="modal-card" onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
           <h2>🎭 Masquerade as Role</h2>
-          <button className="close-button" onClick={() => dispatch({ type: "SET_ACTIVE_MODAL", payload: null })}>✕</button>
+          <button className="close-button" onClick={() => dispatch({ type: "SET_ACTIVE_MODAL", payload: null })}><Icon name="x" size={16} /></button>
         </div>
 
         <form onSubmit={handleSubmit} className="masquerade-form">

--- a/apps/web/components/modals/VoiceSettingsModal.tsx
+++ b/apps/web/components/modals/VoiceSettingsModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useEffect, useState } from "react";
+import Icon from "../icon";
 
 interface VoiceSettingsModalProps {
     activeModal: string | null;

--- a/apps/web/components/notifications-panel.tsx
+++ b/apps/web/components/notifications-panel.tsx
@@ -3,6 +3,7 @@
 import React, { useMemo, useState, useRef, useEffect } from "react";
 import { useChat, useChatHandlers } from "../context/chat-context";
 import { getChannelName } from "../lib/channel-utils";
+import Icon from "./icon";
 
 interface NotificationItem {
     channelId: string;
@@ -83,14 +84,14 @@ export function NotificationsPanel() {
         <div className="notifications-anchor" ref={ref}>
             <button
                 type="button"
-                className="icon-button"
+                className="btn-icon btn-icon--outline"
                 aria-label="Notifications"
                 aria-expanded={open}
                 title={totalCount > 0 ? `${totalCount} unread notification${totalCount === 1 ? "" : "s"}` : "Notifications"}
                 onClick={() => setOpen((v) => !v)}
                 data-testid="notifications-bell"
             >
-                <span className="bell-glyph">🔔</span>
+                <Icon name="bell" size={16} />
                 {totalCount > 0 && <span className="notif-badge" data-testid="notifications-badge">{totalCount > 99 ? "99+" : totalCount}</span>}
             </button>
 
@@ -98,7 +99,7 @@ export function NotificationsPanel() {
                 <div className="notifications-panel" role="dialog" aria-label="Notifications" data-testid="notifications-panel">
                     <header className="notifications-header">
                         <h3>Notifications</h3>
-                        <button type="button" className="close-button" aria-label="Close notifications" onClick={() => setOpen(false)}>×</button>
+                        <button type="button" className="close-button" aria-label="Close notifications" onClick={() => setOpen(false)}><Icon name="x" size={16} /></button>
                     </header>
                     {items.length === 0 ? (
                         <p className="notifications-empty">You&apos;re all caught up.</p>

--- a/apps/web/components/profile-modal.tsx
+++ b/apps/web/components/profile-modal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
+import Icon from "./icon";
 import { useChat } from "../context/chat-context";
 import { updateUserProfile, fetchViewerSession, controlPlaneBaseUrl, fetchUser } from "../lib/control-plane";
 import { useToast } from "./toast-provider";

--- a/apps/web/components/role-modal.tsx
+++ b/apps/web/components/role-modal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState } from "react";
+import Icon from "./icon";
 import { useChat } from "../context/chat-context";
 import { grantRole } from "../lib/control-plane";
 import { useToast } from "./toast-provider";
@@ -60,7 +61,7 @@ export function RoleModal() {
           <button className="close-button" onClick={() => {
             dispatch({ type: "SET_ACTIVE_MODAL", payload: null });
             dispatch({ type: "SET_ROLE_CONTEXT", payload: null });
-          }}>✕</button>
+          }}><Icon name="x" size={16} /></button>
         </div>
 
         <form onSubmit={handleSubmit} className="role-form">

--- a/apps/web/components/search-modal.tsx
+++ b/apps/web/components/search-modal.tsx
@@ -5,6 +5,7 @@ import { useChat } from "../context/chat-context";
 import { searchMessages } from "../lib/control-plane";
 import type { ChatMessage } from "@skerry/shared";
 import { useRouter } from "next/navigation";
+import Icon from "./icon";
 
 export function SearchModal() {
     const { state, dispatch } = useChat();
@@ -66,7 +67,7 @@ export function SearchModal() {
             <div className="modal-content search-modal" onClick={(e) => e.stopPropagation()}>
                 <header className="modal-header">
                     <h2>Search Messages</h2>
-                    <button className="close-button" onClick={() => dispatch({ type: "SET_ACTIVE_MODAL", payload: null })}>×</button>
+                    <button className="close-button" onClick={() => dispatch({ type: "SET_ACTIVE_MODAL", payload: null })}><Icon name="x" size={16} /></button>
                 </header>
 
                 <div className="modal-body">

--- a/apps/web/components/sidebar.tsx
+++ b/apps/web/components/sidebar.tsx
@@ -456,7 +456,7 @@ export function Sidebar({
                                                         type="button"
                                                         className="btn-icon btn-icon--outline"
                                                         title="Create Room"
-                                                        aria-label="New room in this category"
+                                                        aria-label="Add channel to this category"
                                                         onClick={() => {
                                                             dispatch({ type: "SET_SELECTED_CATEGORY_FOR_CREATE", payload: group.id ?? "" });
                                                             dispatch({ type: "SET_ACTIVE_MODAL", payload: "create-room" });

--- a/apps/web/components/sidebar.tsx
+++ b/apps/web/components/sidebar.tsx
@@ -7,6 +7,7 @@ import { Channel, Server } from "@skerry/shared";
 import { getChannelName, getChannelIcon } from "../lib/channel-utils";
 import { ContextMenu, ContextMenuItem } from "./context-menu";
 import { upsertChannelReadState, joinServer, leaveDmChannel } from "../lib/control-plane";
+import Icon from "./icon";
 
 const cn = (...classes: (string | boolean | undefined)[]) => classes.filter(Boolean).join(" ");
 
@@ -220,21 +221,21 @@ export function Sidebar({
                                 <>
                                     <button
                                         type="button"
-                                        className="icon-button"
+                                        className="btn-icon btn-icon--outline"
                                         aria-label="Masquerade"
                                         title="Masquerade as Role"
                                         onClick={() => dispatch({ type: "SET_ACTIVE_MODAL", payload: "masquerade" })}
                                     >
-                                        🎭
+                                        <Icon name="shield" size={16} />
                                     </button>
                                     <button
                                         type="button"
-                                        className="icon-button"
+                                        className="btn-icon btn-icon--outline"
                                         aria-label="Create Space"
                                         data-testid="add-space-button"
                                         onClick={() => dispatch({ type: "SET_ACTIVE_MODAL", payload: "create-space" })}
                                     >
-                                        +
+                                        <Icon name="plus" size={16} />
                                     </button>
                                 </>
                             )}
@@ -285,7 +286,7 @@ export function Sidebar({
                                             <div className="inline-mgmt persistent">
                                                 <button
                                                     type="button"
-                                                    className="icon-button"
+                                                    className="btn-icon btn-icon--outline"
                                                     title="Edit Server"
                                                     data-testid="server-settings-button"
                                                     onClick={(e) => {
@@ -294,11 +295,11 @@ export function Sidebar({
                                                         dispatch({ type: "SET_ACTIVE_MODAL", payload: "rename-space" });
                                                     }}
                                                 >
-                                                    ✎
+                                                    <Icon name="pen-line" size={14} />
                                                 </button>
                                                 <button
                                                     type="button"
-                                                    className="icon-button danger"
+                                                    className="btn-icon btn-icon--outline btn-icon--danger"
                                                     title="Delete Server"
                                                     onClick={(e) => {
                                                         e.stopPropagation();
@@ -308,7 +309,7 @@ export function Sidebar({
                                                         }
                                                     }}
                                                 >
-                                                    ×
+                                                    <Icon name="x" size={14} />
                                                 </button>
                                             </div>
                                         )}
@@ -322,11 +323,11 @@ export function Sidebar({
                         <h2>Direct Messages</h2>
                         <button
                             type="button"
-                            className="icon-button"
+                            className="btn-icon btn-icon--outline"
                             aria-label="New Message"
                             onClick={() => dispatch({ type: "SET_ACTIVE_MODAL", payload: "dm-picker" })}
                         >
-                            +
+                            <Icon name="plus" size={16} />
                         </button>
                     </div>
 
@@ -386,7 +387,7 @@ export function Sidebar({
                                 onClick={() => setView("servers")}
                                 title="Back to Servers"
                             >
-                                ←
+                                <Icon name="arrow-left" size={16} />
                             </button>
                             <h2 className="server-title">{activeServer?.name || "Channels"}</h2>
                         </div>
@@ -396,12 +397,12 @@ export function Sidebar({
                             <div style={{ position: "relative" }}>
                                 <button
                                     type="button"
-                                    className="icon-button"
+                                    className="btn-icon btn-icon--outline"
                                     title="Add..."
                                     data-testid="add-channel-menu-trigger"
                                     onClick={() => dispatch({ type: "SET_ADD_MENU_OPEN", payload: !isAddMenuOpen })}
                                 >
-                                    +
+                                    <Icon name="plus" size={16} />
                                 </button>
                                 {isAddMenuOpen && (
                                     <div className="add-menu-dropdown" data-testid="add-menu-dropdown">
@@ -451,25 +452,25 @@ export function Sidebar({
                                                 <div className="inline-mgmt persistent">
                                                     <button
                                                         type="button"
-                                                        className="icon-button"
+                                                        className="btn-icon btn-icon--outline"
                                                         title="Create Room"
                                                         onClick={() => {
                                                             dispatch({ type: "SET_SELECTED_CATEGORY_FOR_CREATE", payload: group.id ?? "" });
                                                             dispatch({ type: "SET_ACTIVE_MODAL", payload: "create-room" });
                                                         }}
                                                     >
-                                                        +
+                                                        <Icon name="plus" size={14} />
                                                     </button>
                                                     <button
                                                         type="button"
-                                                        className="icon-button"
+                                                        className="btn-icon btn-icon--outline"
                                                         title="Rename Category"
                                                         onClick={() => {
                                                             dispatch({ type: "SET_RENAME_CATEGORY", payload: { id: group.id!, name: group.name } });
                                                             dispatch({ type: "SET_ACTIVE_MODAL", payload: "rename-category" });
                                                         }}
                                                     >
-                                                        ✎
+                                                        <Icon name="pen-line" size={14} />
                                                     </button>
                                                 </div>
                                             )}
@@ -513,7 +514,7 @@ export function Sidebar({
                                                             <div className="inline-mgmt">
                                                                 <button
                                                                     type="button"
-                                                                    className="icon-button"
+                                                                    className="btn-icon btn-icon--outline"
                                                                     title="Edit Room"
                                                                     onClick={(e) => {
                                                                         e.stopPropagation();
@@ -521,11 +522,11 @@ export function Sidebar({
                                                                         dispatch({ type: "SET_ACTIVE_MODAL", payload: "rename-room" });
                                                                     }}
                                                                 >
-                                                                    ✎
+                                                                    <Icon name="pen-line" size={14} />
                                                                 </button>
                                                                 <button
                                                                     type="button"
-                                                                    className="icon-button danger"
+                                                                    className="btn-icon btn-icon--outline btn-icon--danger"
                                                                     title="Delete Room"
                                                                     onClick={(e) => {
                                                                         e.stopPropagation();
@@ -536,7 +537,7 @@ export function Sidebar({
                                                                         }
                                                                     }}
                                                                 >
-                                                                    ×
+                                                                    <Icon name="x" size={14} />
                                                                 </button>
                                                             </div>
                                                         )}

--- a/apps/web/components/sidebar.tsx
+++ b/apps/web/components/sidebar.tsx
@@ -288,6 +288,7 @@ export function Sidebar({
                                                     type="button"
                                                     className="btn-icon btn-icon--outline"
                                                     title="Edit Server"
+                                                    aria-label="Edit server"
                                                     data-testid="server-settings-button"
                                                     onClick={(e) => {
                                                         e.stopPropagation();
@@ -301,6 +302,7 @@ export function Sidebar({
                                                     type="button"
                                                     className="btn-icon btn-icon--outline btn-icon--danger"
                                                     title="Delete Server"
+                                                    aria-label="Delete server"
                                                     onClick={(e) => {
                                                         e.stopPropagation();
                                                         if (confirm(`Are you sure you want to delete "${server.name}"? This cannot be undone.`)) {
@@ -454,6 +456,7 @@ export function Sidebar({
                                                         type="button"
                                                         className="btn-icon btn-icon--outline"
                                                         title="Create Room"
+                                                        aria-label="Create room in category"
                                                         onClick={() => {
                                                             dispatch({ type: "SET_SELECTED_CATEGORY_FOR_CREATE", payload: group.id ?? "" });
                                                             dispatch({ type: "SET_ACTIVE_MODAL", payload: "create-room" });
@@ -465,6 +468,7 @@ export function Sidebar({
                                                         type="button"
                                                         className="btn-icon btn-icon--outline"
                                                         title="Rename Category"
+                                                        aria-label="Rename category"
                                                         onClick={() => {
                                                             dispatch({ type: "SET_RENAME_CATEGORY", payload: { id: group.id!, name: group.name } });
                                                             dispatch({ type: "SET_ACTIVE_MODAL", payload: "rename-category" });
@@ -516,6 +520,7 @@ export function Sidebar({
                                                                     type="button"
                                                                     className="btn-icon btn-icon--outline"
                                                                     title="Edit Room"
+                                                                    aria-label="Edit room"
                                                                     onClick={(e) => {
                                                                         e.stopPropagation();
                                                                         dispatch({ type: "SET_RENAME_ROOM", payload: { id: channel.id, name: channel.name, type: channel.type, categoryId: channel.categoryId, topic: channel.topic, styleContent: channel.styleContent } });
@@ -528,6 +533,7 @@ export function Sidebar({
                                                                     type="button"
                                                                     className="btn-icon btn-icon--outline btn-icon--danger"
                                                                     title="Delete Room"
+                                                                    aria-label="Delete room"
                                                                     onClick={(e) => {
                                                                         e.stopPropagation();
                                                                         if (confirm(`Are you sure you want to delete "#${channel.name}"?`)) {

--- a/apps/web/components/sidebar.tsx
+++ b/apps/web/components/sidebar.tsx
@@ -456,7 +456,7 @@ export function Sidebar({
                                                         type="button"
                                                         className="btn-icon btn-icon--outline"
                                                         title="Create Room"
-                                                        aria-label="Create room in category"
+                                                        aria-label="New room in this category"
                                                         onClick={() => {
                                                             dispatch({ type: "SET_SELECTED_CATEGORY_FOR_CREATE", payload: group.id ?? "" });
                                                             dispatch({ type: "SET_ACTIVE_MODAL", payload: "create-room" });

--- a/apps/web/components/thread-panel.tsx
+++ b/apps/web/components/thread-panel.tsx
@@ -11,6 +11,7 @@ const EmojiPicker = dynamic(() => import("emoji-picker-react"), { ssr: false }) 
 import type { EmojiClickData } from "emoji-picker-react";
 import { useToast } from "./toast-provider";
 import { ContextMenu, ContextMenuItem } from "./context-menu";
+import Icon from "./icon";
 
 export function ThreadPanel() {
     const { state, dispatch } = useChat();
@@ -100,7 +101,7 @@ export function ThreadPanel() {
     useEffect(() => {
         const handleClickOutside = (event: MouseEvent) => {
             const target = event.target as HTMLElement;
-            if (reactionTargetMessageId && !target.closest(".emoji-picker-container") && !target.closest(".hover-action-item") && !target.closest(".interaction-btn")) {
+            if (reactionTargetMessageId && !target.closest(".emoji-picker-container") && !target.closest(".btn-icon--ghost") && !target.closest(".interaction-btn")) {
                 setReactionTargetMessageId(null);
                 setReactionPickerPos(null);
             }
@@ -231,7 +232,7 @@ export function ThreadPanel() {
         const items: ContextMenuItem[] = [
             {
                 label: "Add Reaction",
-                icon: "😀",
+                icon: "smile-plus",
                 onClick: () => {
                     setReactionTargetMessageId(contextMenu.message.id);
                     setReactionPickerPos({ x: contextMenu.x, y: contextMenu.y });
@@ -239,7 +240,7 @@ export function ThreadPanel() {
             },
             {
                 label: "Reply in Thread",
-                icon: "🧵",
+                icon: "message-square-dot",
                 onClick: () => {
                     setDraft(prev => prev ? `${prev}\n` : "");
                     // Just focus composer
@@ -247,7 +248,7 @@ export function ThreadPanel() {
             },
             {
                 label: "Copy Text",
-                icon: "📋",
+                icon: "clipboard",
                 onClick: () => {
                     void navigator.clipboard.writeText(contextMenu.message?.content || "");
                 }
@@ -257,7 +258,7 @@ export function ThreadPanel() {
         if (isAuthor) {
             items.push({
                 label: "Edit Message",
-                icon: "✏️",
+                icon: "pen-line",
                 onClick: () => {
                     setEditingMessageId(contextMenu.message.id);
                     setEditContent(contextMenu.message.content);
@@ -268,7 +269,7 @@ export function ThreadPanel() {
         if (isModerator || isAuthor) {
             items.push({
                 label: "Delete Message",
-                icon: "🗑️",
+                icon: "trash-2",
                 danger: true,
                 onClick: () => {
                     dispatch({
@@ -340,7 +341,7 @@ export function ThreadPanel() {
         if (isModerator && !isAuthor) {
             items.push({
                 label: "Moderate User...",
-                icon: "🛡️",
+                icon: "shield",
                 danger: true,
                 onClick: () => {
                     dispatch({
@@ -356,7 +357,7 @@ export function ThreadPanel() {
             });
             items.push({
                 label: "Timeout User",
-                icon: "⏳",
+                icon: "hourglass",
                 danger: true,
                 onClick: () => {
                     const isMasquerade = !!sessionStorage.getItem("masquerade_token");
@@ -375,7 +376,7 @@ export function ThreadPanel() {
             });
             items.push({
                 label: "Kick User",
-                icon: "👢",
+                icon: "ban",
                 danger: true,
                 onClick: () => {
                     const isMasquerade = !!sessionStorage.getItem("masquerade_token");
@@ -396,7 +397,7 @@ export function ThreadPanel() {
         const isPinned = contextMenu.message.isPinned;
         items.push({
             label: isPinned ? "Unpin Message" : "Pin Message",
-            icon: "📌",
+            icon: "pin",
             onClick: async () => {
                 const isMasquerade = !!sessionStorage.getItem("masquerade_token");
                 if (isMasquerade) {
@@ -449,7 +450,7 @@ export function ThreadPanel() {
         if (isModerator && !isSelf) {
             items.push({
                 label: "Timeout User",
-                icon: "⏳",
+                icon: "hourglass",
                 danger: true,
                 onClick: () => {
                     const isMasquerade = !!sessionStorage.getItem("masquerade_token");
@@ -468,7 +469,7 @@ export function ThreadPanel() {
             });
             items.push({
                 label: "Kick User",
-                icon: "👢",
+                icon: "ban",
                 danger: true,
                 onClick: () => {
                     const isMasquerade = !!sessionStorage.getItem("masquerade_token");
@@ -701,7 +702,7 @@ export function ThreadPanel() {
                         {attachments.map(att => (
                             <div key={att.id} className="attachment-preview">
                                 <img src={att.url} alt="preview" />
-                                <button type="button" onClick={() => setAttachments(prev => prev.filter(a => a.id !== att.id))}>×</button>
+                                <button type="button" onClick={() => setAttachments(prev => prev.filter(a => a.id !== att.id))}><Icon name="x" size={16} /></button>
                             </div>
                         ))}
                     </div>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,6 +19,7 @@
     "emoji-picker-react": "^4.18.0",
     "livekit-client": "^2.17.2",
     "lottie-react": "^2.4.1",
+    "lucide-react": "^1.14.0",
     "matrix-js-sdk": "^40.3.0-rc.0",
     "next": "14.2.30",
     "prismjs": "^1.30.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,6 +121,9 @@ importers:
       lottie-react:
         specifier: ^2.4.1
         version: 2.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      lucide-react:
+        specifier: ^1.14.0
+        version: 1.14.0(react@18.3.1)
       matrix-js-sdk:
         specifier: ^40.3.0-rc.0
         version: 40.3.0-rc.0
@@ -2284,6 +2287,11 @@ packages:
   lru-cache@11.2.6:
     resolution: {integrity: sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==}
     engines: {node: 20 || >=22}
+
+  lucide-react@1.14.0:
+    resolution: {integrity: sha512-+1mdWcfSJVUsaTIjN9zoezmUhfXo5l0vP7ekBMPo3jcS/aIkxHnXqAPsByszMZx/Y8oQBRJxJx5xg+RH3urzxA==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   magic-bytes.js@1.13.0:
     resolution: {integrity: sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==}
@@ -5922,6 +5930,10 @@ snapshots:
   lru-cache@10.4.3: {}
 
   lru-cache@11.2.6: {}
+
+  lucide-react@1.14.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   magic-bytes.js@1.13.0: {}
 


### PR DESCRIPTION
## Summary

Replaces all Unicode emoji used as button icons with consistent `lucide-react` SVG icons. This eliminates cross-platform rendering inconsistencies and establishes a unified icon button design system.

## Changes

- **New dependency**: `lucide-react` (MIT, tree-shakeable, 24px grid)
- **New component**: `<Icon>` — wraps lucide with 38 mapped icon names, theme-aware, aria-label support
- **Unified button CSS**: `.btn-icon` base class with three variants:
  - `--ghost` — no border/bg (hover actions bar)
  - `--outline` — bordered with bg (headers, toolbars, sidebars)
  - `--pill` — rounded-full (reaction badges)
- **New states**: `:active` press-down scale(0.95), `:focus-visible` accent ring, `:disabled` dimming
- **Hardcoded colors removed**: `#d9e9ff`/`#8db0e1` in .active-toggle replaced with `var(--accent)`
- **Old CSS removed**: `.icon-button` and `.hover-action-item` rules (including all `!important` chains)
- **ContextMenu** now auto-detects lucide icon names vs raw strings

### Files changed: 20 (1 new, 19 modified)

| Area | Files |
|---|---|
| Icon system | `icon.tsx` (new), `globals.css` |
| Chat window | `chat-window.tsx` (hover actions, voice controls, header) |
| Sidebar/topbar | `sidebar.tsx`, `ClientTopbar.tsx`, `notifications-panel.tsx` |
| Modals | `confirmation-modal`, `profile-modal`, `masquerade-modal`, `role-modal`, `search-modal`, `dm-picker-modal`, `InviteModals`, `VoiceSettingsModal` |
| Overlays | `masquerade-drawer`, `edit-history-popover`, `pinned-messages-drawer` |
| Misc | `context-menu.tsx`, `thread-panel.tsx`, `toast-provider.tsx`, `settings/layout.tsx`, `CreatorSuite.tsx` |

## Verification

- Typecheck: passes (shared + control-plane + web)
- Build: all 13 pages compile
- Tests: 49/49 web tests pass