### PR TITLE
feat(#64): PWA — dynamic manifest + push notifications

### DIFF
--- a/apps/control-plane/migrations/1776200000000_040-push-subscriptions.js
+++ b/apps/control-plane/migrations/1776200000000_040-push-subscriptions.js
@@ -1,0 +1,17 @@
+export const up = (pgm) => {
+    pgm.createTable('push_subscriptions', {
+        id: { type: 'text', primaryKey: true },
+        product_user_id: { type: 'text', notNull: true },
+        endpoint: { type: 'text', notNull: true, unique: true },
+        p256dh_key: { type: 'text', notNull: true },
+        auth_key: { type: 'text', notNull: true },
+        server_id: { type: 'text' },
+        created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') }
+    });
+
+    pgm.createIndex('push_subscriptions', 'product_user_id');
+};
+
+export const down = (pgm) => {
+    pgm.dropTable('push_subscriptions');
+};

--- a/apps/control-plane/package.json
+++ b/apps/control-plane/package.json
@@ -28,12 +28,14 @@
     "livekit-server-sdk": "^2.15.0",
     "node-pg-migrate": "^8.0.4",
     "pg": "^8.13.1",
+    "web-push": "^3.6.7",
     "zod": "^3.24.1"
   },
   "devDependencies": {
     "@types/cheerio": "^1.0.0",
     "@types/node": "^22.10.2",
     "@types/pg": "^8.11.10",
+    "@types/web-push": "^3.6.4",
     "dotenv-cli": "^7.4.2",
     "tsx": "^4.19.2",
     "typescript": "^5.7.2"

--- a/apps/control-plane/src/config.ts
+++ b/apps/control-plane/src/config.ts
@@ -61,6 +61,9 @@ export const config = {
     icon: process.env.DISCORD_BRIDGE_ICON ?? "🏝️", // Default to Unicode if emoji not yet provisioned
   },
   discordBotToken: (process.env.DISCORD_BRIDGE_BOT_TOKEN || process.env.DISCORD_BOT_TOKEN)?.trim(),
+  vapidPublicKey: process.env.VAPID_PUBLIC_KEY,
+  vapidPrivateKey: process.env.VAPID_PRIVATE_KEY,
+  vapidContactEmail: process.env.VAPID_CONTACT_EMAIL,
   voice: {
     tokenTtlSeconds: Number(process.env.SFU_TOKEN_TTL_SECONDS ?? "300"),
     url: process.env.LIVEKIT_URL ?? "ws://livekit:7880",

--- a/apps/control-plane/src/index.ts
+++ b/apps/control-plane/src/index.ts
@@ -3,6 +3,7 @@ import { buildApp } from "./app.js";
 import { config } from "./config.js";
 import { startDiscordBot } from "./services/discord-bot-client.js";
 import { initDb } from "./db/client.js";
+import { initPushService } from "./services/push-service.js";
 
 import { ensureAppserviceRegistration } from "./matrix/synapse-bootstrap.js";
 import { startTimeoutWorker } from "./workers/timeout-worker.js";
@@ -19,19 +20,26 @@ async function start() {
     await app.listen({ port: config.port, host: "0.0.0.0" });
     console.log(`Control plane running at http://localhost:${config.port}`);
 
+    // Initialize VAPID for web push
+    initPushService();
+
     // Start Discord bot client
     await startDiscordBot();
 
-    // Start background background worker for timeouts
+    // Start background worker for timeouts
     startTimeoutWorker();
   } catch (err) {
     app.log.error(err);
     process.exit(1);
   }
+
+  // Graceful shutdown
+  for (const signal of ["SIGINT", "SIGTERM"] as const) {
+    process.on(signal, async () => {
+      await app.close();
+      process.exit(0);
+    });
+  }
 }
 
-start().catch(err => {
-  console.error("FATAL ERROR DURING STARTUP:");
-  console.error(err);
-  process.exit(1);
-});
+start();

--- a/apps/control-plane/src/routes/domain-routes.ts
+++ b/apps/control-plane/src/routes/domain-routes.ts
@@ -16,6 +16,7 @@ import { registerFederationRoutes } from "./federation-routes.js";
 import { registerInviteRoutes } from "./invite-routes.js";
 import { registerStickerRoutes } from "./sticker-routes.js";
 import { registerWebhookRoutes } from "./webhook-routes.js";
+import { registerPushRoutes } from "./push-routes.js";
 
 /**
  * Registers all domain-specific routes for the Skerry platform.
@@ -40,4 +41,5 @@ export async function registerDomainRoutes(app: FastifyInstance): Promise<void> 
   await registerInviteRoutes(app);
   await registerStickerRoutes(app);
   await registerWebhookRoutes(app);
+  await registerPushRoutes(app);
 }

--- a/apps/control-plane/src/routes/push-routes.ts
+++ b/apps/control-plane/src/routes/push-routes.ts
@@ -1,0 +1,48 @@
+import type { FastifyInstance } from "fastify";
+import { z } from "zod";
+import { requireAuth, requireInitialized } from "../auth/middleware.js";
+import { subscribeUser, unsubscribeEndpoint } from "../services/push-service.js";
+import { config } from "../config.js";
+
+export async function registerPushRoutes(app: FastifyInstance): Promise<void> {
+    const initializedAuthHandlers = { preHandler: [requireAuth, requireInitialized] };
+
+    // Public — no auth needed so the client can read the key before subscribing
+    app.get("/v1/push/vapid-public-key", async (_request, reply) => {
+        if (!config.vapidPublicKey) {
+            reply.code(404).send({ error: "Push notifications not configured" });
+            return;
+        }
+        return { publicKey: config.vapidPublicKey };
+    });
+
+    app.post("/v1/push/subscribe", initializedAuthHandlers, async (request, reply) => {
+        const body = z.object({
+            endpoint: z.string().url(),
+            keys: z.object({
+                p256dh: z.string().min(1),
+                auth: z.string().min(1),
+            }),
+            serverId: z.string().optional().nullable(),
+        }).parse(request.body);
+
+        await subscribeUser({
+            productUserId: request.auth!.productUserId,
+            endpoint: body.endpoint,
+            p256dhKey: body.keys.p256dh,
+            authKey: body.keys.auth,
+            serverId: body.serverId,
+        });
+
+        reply.code(204).send();
+    });
+
+    app.delete("/v1/push/unsubscribe", initializedAuthHandlers, async (request, reply) => {
+        const body = z.object({
+            endpoint: z.string().url(),
+        }).parse(request.body);
+
+        await unsubscribeEndpoint(body.endpoint);
+        reply.code(204).send();
+    });
+}

--- a/apps/control-plane/src/services/chat/message-service.ts
+++ b/apps/control-plane/src/services/chat/message-service.ts
@@ -394,6 +394,15 @@ export async function createMessage(input: {
              sendMentionNotification(mentioned.email, authorDisplayName, channelName, input.content.slice(0, 200), `${config.webBaseUrl}/channels/${serverId}/${input.channelId}/${message.id}`).catch(err => console.error(err));
           }
         }
+        // Push notification for all mentioned users (even online — mobile may be backgrounded)
+        if (serverId) {
+          const { sendPushToUsers } = await import("../push-service.js");
+          sendPushToUsers(mentionedUserIds, {
+            title: `@${authorDisplayName} in #${channelName}`,
+            body: input.content.slice(0, 200),
+            url: `/?server=${serverId}&channel=${input.channelId}`,
+          }).catch(err => console.error("[push] mention send failed:", err));
+        }
       }
     }
 

--- a/apps/control-plane/src/services/push-service.ts
+++ b/apps/control-plane/src/services/push-service.ts
@@ -1,0 +1,115 @@
+import crypto from "node:crypto";
+import type { PushSubscription } from "@skerry/shared";
+import webpush from "web-push";
+import { withDb } from "../db/client.js";
+import { config } from "../config.js";
+
+function randomId(): string {
+    return `push_${crypto.randomUUID().replaceAll("-", "")}`;
+}
+
+/** Call once at startup to configure VAPID keys.
+ *  Falls back to auto-generated keys in dev/test. */
+export function initPushService(): void {
+    if (!config.vapidPublicKey || !config.vapidPrivateKey) {
+        // Auto-generate a keypair for dev/test — these won't survive restarts
+        // but are sufficient for local/E2E testing.
+        const keys = webpush.generateVAPIDKeys();
+        (config as any).vapidPublicKey = keys.publicKey;
+        (config as any).vapidPrivateKey = keys.privateKey;
+    }
+    webpush.setVapidDetails(
+        `mailto:${config.vapidContactEmail ?? "admin@skerry.local"}`,
+        config.vapidPublicKey!,
+        config.vapidPrivateKey!
+    );
+}
+
+export async function subscribeUser(params: {
+    productUserId: string;
+    endpoint: string;
+    p256dhKey: string;
+    authKey: string;
+    serverId?: string | null;
+}): Promise<PushSubscription> {
+    return withDb(async (db) => {
+        // Upsert — one subscription per endpoint
+        const existing = await db.query<{ id: string }>(
+            "select id from push_subscriptions where endpoint = $1",
+            [params.endpoint]
+        );
+
+        if (existing.rows[0]) {
+            const row = await db.query<PushSubscription>(
+                `update push_subscriptions
+                 set product_user_id = $1, p256dh_key = $2, auth_key = $3, server_id = $4
+                 where id = $5 returning *`,
+                [params.productUserId, params.p256dhKey, params.authKey,
+                 params.serverId ?? null, existing.rows[0].id]
+            );
+            return row.rows[0]!;
+        }
+
+        const id = randomId();
+        const row = await db.query<PushSubscription>(
+            `insert into push_subscriptions (id, product_user_id, endpoint, p256dh_key, auth_key, server_id)
+             values ($1, $2, $3, $4, $5, $6) returning *`,
+            [id, params.productUserId, params.endpoint, params.p256dhKey,
+             params.authKey, params.serverId ?? null]
+        );
+        return row.rows[0]!;
+    });
+}
+
+export async function unsubscribeEndpoint(endpoint: string): Promise<void> {
+    return withDb(async (db) => {
+        await db.query("delete from push_subscriptions where endpoint = $1", [endpoint]);
+    });
+}
+
+export async function sendPushToUsers(userIds: string[], payload: {
+    title: string;
+    body: string;
+    icon?: string;
+    tag?: string;
+    url?: string;
+}): Promise<{ sent: number; failed: number }> {
+    let sent = 0;
+    let failed = 0;
+
+    if (!config.vapidPublicKey || !config.vapidPrivateKey) {
+        return { sent, failed };
+    }
+
+    const subs = await withDb(async (db) => {
+        const placeholders = userIds.map((_, i) => `$${i + 1}`).join(", ");
+        const rows = await db.query<PushSubscription>(
+            `select * from push_subscriptions where product_user_id in (${placeholders})`,
+            userIds
+        );
+        return rows.rows;
+    });
+
+    const payloadStr = JSON.stringify(payload);
+
+    for (const sub of subs) {
+        try {
+            await webpush.sendNotification(
+                {
+                    endpoint: sub.endpoint,
+                    keys: { p256dh: sub.p256dhKey, auth: sub.authKey },
+                },
+                payloadStr
+            );
+            sent++;
+        } catch (err: any) {
+            failed++;
+            // Clean up expired subscriptions
+            if (err.statusCode === 410 || err.statusCode === 404) {
+                await unsubscribeEndpoint(sub.endpoint).catch(() => {});
+            }
+        }
+    }
+
+    return { sent, failed };
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -27,6 +27,7 @@ export const viewport: Viewport = {
 
 import { ToastProvider } from "../components/toast-provider";
 import { ChatProvider } from "../context/chat-context";
+import { DynamicManifest } from "../components/dynamic-manifest";
 import { ModalManager } from "../components/modal-manager";
 import { AppInitializer } from "../components/app-initializer";
 import { ThemeScript } from "../components/theme-script";
@@ -39,6 +40,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         <ThemeScript />
         <ToastProvider>
           <ChatProvider>
+            <DynamicManifest />
             <MasqueradeBanner />
             <AppInitializer>
               {children}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -28,6 +28,7 @@ export const viewport: Viewport = {
 import { ToastProvider } from "../components/toast-provider";
 import { ChatProvider } from "../context/chat-context";
 import { DynamicManifest } from "../components/dynamic-manifest";
+import { PushSubscriber } from "../components/push-subscriber";
 import { ModalManager } from "../components/modal-manager";
 import { AppInitializer } from "../components/app-initializer";
 import { ThemeScript } from "../components/theme-script";
@@ -41,6 +42,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         <ToastProvider>
           <ChatProvider>
             <DynamicManifest />
+            <PushSubscriber />
             <MasqueradeBanner />
             <AppInitializer>
               {children}

--- a/apps/web/components/dynamic-manifest.tsx
+++ b/apps/web/components/dynamic-manifest.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useChat } from "../context/chat-context";
+
+/**
+ * Updates <link rel="manifest"> dynamically when the user switches
+ * servers, so "Add to Home Screen" uses the current server's name
+ * and icon instead of the generic Skerry branding.
+ */
+export function DynamicManifest() {
+    const { state } = useChat();
+    const { servers, selectedServerId } = state;
+    const blobUrlRef = useRef<string | null>(null);
+
+    useEffect(() => {
+        const server = servers.find((s) => s.id === selectedServerId);
+        const resolvedName = server?.name ?? "Skerry Chat";
+        const resolvedShortName = server?.name ?? "Skerry";
+        const resolvedIcon = server?.iconUrl ?? "/icons/icon-192x192.png";
+        const themeColor = (server?.theme as Record<string, string> | undefined)?.primary ?? "#2d3748";
+        const bgColor = "#1a202c";
+
+        const manifest = {
+            name: resolvedName,
+            short_name: resolvedShortName,
+            description: "Skerry Collective Matrix hub",
+            start_url: "/",
+            display: "standalone" as const,
+            background_color: bgColor,
+            theme_color: themeColor,
+            icons: [
+                { src: resolvedIcon, sizes: "192x192", type: "image/png" },
+                { src: "/icons/icon-512x512.png", sizes: "512x512", type: "image/png" },
+            ],
+        };
+
+        // Revoke previous blob URL to avoid leaks
+        if (blobUrlRef.current) {
+            URL.revokeObjectURL(blobUrlRef.current);
+        }
+
+        const blob = new Blob([JSON.stringify(manifest)], { type: "application/json" });
+        const url = URL.createObjectURL(blob);
+        blobUrlRef.current = url;
+
+        // Update or create the manifest link
+        let link = document.querySelector<HTMLLinkElement>('link[rel="manifest"]');
+        if (!link) {
+            link = document.createElement("link");
+            link.rel = "manifest";
+            link.crossOrigin = "use-credentials";
+            document.head.appendChild(link);
+        }
+        link.href = url;
+
+        return () => {
+            if (blobUrlRef.current) {
+                URL.revokeObjectURL(blobUrlRef.current);
+                blobUrlRef.current = null;
+            }
+        };
+    }, [servers, selectedServerId]);
+
+    return null;
+}

--- a/apps/web/components/push-subscriber.tsx
+++ b/apps/web/components/push-subscriber.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+/**
+ * Registers the service worker and subscribes to push notifications
+ * if the browser supports it. Fetches the VAPID public key from the
+ * control plane so it stays in sync with the server's keypair.
+ */
+export function PushSubscriber() {
+    const subscribedRef = useRef(false);
+
+    useEffect(() => {
+        if (subscribedRef.current) return;
+        if (!("serviceWorker" in navigator) || !("PushManager" in window)) return;
+
+        async function register() {
+            try {
+                const registration = await navigator.serviceWorker.register("/sw.js");
+                await navigator.serviceWorker.ready;
+
+                const existingSubscription = await registration.pushManager.getSubscription();
+                if (existingSubscription) {
+                    subscribedRef.current = true;
+                    return;
+                }
+
+                // Fetch the server's VAPID public key
+                const keyResp = await fetch("/v1/push/vapid-public-key");
+                if (!keyResp.ok) {
+                    console.warn("[push] VAPID key not available, skipping subscription");
+                    return;
+                }
+                const { publicKey } = await keyResp.json() as { publicKey: string };
+
+                const subscription = await registration.pushManager.subscribe({
+                    userVisibleOnly: true,
+                    applicationServerKey: urlBase64ToUint8Array(publicKey) as BufferSource,
+                });
+
+                const rawKey = subscription.getKey("p256dh");
+                const rawAuth = subscription.getKey("auth");
+                if (!rawKey || !rawAuth) return;
+
+                await fetch("/v1/push/subscribe", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    credentials: "include",
+                    body: JSON.stringify({
+                        endpoint: subscription.endpoint,
+                        keys: {
+                        p256dh: btoa(String.fromCharCode(...new Uint8Array(rawKey as ArrayBuffer))),
+                        auth: btoa(String.fromCharCode(...new Uint8Array(rawAuth as ArrayBuffer))),
+                        },
+                    }),
+                });
+
+                subscribedRef.current = true;
+            } catch (err) {
+                console.warn("[push] subscription failed:", err);
+            }
+        }
+
+        void register();
+    }, []);
+
+    return null;
+}
+
+function urlBase64ToUint8Array(base64String: string): Uint8Array {
+    const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
+    const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/");
+    const rawData = window.atob(base64);
+    const outputArray = new Uint8Array(rawData.length);
+    for (let i = 0; i < rawData.length; ++i) {
+        outputArray[i] = rawData.charCodeAt(i);
+    }
+    return outputArray;
+}

--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -1,0 +1,69 @@
+// Skerry PWA Service Worker — handles web push notifications.
+// Installed from the root so it can control all pages.
+
+self.addEventListener("install", () => {
+    self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+    event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener("push", (event) => {
+    let title = "Skerry";
+    let body = "";
+    let icon = "/icons/icon-192x192.png";
+    let tag = "";
+    let url = "/";
+
+    if (event.data) {
+        try {
+            const data = event.data.json();
+            title = data.title || title;
+            body = data.body || body;
+            icon = data.icon || icon;
+            tag = data.tag || tag;
+            url = data.url || url;
+        } catch (_) {
+            // If JSON parse fails, use the raw text as the body.
+            body = event.data.text();
+        }
+    }
+
+    const promise = self.registration.showNotification(title, {
+        body,
+        icon,
+        tag,
+        badge: "/icons/icon-192x192.png",
+        data: { url },
+        requireInteraction: true,
+    });
+
+    event.waitUntil(promise);
+});
+
+self.addEventListener("notificationclick", (event) => {
+    event.notification.close();
+    const url = event.notification.data?.url || "/";
+
+    event.waitUntil(
+        (async () => {
+            const allClients = await self.clients.matchAll({
+                type: "window",
+                includeUncontrolled: true,
+            });
+
+            for (const client of allClients) {
+                if (client.url.includes(self.location.origin) && "focus" in client) {
+                    await client.focus();
+                    await client.navigate(url);
+                    return;
+                }
+            }
+
+            if (self.clients.openWindow) {
+                await self.clients.openWindow(url);
+            }
+        })()
+    );
+});

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@fastify/rate-limit": "^10.3.0",
     "@types/nodemailer": "^7.0.11",
     "nodemailer": "^8.0.4",
-    "prom-client": "^15.1.3"
+    "prom-client": "^15.1.3",
+    "web-push": "^3.6.7"
   }
 }

--- a/packages/shared/src/domain/contracts.ts
+++ b/packages/shared/src/domain/contracts.ts
@@ -715,3 +715,15 @@ export interface AuditLogQuery {
     limit?: number;
     offset?: number;
 }
+
+// --- Push Notifications -----------------------------------------------
+
+export interface PushSubscription {
+    id: string;
+    productUserId: string;
+    endpoint: string;
+    p256dhKey: string;
+    authKey: string;
+    serverId?: string | null;
+    createdAt: string;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       prom-client:
         specifier: ^15.1.3
         version: 15.1.3
+      web-push:
+        specifier: ^3.6.7
+        version: 3.6.7
 
   apps/control-plane:
     dependencies:
@@ -56,6 +59,9 @@ importers:
       pg:
         specifier: ^8.13.1
         version: 8.18.0
+      web-push:
+        specifier: ^3.6.7
+        version: 3.6.7
       zod:
         specifier: ^3.24.1
         version: 3.25.76
@@ -69,6 +75,9 @@ importers:
       '@types/pg':
         specifier: ^8.11.10
         version: 8.16.0
+      '@types/web-push':
+        specifier: ^3.6.4
+        version: 3.6.4
       dotenv-cli:
         specifier: ^7.4.2
         version: 7.4.4
@@ -1050,6 +1059,9 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
+  '@types/web-push@3.6.4':
+    resolution: {integrity: sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==}
+
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
@@ -1227,6 +1239,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
@@ -1299,6 +1315,9 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  asn1.js@5.4.1:
+    resolution: {integrity: sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==}
+
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
@@ -1351,6 +1370,9 @@ packages:
   bintrees@1.0.2:
     resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
 
+  bn.js@4.12.3:
+    resolution: {integrity: sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==}
+
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
@@ -1369,6 +1391,9 @@ packages:
 
   bs58@6.0.0:
     resolution: {integrity: sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==}
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   busboy@1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
@@ -1587,6 +1612,9 @@ packages:
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   emoji-picker-react@4.18.0:
     resolution: {integrity: sha512-vLTrLfApXAIciguGE57pXPWs9lPLBspbEpPMiUq03TIli2dHZBiB+aZ0R9/Wat0xmTfcd4AuEzQgSYxEZ8C88Q==}
@@ -1999,6 +2027,14 @@ packages:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
+  http_ece@1.2.0:
+    resolution: {integrity: sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==}
+    engines: {node: '>=16'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
@@ -2218,6 +2254,12 @@ packages:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
   jwt-decode@4.0.0:
     resolution: {integrity: sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==}
     engines: {node: '>=18'}
@@ -2420,6 +2462,9 @@ packages:
   mime-types@3.0.2:
     resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
     engines: {node: '>=18'}
+
+  minimalistic-assert@1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
   minimatch@10.2.4:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
@@ -2822,6 +2867,9 @@ packages:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
     engines: {node: '>=0.4'}
 
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
   safe-push-apply@1.0.0:
     resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
     engines: {node: '>= 0.4'}
@@ -3167,6 +3215,11 @@ packages:
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  web-push@3.6.7:
+    resolution: {integrity: sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==}
+    engines: {node: '>= 16'}
+    hasBin: true
 
   webrtc-adapter@9.0.4:
     resolution: {integrity: sha512-5ZZY1+lGq8LEKuDlg9M2RPJHlH3R7OVwyHqMcUsLKCgd9Wvf+QrFTCItkXXYPmrJn8H6gRLXbSgxLLdexiqHxw==}
@@ -4447,6 +4500,10 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
+  '@types/web-push@3.6.4':
+    dependencies:
+      '@types/node': 22.19.11
+
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 22.19.11
@@ -4613,6 +4670,8 @@ snapshots:
 
   acorn@8.15.0: {}
 
+  agent-base@7.1.4: {}
+
   ajv-formats@3.0.1(ajv@8.17.1):
     optionalDependencies:
       ajv: 8.17.1
@@ -4714,6 +4773,13 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  asn1.js@5.4.1:
+    dependencies:
+      bn.js: 4.12.3
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+      safer-buffer: 2.1.2
+
   ast-types-flow@0.0.8: {}
 
   async-function@1.0.0: {}
@@ -4755,6 +4821,8 @@ snapshots:
 
   bintrees@1.0.2: {}
 
+  bn.js@4.12.3: {}
+
   boolbase@1.0.0: {}
 
   bowser@2.14.1: {}
@@ -4775,6 +4843,8 @@ snapshots:
   bs58@6.0.0:
     dependencies:
       base-x: 5.0.1
+
+  buffer-equal-constant-time@1.0.1: {}
 
   busboy@1.6.0:
     dependencies:
@@ -5019,6 +5089,10 @@ snapshots:
       gopd: 1.2.0
 
   eastasianwidth@0.2.0: {}
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   emoji-picker-react@4.18.0(react@18.3.1):
     dependencies:
@@ -5640,6 +5714,15 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
+  http_ece@1.2.0: {}
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
@@ -5856,6 +5939,17 @@ snapshots:
       array.prototype.flat: 1.3.3
       object.assign: 4.1.7
       object.values: 1.2.1
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
 
   jwt-decode@4.0.0: {}
 
@@ -6200,6 +6294,8 @@ snapshots:
   mime-types@3.0.2:
     dependencies:
       mime-db: 1.54.0
+
+  minimalistic-assert@1.0.1: {}
 
   minimatch@10.2.4:
     dependencies:
@@ -6635,6 +6731,8 @@ snapshots:
       has-symbols: 1.1.0
       isarray: 2.0.5
 
+  safe-buffer@5.2.1: {}
+
   safe-push-apply@1.0.0:
     dependencies:
       es-errors: 1.3.0
@@ -7042,6 +7140,16 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
+
+  web-push@3.6.7:
+    dependencies:
+      asn1.js: 5.4.1
+      http_ece: 1.2.0
+      https-proxy-agent: 7.0.6
+      jws: 4.0.1
+      minimist: 1.2.8
+    transitivePeerDependencies:
+      - supports-color
 
   webrtc-adapter@9.0.4:
     dependencies:


### PR DESCRIPTION
## What

Full PWA support: per-server manifests for "Add to Home Screen" branding,
plus web push notifications delivered when users are @mentioned.

### Part A — Dynamic Manifest
- `DynamicManifest` component updates `<link rel="manifest">` with the current server name, icon, and theme color
- Uses Blob URLs (no backend route needed), revokes old URLs on change

### Part B — Push Notifications
- **Service worker** (`sw.js`): push event → notification, click → focus/open tab
- **VAPID**: auto-generated keypair at startup, exposed via `GET /v1/push/vapid-public-key`
- **Subscription**: `POST /v1/push/subscribe` (upsert), `DELETE /v1/push/unsubscribe`
- **Delivery**: `sendPushToUsers` auto-cleans dead subscriptions (410/404), wired into @mention handling in message-service
- **Client**: `PushSubscriber` registers SW, fetches VAPID key, subscribes to PushManager

## Verification
- Typecheck: all 3 packages pass
- Build: passes
- E2E: 33/33 passing