### PR TITLE
feat(#107): OIDC split detection — interstitial on potential duplicate account

### DIFF
--- a/apps/control-plane/src/auth/session.ts
+++ b/apps/control-plane/src/auth/session.ts
@@ -121,3 +121,61 @@ export function createMasqueradeToken(
 export function verifyMasqueradeToken(token: string): SessionPayload | null {
   return verify(token);
 }
+
+// --- Pending identity token (OIDC split-detection interstitial) ---
+
+export interface PendingIdentityPayload {
+  provider: string;
+  oidcSubject: string;
+  email: string | null;
+  displayName: string | null;
+  avatarUrl: string | null;
+  accessToken: string | null;
+  refreshToken: string | null;
+  tokenExpiresAt: string | null;
+  expiresAt: number;
+}
+
+export function createPendingIdentityToken(payload: Omit<PendingIdentityPayload, "expiresAt">): string {
+  return createSessionToken({
+    productUserId: "__pending__",
+    provider: payload.provider,
+    oidcSubject: payload.oidcSubject,
+    expiresAt: Date.now() + 5 * 60 * 1000, // 5-minute TTL
+  } as SessionPayload);
+}
+
+const PENDING_IDENTITY_KEY_PREFIX = "pending_identity:";
+
+export function setPendingIdentityCookie(reply: FastifyReply, payload: Omit<PendingIdentityPayload, "expiresAt">): string {
+  const fullPayload: PendingIdentityPayload = {
+    ...payload,
+    expiresAt: Date.now() + 5 * 60 * 1000,
+  };
+  const token = createPendingIdentityToken(fullPayload);
+  // Store the full payload in a separate cookie that the interstitial page reads
+  reply.header("Set-Cookie",
+    `pending_identity=${Buffer.from(JSON.stringify(fullPayload)).toString("base64url")}; Path=/; HttpOnly; SameSite=Lax; Max-Age=300`
+  );
+  return token;
+}
+
+export function getPendingIdentityCookie(request: FastifyRequest): PendingIdentityPayload | null {
+  const cookieHeader = request.headers.cookie;
+  if (!cookieHeader) return null;
+  const parts = cookieHeader.split(";").map(p => p.trim());
+  const raw = parts.find(p => p.startsWith("pending_identity="));
+  if (!raw) return null;
+  try {
+    const encoded = raw.replace("pending_identity=", "");
+    return JSON.parse(Buffer.from(encoded, "base64url").toString("utf8")) as PendingIdentityPayload;
+  } catch {
+    return null;
+  }
+}
+
+export function clearPendingIdentityCookie(reply: FastifyReply): void {
+  reply.header("Set-Cookie",
+    "pending_identity=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0"
+  );
+}

--- a/apps/control-plane/src/routes/auth-routes.ts
+++ b/apps/control-plane/src/routes/auth-routes.ts
@@ -313,18 +313,64 @@ export async function registerAuthRoutes(app: FastifyInstance): Promise<void> {
     } else if (!linkedIdentity) {
       const existingUserIdFromEmail =
         profile.email ? await findUniqueProductUserIdByEmail(profile.email) : null;
-      identity = await upsertIdentityMapping({
-        provider: profile.provider,
-        oidcSubject: profile.oidcSubject,
-        email: profile.email,
-        preferredUsername: null,
-        displayName: profile.displayName,
-        avatarUrl: profile.avatarUrl,
-        productUserId: existingUserIdFromEmail ?? undefined,
-        accessToken: exchanged.accessToken,
-        refreshToken: exchanged.refreshToken,
-        tokenExpiresAt: exchanged.tokenExpiresAt
-      });
+
+      if (existingUserIdFromEmail) {
+        // Email matches an existing account — link this new provider to it.
+        identity = await upsertIdentityMapping({
+          provider: profile.provider,
+          oidcSubject: profile.oidcSubject,
+          email: profile.email,
+          preferredUsername: null,
+          displayName: profile.displayName,
+          avatarUrl: profile.avatarUrl,
+          productUserId: existingUserIdFromEmail,
+          accessToken: exchanged.accessToken,
+          refreshToken: exchanged.refreshToken,
+          tokenExpiresAt: exchanged.tokenExpiresAt
+        });
+      } else {
+        // No email match. Check if any accounts exist on the platform —
+        // if so, this might be an existing user with a different email
+        // on another provider. Redirect to an interstitial instead of
+        // silently minting a second account (#107).
+        const { setPendingIdentityCookie } = await import("../auth/session.js");
+        const hasExistingUsers = await withDb(async (db) => {
+          const r = await db.query<{ exists: boolean }>(
+            "select exists(select 1 from identity_mappings limit 1) as exists"
+          );
+          return r.rows[0]?.exists ?? false;
+        });
+
+        if (hasExistingUsers) {
+          setPendingIdentityCookie(reply, {
+            provider: profile.provider,
+            oidcSubject: profile.oidcSubject,
+            email: profile.email,
+            displayName: profile.displayName,
+            avatarUrl: profile.avatarUrl,
+            accessToken: exchanged.accessToken,
+            refreshToken: exchanged.refreshToken ?? null,
+            tokenExpiresAt: exchanged.tokenExpiresAt ?? null,
+          });
+          const dest = new URL("/auth/link-or-create", config.webBaseUrl);
+          reply.redirect(dest.toString(), 302);
+          return;
+        }
+
+        // Platform has zero users — first signup, proceed normally.
+        identity = await upsertIdentityMapping({
+          provider: profile.provider,
+          oidcSubject: profile.oidcSubject,
+          email: profile.email,
+          preferredUsername: null,
+          displayName: profile.displayName,
+          avatarUrl: profile.avatarUrl,
+          productUserId: undefined,
+          accessToken: exchanged.accessToken,
+          refreshToken: exchanged.refreshToken,
+          tokenExpiresAt: exchanged.tokenExpiresAt
+        });
+      }
     }
 
     if (!identity) {
@@ -347,6 +393,52 @@ export async function registerAuthRoutes(app: FastifyInstance): Promise<void> {
     }
     const destination = destinationUrl.toString();
     reply.redirect(destination, 302);
+  });
+
+  // Consumes the pending identity cookie set by the OIDC split-detection
+  // flow. Creates the identity mapping and logs the user in.
+  app.post("/auth/confirm-new-account", async (request, reply) => {
+    const { getPendingIdentityCookie, clearPendingIdentityCookie } = await import("../auth/session.js");
+    const pending = getPendingIdentityCookie(request);
+    if (!pending) {
+      reply.code(400).send({ message: "No pending identity found. The link may have expired." });
+      return;
+    }
+
+    const linkedIdentity = await getIdentityByProviderSubject({
+      provider: pending.provider as IdentityProvider,
+      oidcSubject: pending.oidcSubject,
+    });
+    if (linkedIdentity) {
+      // Already linked (race condition or double-submit) — just log in.
+      setSessionCookie(reply, {
+        productUserId: linkedIdentity.productUserId,
+        provider: linkedIdentity.provider,
+        oidcSubject: linkedIdentity.oidcSubject,
+      });
+    } else {
+      const identity = await upsertIdentityMapping({
+        provider: pending.provider as IdentityProvider,
+        oidcSubject: pending.oidcSubject,
+        email: pending.email,
+        preferredUsername: null,
+        displayName: pending.displayName,
+        avatarUrl: pending.avatarUrl,
+        productUserId: undefined, // mint new account
+        accessToken: pending.accessToken ?? undefined,
+        refreshToken: pending.refreshToken ?? undefined,
+        tokenExpiresAt: pending.tokenExpiresAt ?? undefined,
+      });
+      setSessionCookie(reply, {
+        productUserId: identity.productUserId,
+        provider: identity.provider,
+        oidcSubject: identity.oidcSubject,
+      });
+    }
+
+    clearPendingIdentityCookie(reply);
+    const dest = new URL(config.webBaseUrl);
+    reply.redirect(dest.toString(), 302);
   });
 
   app.get("/auth/session/me", { preHandler: requireAuth }, async (request, reply) => {

--- a/apps/web/app/auth/link-or-create/page.tsx
+++ b/apps/web/app/auth/link-or-create/page.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { useSearchParams, useRouter } from "next/navigation";
+import { useState, Suspense } from "react";
+
+export const dynamic = "force-dynamic";
+
+function LinkOrCreateContent() {
+    const searchParams = useSearchParams();
+    const router = useRouter();
+    const provider = searchParams.get("provider") ?? "another provider";
+    const [submitting, setSubmitting] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    async function handleCreateNew() {
+        setSubmitting(true);
+        setError(null);
+        try {
+            const resp = await fetch("/auth/confirm-new-account", {
+                method: "POST",
+                credentials: "include",
+            });
+            if (resp.redirected) {
+                window.location.href = resp.url;
+                return;
+            }
+            if (!resp.ok) {
+                const body = await resp.json().catch(() => ({ message: "Unknown error" }));
+                setError((body as any).message ?? "Failed to create account");
+            }
+        } catch (e: any) {
+            setError(e.message ?? "Network error");
+        } finally {
+            setSubmitting(false);
+        }
+    }
+
+    return (
+        <div className="auth-page">
+            <div className="auth-card">
+                <h1>Account Not Found</h1>
+                <p>
+                    We couldn&apos;t find an existing Skerry account linked
+                    to your <strong>{provider}</strong> identity.
+                </p>
+
+                <div className="options">
+                    <div className="option-card">
+                        <h2>Create a New Account</h2>
+                        <p>
+                            Sign up with <strong>{provider}</strong> as a
+                            brand-new Skerry account.
+                        </p>
+                        <button
+                            className="button primary"
+                            onClick={handleCreateNew}
+                            disabled={submitting}
+                        >
+                            {submitting ? "Creating..." : `Create Account with ${provider}`}
+                        </button>
+                    </div>
+
+                    <div className="option-card">
+                        <h2>Link to Existing Account</h2>
+                        <p>
+                            If you already have a Skerry account with a
+                            different login method, sign in with that method
+                            first, then add {provider} from Settings.
+                        </p>
+                        <a className="button secondary" href="/login">
+                            Go to Login
+                        </a>
+                    </div>
+                </div>
+
+                {error && <div className="error-message">{error}</div>}
+            </div>
+
+            <style jsx>{`
+                .auth-page {
+                    display: flex;
+                    align-items: center;
+                    justify-content: center;
+                    min-height: 100vh;
+                    padding: 2rem;
+                    background: var(--bg-primary);
+                }
+                .auth-card {
+                    max-width: 560px;
+                    width: 100%;
+                    padding: 2rem;
+                    border-radius: 12px;
+                    background: var(--bg-secondary);
+                    border: 1px solid var(--border);
+                }
+                h1 {
+                    margin: 0 0 1rem;
+                    font-size: 1.5rem;
+                }
+                p {
+                    color: var(--text-muted);
+                    margin: 0 0 1.5rem;
+                    line-height: 1.5;
+                }
+                .options {
+                    display: grid;
+                    grid-template-columns: 1fr 1fr;
+                    gap: 1rem;
+                    margin-bottom: 1.5rem;
+                }
+                @media (max-width: 500px) {
+                    .options {
+                        grid-template-columns: 1fr;
+                    }
+                }
+                .option-card {
+                    padding: 1.25rem;
+                    border: 1px solid var(--border);
+                    border-radius: 8px;
+                    background: var(--bg-primary);
+                }
+                .option-card h2 {
+                    font-size: 1rem;
+                    margin: 0 0 0.5rem;
+                }
+                .option-card p {
+                    font-size: 0.85rem;
+                    margin: 0 0 1rem;
+                }
+                .button {
+                    display: inline-block;
+                    padding: 0.5rem 1rem;
+                    border-radius: 6px;
+                    font-size: 0.9rem;
+                    font-weight: 500;
+                    cursor: pointer;
+                    text-decoration: none;
+                    border: none;
+                }
+                .button.primary {
+                    background: var(--accent);
+                    color: #fff;
+                }
+                .button.primary:disabled {
+                    opacity: 0.6;
+                    cursor: not-allowed;
+                }
+                .button.secondary {
+                    background: transparent;
+                    border: 1px solid var(--border);
+                    color: var(--text-normal);
+                }
+                .error-message {
+                    padding: 0.75rem;
+                    border-radius: 6px;
+                    background: rgba(240, 71, 71, 0.1);
+                    color: #f04747;
+                    font-size: 0.85rem;
+                }
+            `}</style>
+        </div>
+    );
+}
+
+export default function LinkOrCreatePage() {
+    return (
+        <Suspense fallback={<div className="auth-page"><div className="auth-card"><p>Loading...</p></div></div>}>
+            <LinkOrCreateContent />
+        </Suspense>
+    );
+}


### PR DESCRIPTION
## Problem

When a user signs up with Discord (email A), then later tries to sign in
via Twitch (email B), the callback handler sees no email match and silently
creates a second account. The user ends up with two separate accounts with
no indication.

## Fix

The auth callback now detects when a potential split is happening:

1. New provider, no existing linked identity
2. Email doesn't match any existing account
3. Platform has existing users (so this isn't the first signup)

When all three are true, the OIDC profile is stored in a short-lived
HttpOnly cookie and the user is redirected to `/auth/link-or-create`.

The interstitial page offers two choices:
- **Create New Account** — proceeds with the signup
- **Link to Existing** — directs them to log in with their original
  provider first, then add the new provider from Settings

## Changes

- `session.ts`: pending identity cookie helpers (store/retrieve/clear)
- `auth-routes.ts`: split detection in callback + POST confirm endpoint
- `/auth/link-or-create/page.tsx`: interstitial page with Suspense

## Follow-up

- #125 — Account Merge feature for post-hoc resolution of existing splits

## Verification

- Typecheck: all 3 packages pass
- Build: passes
- E2E: 33/33 passing