### PR TITLE
perf(#55): skip metadata re-fetches on same-server channel switch

### DIFF
--- a/apps/web/hooks/use-chat-initialization.ts
+++ b/apps/web/hooks/use-chat-initialization.ts
@@ -369,8 +369,10 @@ export function useChatInitialization({
     setDraftMessage(draftMessagesByChannel[channelId] ?? "");
 
     try {
-      // REFACTOR: Just call refreshChatState with force=true to avoid duplicate code
-      await refreshChatState(selectedServerId ?? undefined, channelId, undefined, true);
+      // REFACTOR: Just call refreshChatState to avoid duplicate code.
+      // force=false: the server hasn't changed, so we can reuse cached
+      // servers/roles/hubs/channels/categories (#55).
+      await refreshChatState(selectedServerId ?? undefined, channelId, undefined, false);
     } catch (cause) {
       dispatch({ type: "SET_ERROR", payload: cause instanceof Error ? cause.message : "Failed to load channel." });
     }


### PR DESCRIPTION
## Problem

Every channel switch called `refreshChatState(..., force=true)`,
which re-fetched servers, roles, hubs, channels, and categories —
~6 requests per click. None of these change on an intra-server
channel switch.

## Fix

One-line change: `force=true` → `force=false` in `handleChannelChange`.

- Servers/roles/hubs: reused from cached state
- Channels/categories: skipped because `nextServerId === state.selectedServerId`
- Early-return gate: still bypassed because `nextChannelId !== selectedChannelId`

## Verification

- Typecheck: all 3 packages pass
- Build: passes
- E2E: 33/33 passing