### PR TITLE
feat(#108): per-hub autojoin default + landing page

### DIFF
--- a/apps/control-plane/migrations/1776300000000_041-hub-default-autojoin.js
+++ b/apps/control-plane/migrations/1776300000000_041-hub-default-autojoin.js
@@ -1,0 +1,9 @@
+export const up = (pgm) => {
+    pgm.addColumn('hubs', {
+        default_auto_join_hub_members: { type: 'boolean', notNull: true, default: true },
+    });
+};
+
+export const down = (pgm) => {
+    pgm.dropColumn('hubs', 'default_auto_join_hub_members');
+};

--- a/apps/control-plane/src/services/provisioning-service.ts
+++ b/apps/control-plane/src/services/provisioning-service.ts
@@ -81,6 +81,14 @@ export async function createServerWorkflow(input: {
 
   const server = await withDb(async (db) => {
     const id = randomId("srv");
+
+    // Read the hub's default auto-join setting (#108)
+    const hubRow = await db.query<{ default_auto_join: boolean }>(
+      "select default_auto_join_hub_members as default_auto_join from hubs where id = $1",
+      [input.hubId]
+    );
+    const autoJoin = hubRow.rows[0]?.default_auto_join ?? true;
+
     const row = await db.query<{
       id: string;
       hub_id: string;
@@ -95,9 +103,9 @@ export async function createServerWorkflow(input: {
       icon_url: string | null;
     }>(
       `insert into servers (id, hub_id, name, type, matrix_space_id, created_by_user_id, owner_user_id, auto_join_hub_members, join_policy)
-       values ($1, $2, $3, 'default', $4, $5, $6, true, 'open')
+       values ($1, $2, $3, 'default', $4, $5, $6, $7, 'open')
        returning *`,
-      [id, input.hubId, input.name, matrixSpaceId, input.productUserId, ownerUserId]
+      [id, input.hubId, input.name, matrixSpaceId, input.productUserId, ownerUserId, autoJoin]
     );
 
     const value = row.rows[0];

--- a/apps/control-plane/src/services/settings-service.ts
+++ b/apps/control-plane/src/services/settings-service.ts
@@ -4,7 +4,8 @@ import type { Hub, Server, Channel } from "@skerry/shared";
 export async function getHubSettings(hubId: string): Promise<Partial<Hub>> {
   return withDb(async (db) => {
     const res = await db.query(
-      `select theme, space_customization_limits, oidc_config, allow_space_discord_bridge, 
+      `select theme, space_customization_limits, oidc_config, allow_space_discord_bridge,
+              default_auto_join_hub_members,
               is_suspended, suspended_at, suspension_expires_at, unlock_code_hash
        from hubs where id = $1`,
       [hubId]
@@ -16,6 +17,7 @@ export async function getHubSettings(hubId: string): Promise<Partial<Hub>> {
       spaceCustomizationLimits: row.space_customization_limits,
       oidcConfig: row.oidc_config,
       allowSpaceDiscordBridge: row.allow_space_discord_bridge,
+      defaultAutoJoinHubMembers: row.default_auto_join_hub_members,
       suspension: {
         isSuspended: row.is_suspended,
         suspendedAt: row.suspended_at,
@@ -31,6 +33,7 @@ export async function updateHubSettings(hubId: string, settings: {
   spaceCustomizationLimits?: any;
   oidcConfig?: any;
   allowSpaceDiscordBridge?: boolean;
+  defaultAutoJoinHubMembers?: boolean;
   suspension?: {
     isSuspended?: boolean;
     suspendedAt?: string | null;
@@ -45,10 +48,11 @@ export async function updateHubSettings(hubId: string, settings: {
         space_customization_limits = case when $3::jsonb is not null then $3::jsonb else space_customization_limits end,
         oidc_config = case when $4::jsonb is not null then $4::jsonb else oidc_config end,
         allow_space_discord_bridge = coalesce($5, allow_space_discord_bridge),
-        is_suspended = coalesce($6, is_suspended),
-        suspended_at = case when $7::text is not null or $10::boolean then $7::timestamptz else suspended_at end,
-        suspension_expires_at = case when $8::text is not null or $11::boolean then $8::timestamptz else suspension_expires_at end,
-        unlock_code_hash = case when $9::text is not null or $12::boolean then $9::text else unlock_code_hash end
+        default_auto_join_hub_members = coalesce($6, default_auto_join_hub_members),
+        is_suspended = coalesce($7, is_suspended),
+        suspended_at = case when $8::text is not null or $11::boolean then $8::timestamptz else suspended_at end,
+        suspension_expires_at = case when $9::text is not null or $12::boolean then $9::timestamptz else suspension_expires_at end,
+        unlock_code_hash = case when $10::text is not null or $13::boolean then $10::text else unlock_code_hash end
       where id = $1`,
       [
         hubId,
@@ -56,6 +60,7 @@ export async function updateHubSettings(hubId: string, settings: {
         settings.spaceCustomizationLimits ? JSON.stringify(settings.spaceCustomizationLimits) : null,
         settings.oidcConfig ? JSON.stringify(settings.oidcConfig) : null,
         settings.allowSpaceDiscordBridge,
+        settings.defaultAutoJoinHubMembers,
         settings.suspension?.isSuspended,
         settings.suspension?.suspendedAt,
         settings.suspension?.expiresAt,

--- a/apps/web/app/settings/hub/page.tsx
+++ b/apps/web/app/settings/hub/page.tsx
@@ -101,6 +101,18 @@ export default function HubSettingsPage() {
                     <p className="settings-description">When enabled, individual Space Owners can bridge their rooms to Discord without Hub Admin intervention.</p>
                 </section>
 
+                <section className="settings-row checkbox-row">
+                    <label className="checkbox-container">
+                        <input 
+                            type="checkbox" 
+                            checked={settings.defaultAutoJoinHubMembers !== false}
+                            onChange={(e) => setSettings({ ...settings, defaultAutoJoinHubMembers: e.target.checked })}
+                        />
+                        <span className="checkbox-label">Auto-join new hub members to new spaces</span>
+                    </label>
+                    <p className="settings-description">When enabled, new spaces created in this hub will default to automatically adding all current and future hub members. Space owners can change this per-space.</p>
+                </section>
+
                 <hr style={{ margin: '1rem 0', borderColor: 'var(--border)' }} />
 
                 <section className="settings-row">

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+skerry.chat

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,409 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Skerry — Creator Co-Op Hub</title>
+  <meta name="description" content="A Matrix-based collaboration hub with Discord-like UX. Servers, channels, voice/video, Discord bridging. Built for creators, federated by design.">
+  <meta property="og:title" content="Skerry — Creator Co-Op Hub">
+  <meta property="og:description" content="Matrix-based collaboration with Discord-like UX. Federated, sovereign, built for creators.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://skerry.chat">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg: #0d0f14;
+      --bg-card: #151820;
+      --bg-elevated: #1c1f2a;
+      --text: #e1e4eb;
+      --text-muted: #8b8fa3;
+      --accent: #6c8cf5;
+      --accent-glow: rgba(108, 140, 245, 0.15);
+      --border: #252832;
+      --radius: 8px;
+      --max-w: 1100px;
+    }
+
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, sans-serif;
+      line-height: 1.6;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    /* ── Nav ── */
+    nav {
+      position: fixed; top: 0; left: 0; right: 0; z-index: 100;
+      background: rgba(13, 15, 20, 0.85);
+      backdrop-filter: blur(12px);
+      border-bottom: 1px solid var(--border);
+    }
+    nav .nav-inner {
+      max-width: var(--max-w); margin: 0 auto; padding: 0 24px;
+      height: 56px; display: flex; align-items: center; justify-content: space-between;
+    }
+    .nav-logo { font-weight: 700; font-size: 1.25rem; color: var(--text); text-decoration: none; }
+    .nav-logo span { color: var(--accent); }
+    .nav-links { display: flex; gap: 24px; }
+    .nav-links a { color: var(--text-muted); text-decoration: none; font-size: 0.9rem; transition: color .2s; }
+    .nav-links a:hover { color: var(--text); }
+    .nav-cta {
+      background: var(--accent); color: #fff; border: none; padding: 8px 20px;
+      border-radius: var(--radius); font-size: 0.875rem; font-weight: 600; cursor: pointer;
+      text-decoration: none; transition: box-shadow .2s;
+    }
+    .nav-cta:hover { box-shadow: 0 0 20px var(--accent-glow); }
+
+    /* ── Hero ── */
+    .hero {
+      padding: 160px 24px 100px; text-align: center; max-width: 720px; margin: 0 auto;
+    }
+    .hero-badge {
+      display: inline-block; background: var(--accent-glow); color: var(--accent);
+      padding: 4px 14px; border-radius: 100px; font-size: 0.8rem; font-weight: 600;
+      margin-bottom: 24px; border: 1px solid rgba(108, 140, 245, 0.2);
+    }
+    .hero h1 { font-size: 3rem; font-weight: 800; line-height: 1.15; margin-bottom: 20px; letter-spacing: -0.02em; }
+    .hero h1 span { color: var(--accent); }
+    .hero p { color: var(--text-muted); font-size: 1.15rem; max-width: 540px; margin: 0 auto 36px; }
+    .hero-actions { display: flex; gap: 14px; justify-content: center; flex-wrap: wrap; }
+    .btn-primary {
+      background: var(--accent); color: #fff; border: none; padding: 14px 32px;
+      border-radius: var(--radius); font-size: 1rem; font-weight: 600; cursor: pointer;
+      text-decoration: none; transition: box-shadow .2s;
+    }
+    .btn-primary:hover { box-shadow: 0 0 28px var(--accent-glow); }
+    .btn-secondary {
+      background: transparent; color: var(--text); border: 1px solid var(--border);
+      padding: 14px 32px; border-radius: var(--radius); font-size: 1rem; font-weight: 600;
+      cursor: pointer; text-decoration: none; transition: border-color .2s;
+    }
+    .btn-secondary:hover { border-color: var(--accent); }
+
+    /* ── Demo Preview ── */
+    .demo-preview {
+      max-width: var(--max-w); margin: 0 auto 100px; padding: 0 24px;
+    }
+    .demo-frame {
+      background: var(--bg-card); border: 1px solid var(--border); border-radius: 12px;
+      overflow: hidden; box-shadow: 0 0 60px rgba(108, 140, 245, 0.06);
+    }
+    .demo-frame-header {
+      background: var(--bg-elevated); padding: 12px 16px; display: flex; align-items: center;
+      gap: 8px; border-bottom: 1px solid var(--border);
+    }
+    .demo-dot { width: 10px; height: 10px; border-radius: 50%; }
+    .demo-dot.r { background: #ff5f57; } .demo-dot.y { background: #febc2e; } .demo-dot.g { background: #28c840; }
+    .demo-frame-url {
+      flex: 1; text-align: center; font-size: 0.75rem; color: var(--text-muted);
+    }
+    .demo-frame-body {
+      display: grid; grid-template-columns: 220px 1fr; min-height: 420px;
+    }
+    .demo-sidebar {
+      background: var(--bg); border-right: 1px solid var(--border); padding: 16px 12px;
+    }
+    .demo-sidebar-item {
+      padding: 8px 12px; border-radius: 6px; font-size: 0.85rem; color: var(--text-muted);
+      margin-bottom: 4px; display: flex; align-items: center; gap: 8px;
+    }
+    .demo-sidebar-item.active { background: var(--bg-elevated); color: var(--text); }
+    .demo-sidebar-item .hash { color: var(--text-muted); font-weight: 700; }
+    .demo-main {
+      padding: 20px; display: flex; flex-direction: column;
+    }
+    .demo-message {
+      display: flex; gap: 12px; margin-bottom: 18px; align-items: flex-start;
+    }
+    .demo-avatar {
+      width: 36px; height: 36px; border-radius: 50%; flex-shrink: 0;
+    }
+    .demo-avatar.p1 { background: linear-gradient(135deg, #6c8cf5, #4a6dd4); }
+    .demo-avatar.p2 { background: linear-gradient(135deg, #f56c9e, #d44a7a); }
+    .demo-avatar.p3 { background: linear-gradient(135deg, #5ed9a0, #3ab87a); }
+    .demo-msg-content { flex: 1; }
+    .demo-msg-name { font-weight: 700; font-size: 0.9rem; margin-bottom: 2px; }
+    .demo-msg-name .time { font-weight: 400; color: var(--text-muted); font-size: 0.75rem; margin-left: 8px; }
+    .demo-msg-text { font-size: 0.875rem; color: var(--text-muted); line-height: 1.5; }
+    .demo-msg-reactions { display: flex; gap: 6px; margin-top: 8px; }
+    .demo-reaction {
+      background: var(--bg-elevated); border: 1px solid var(--border); padding: 2px 8px;
+      border-radius: 6px; font-size: 0.8rem; color: var(--text-muted);
+    }
+    .demo-input {
+      margin-top: auto; background: var(--bg); border: 1px solid var(--border);
+      border-radius: 8px; padding: 10px 14px; color: var(--text-muted); font-size: 0.85rem;
+    }
+
+    /* ── Sections ── */
+    section { padding: 80px 24px; }
+    .section-inner { max-width: var(--max-w); margin: 0 auto; }
+    .section-label {
+      display: inline-block; color: var(--accent); font-size: 0.8rem; font-weight: 700;
+      text-transform: uppercase; letter-spacing: 0.1em; margin-bottom: 12px;
+    }
+    .section-title { font-size: 2.2rem; font-weight: 800; margin-bottom: 16px; letter-spacing: -0.02em; }
+    .section-subtitle { color: var(--text-muted); font-size: 1.05rem; max-width: 560px; }
+
+    /* ── Features Grid ── */
+    .features-grid {
+      display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 24px; margin-top: 48px;
+    }
+    .feature-card {
+      background: var(--bg-card); border: 1px solid var(--border); border-radius: 12px;
+      padding: 28px; transition: border-color .2s;
+    }
+    .feature-card:hover { border-color: var(--accent); }
+    .feature-icon {
+      width: 44px; height: 44px; border-radius: 10px; background: var(--accent-glow);
+      display: flex; align-items: center; justify-content: center; margin-bottom: 16px;
+      font-size: 1.3rem;
+    }
+    .feature-card h3 { font-size: 1.1rem; font-weight: 700; margin-bottom: 8px; }
+    .feature-card p { color: var(--text-muted); font-size: 0.9rem; line-height: 1.6; }
+
+    /* ── Screenshots ── */
+    .screenshots-grid {
+      display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+      gap: 20px; margin-top: 48px;
+    }
+    .screenshot-card {
+      background: var(--bg-card); border: 1px solid var(--border); border-radius: 12px;
+      overflow: hidden;
+    }
+    .screenshot-placeholder {
+      aspect-ratio: 16/10; background: var(--bg-elevated);
+      display: flex; align-items: center; justify-content: center;
+      color: var(--text-muted); font-size: 0.85rem;
+    }
+    .screenshot-card p { padding: 12px 16px; font-size: 0.85rem; color: var(--text-muted); }
+
+    /* ── Docs Section ── */
+    .docs-section { background: var(--bg-card); border-top: 1px solid var(--border); border-bottom: 1px solid var(--border); }
+    .docs-links { display: flex; gap: 16px; margin-top: 32px; flex-wrap: wrap; }
+    .docs-link {
+      background: var(--bg-elevated); border: 1px solid var(--border); border-radius: var(--radius);
+      padding: 16px 24px; text-decoration: none; color: var(--text); display: flex; align-items: center;
+      gap: 12px; font-weight: 600; transition: border-color .2s; min-width: 200px;
+    }
+    .docs-link:hover { border-color: var(--accent); }
+    .docs-link-icon { font-size: 1.3rem; }
+
+    /* ── CTA ── */
+    .cta-section { text-align: center; }
+    .cta-section .section-title { margin-bottom: 8px; }
+    .cta-section .section-subtitle { margin: 0 auto 32px; }
+    .cta-actions { display: flex; gap: 14px; justify-content: center; flex-wrap: wrap; }
+
+    /* ── Footer ── */
+    footer {
+      border-top: 1px solid var(--border); padding: 32px 24px; text-align: center;
+      color: var(--text-muted); font-size: 0.8rem;
+    }
+    footer a { color: var(--accent); text-decoration: none; }
+
+    /* ── Responsive ── */
+    @media (max-width: 640px) {
+      .hero h1 { font-size: 2rem; }
+      .section-title { font-size: 1.6rem; }
+      .demo-frame-body { grid-template-columns: 1fr; }
+      .demo-sidebar { display: none; }
+      .nav-links { display: none; }
+    }
+  </style>
+</head>
+<body>
+
+<nav>
+  <div class="nav-inner">
+    <a href="/" class="nav-logo"><span>⚓</span> Skerry</a>
+    <div class="nav-links">
+      <a href="#features">Features</a>
+      <a href="#screenshots">Screenshots</a>
+      <a href="#docs">Docs</a>
+      <a href="https://github.com/SecareLupus/Skerry">GitHub</a>
+    </div>
+    <a href="https://app.skerry.chat" class="nav-cta">Launch App</a>
+  </div>
+</nav>
+
+<section class="hero">
+  <div class="hero-badge">Now in Alpha</div>
+  <h1>The <span>Creator Co-Op Hub</span> — sovereign, federated, real-time.</h1>
+  <p>
+    Discord-like chat, voice, and video, built on Matrix.
+    Own your community. Bridge to Discord. No walled gardens.
+  </p>
+  <div class="hero-actions">
+    <a href="https://app.skerry.chat" class="btn-primary">Try the Demo</a>
+    <a href="https://github.com/SecareLupus/Skerry" class="btn-secondary">View on GitHub</a>
+  </div>
+</section>
+
+<div class="demo-preview">
+  <div class="demo-frame">
+    <div class="demo-frame-header">
+      <span class="demo-dot r"></span>
+      <span class="demo-dot y"></span>
+      <span class="demo-dot g"></span>
+      <span class="demo-frame-url">app.skerry.chat — #general</span>
+    </div>
+    <div class="demo-frame-body">
+      <div class="demo-sidebar">
+        <div style="font-size:0.75rem;text-transform:uppercase;color:var(--text-muted);padding:4px 12px 8px;letter-spacing:0.05em">Co-Op Hub</div>
+        <div class="demo-sidebar-item"><span class="hash">#</span> general</div>
+        <div class="demo-sidebar-item active"><span class="hash">#</span> announcements</div>
+        <div class="demo-sidebar-item"><span class="hash">#</span> projects</div>
+        <div class="demo-sidebar-item"><span class="hash">#</span> voice-lounge</div>
+        <div style="font-size:0.75rem;text-transform:uppercase;color:var(--text-muted);padding:16px 12px 8px;letter-spacing:0.05em">Creator Space</div>
+        <div class="demo-sidebar-item"><span class="hash">#</span> general</div>
+        <div class="demo-sidebar-item"><span class="hash">#</span> works-in-progress</div>
+      </div>
+      <div class="demo-main">
+        <div class="demo-message">
+          <div class="demo-avatar p1"></div>
+          <div class="demo-msg-content">
+            <div class="demo-msg-name">PixelGhost<span class="time">Today at 2:34 PM</span></div>
+            <div class="demo-msg-text">Just finished the new sprite sheet for the collab game 🎮 Check it out in #works-in-progress!</div>
+            <div class="demo-msg-reactions">
+              <span class="demo-reaction">🎮 4</span>
+              <span class="demo-reaction">🔥 7</span>
+              <span class="demo-reaction">👀 2</span>
+            </div>
+          </div>
+        </div>
+        <div class="demo-message">
+          <div class="demo-avatar p2"></div>
+          <div class="demo-msg-content">
+            <div class="demo-msg-name">SynthWaves<span class="time">Today at 2:37 PM</span></div>
+            <div class="demo-msg-text">These look incredible! The color palette is chef's kiss. I'll have the soundtrack demo ready by Friday.</div>
+            <div class="demo-msg-reactions">
+              <span class="demo-reaction">🎵 3</span>
+              <span class="demo-reaction">✨ 5</span>
+            </div>
+          </div>
+        </div>
+        <div class="demo-message">
+          <div class="demo-avatar p3"></div>
+          <div class="demo-msg-content">
+            <div class="demo-msg-name">CraftBench<span class="time">Today at 2:42 PM</span></div>
+            <div class="demo-msg-text">Anyone around for a voice jam tonight? We're doing a playtest at 8pm in the voice lounge 🎙️</div>
+            <div class="demo-msg-reactions">
+              <span class="demo-reaction">🎙️ 6</span>
+              <span class="demo-reaction">👍 3</span>
+            </div>
+          </div>
+        </div>
+        <div class="demo-input">Message #announcements</div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<section id="features">
+  <div class="section-inner">
+    <div class="section-label">Why Skerry</div>
+    <h2 class="section-title">Everything you need to run a creator community</h2>
+    <p class="section-subtitle">The UX you love, on infrastructure you control.</p>
+
+    <div class="features-grid">
+      <div class="feature-card">
+        <div class="feature-icon">💬</div>
+        <h3>Discord-like UX</h3>
+        <p>Servers, channels, threads, reactions, pinned messages. Everything your community already knows how to use.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">🌐</div>
+        <h3>Matrix Federation</h3>
+        <p>Built on the Matrix protocol. Users on different Skerry instances can interact. No single point of control.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">🔗</div>
+        <h3>Discord Bridge</h3>
+        <p>Bridge Skerry channels to Discord. Messages flow both ways. Your community stays connected wherever they prefer to be.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">🎙️</div>
+        <h3>Voice &amp; Video</h3>
+        <p>Built-in voice rooms with WebRTC via LiveKit. Hop in, share your screen, stream — no third-party services required.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">🛡️</div>
+        <h3>Scoped Moderation</h3>
+        <p>Hub admins, space owners, moderators. Granular role-based permissions at every level. Audit log tracks everything.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">🔒</div>
+        <h3>Data Sovereignty</h3>
+        <p>Your data lives on your server. End-to-end encryption via Matrix. No telemetry, no tracking, no ads.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="screenshots">
+  <div class="section-inner">
+    <div class="section-label">See It in Action</div>
+    <h2 class="section-title">Screenshots</h2>
+    <p class="section-subtitle">Real screenshots coming soon. Here's what's in place.</p>
+
+    <div class="screenshots-grid">
+      <div class="screenshot-card">
+        <div class="screenshot-placeholder">📸 Chat Interface — coming soon</div>
+        <p>Rich chat with markdown, reactions, threads, and pinned messages.</p>
+      </div>
+      <div class="screenshot-card">
+        <div class="screenshot-placeholder">📸 Voice Room — coming soon</div>
+        <p>Voice &amp; video with LiveKit. Mute, deafen, screen share, push-to-talk.</p>
+      </div>
+      <div class="screenshot-card">
+        <div class="screenshot-placeholder">📸 Admin Dashboard — coming soon</div>
+        <p>Hub settings, space management, audit log, and moderation tools.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="docs" class="docs-section">
+  <div class="section-inner">
+    <div class="section-label">Learn More</div>
+    <h2 class="section-title">Documentation</h2>
+    <p class="section-subtitle">Guides, API reference, and self-hosting instructions.</p>
+
+    <div class="docs-links">
+      <a href="https://github.com/SecareLupus/Skerry/wiki" class="docs-link">
+        <span class="docs-link-icon">📚</span> GitHub Wiki
+      </a>
+      <a href="https://github.com/SecareLupus/Skerry" class="docs-link">
+        <span class="docs-link-icon">⌨️</span> Source Code
+      </a>
+      <a href="https://github.com/SecareLupus/Skerry/issues" class="docs-link">
+        <span class="docs-link-icon">🐛</span> Report a Bug
+      </a>
+    </div>
+  </div>
+</section>
+
+<section class="cta-section">
+  <div class="section-inner">
+    <h2 class="section-title">Ready to try it?</h2>
+    <p class="section-subtitle">The demo server is live. Self-hosting is a Docker Compose up away.</p>
+    <div class="cta-actions">
+      <a href="https://app.skerry.chat" class="btn-primary">Open the Demo</a>
+      <a href="https://github.com/SecareLupus/Skerry#readme" class="btn-secondary">Self-Host Guide</a>
+    </div>
+  </div>
+</section>
+
+<footer>
+  <p>
+    Skerry is open source under the <a href="https://github.com/SecareLupus/Skerry/blob/main/LICENSE">MIT License</a>.
+    Built by <a href="https://github.com/SecareLupus">@SecareLupus</a> and contributors.
+  </p>
+</footer>
+
+</body>
+</html>

--- a/packages/shared/src/domain/contracts.ts
+++ b/packages/shared/src/domain/contracts.ts
@@ -180,6 +180,7 @@ export interface Hub {
     oidcConfig?: Record<string, any>;
     allowSpaceDiscordBridge?: boolean;
     allowSpaceCustomization?: boolean;
+    defaultAutoJoinHubMembers?: boolean;
     suspension?: HubSuspension;
     createdAt: string;
 }


### PR DESCRIPTION
## Changes

### #108 — Per-hub auto-join default
Hub admins can now configure whether new spaces default to
auto-joining all hub members. Previously this was unconditionally true.

- Migration 041: adds `default_auto_join_hub_members` to hubs (default true)
- New field on Hub type, provisioning-service reads hub default
- Hub Settings UI: checkbox toggle in hub admin settings

### Landing Page
- `docs/index.html` — full marketing page for skerry.chat
- Hero, feature cards, chat mockup, screenshot placeholders, docs links
- CNAME file for custom domain
- GitHub Pages already enabled (serving from docs/ on main)

## Verification
- Typecheck: all 3 packages pass
- E2E: 33/33 passing