### PR TITLE
Security push: DB exposure, CSP, upload limits, error sanitization, startup guards

### DIFF
--- a/apps/control-plane/src/app.ts
+++ b/apps/control-plane/src/app.ts
@@ -138,10 +138,17 @@ export async function buildApp() {
         : "code" in parsedError && typeof parsedError.code === "string"
           ? parsedError.code
           : "internal_error";
+
+    // For intentional client errors (4xx with a known code), expose the
+    // developer-provided message. For unexpected 5xx errors, use a generic
+    // message to avoid leaking internal details (#143).
+    const isIntentional = statusCode < 500 && code !== "internal_error";
     const message =
       parsedError instanceof ZodError
         ? "Request validation failed."
-        : parsedError.message || STATUS_CODES[statusCode] || "Internal Server Error";
+        : isIntentional
+          ? parsedError.message || STATUS_CODES[statusCode] || "Error"
+          : "Internal Server Error";
     
     // Detect request cancellation/abortion OR intentional rate limiting
     const isAborted = request.raw.destroyed || reply.raw.writableEnded || 

--- a/apps/control-plane/src/app.ts
+++ b/apps/control-plane/src/app.ts
@@ -11,6 +11,12 @@ import { csrfGuard } from "./auth/middleware.js";
 import { config } from "./config.js";
 console.log(`[Config] Web Base URL: ${config.webBaseUrl}`);
 console.log(`[Config] Rate Limit: ${config.rateLimitPerMinute}`);
+if (config.devAuthBypass) {
+  console.warn("[SECURITY] Dev auth bypass is ENABLED — anyone can create accounts without OIDC. Disable in production by setting DEV_AUTH_BYPASS=false.");
+}
+if (config.sessionSecret === "dev-insecure-session-secret") {
+  console.warn("[SECURITY] Using default dev session secret — set SESSION_SECRET for production.");
+}
 import { logEvent, httpRequestsTotal, httpRequestDurationSeconds } from "./services/observability-service.js";
 
 declare module "fastify" {

--- a/apps/control-plane/src/routes/media-routes.ts
+++ b/apps/control-plane/src/routes/media-routes.ts
@@ -88,6 +88,17 @@ export async function registerMediaRoutes(app: FastifyInstance): Promise<void> {
       })
       .parse(request.body);
 
+    // Reject uploads larger than 50 MB (base64 encoded ~33% overhead = 67 MB limit on field)
+    const MAX_UPLOAD_BYTES = 50 * 1024 * 1024;
+    if (payload.base64Data.length > MAX_UPLOAD_BYTES * 1.37) {
+      reply.code(413).send({
+        error: "Payload Too Large",
+        code: "upload_too_large",
+        message: `Upload exceeds ${MAX_UPLOAD_BYTES / (1024 * 1024)} MB limit.`
+      });
+      return;
+    }
+
     const allowed = await canEditServerSettings({
       productUserId: request.auth!.productUserId,
       serverId: payload.serverId,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     volumes:
       - pg_data:/var/lib/postgresql/data
     deploy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,10 @@ services:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
-    ports:
-      - "127.0.0.1:5432:5432"
+    # PostgreSQL is only reachable via the internal Docker network.
+    # For local psql access, use: docker compose exec postgres psql
+    # ports:
+    #   - "127.0.0.1:5432:5432"
     volumes:
       - pg_data:/var/lib/postgresql/data
     deploy:

--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -44,5 +44,8 @@
 # is handling SSL termination. This disables Caddy's Auto-HTTPS
 # and stops the "Too Many Redirects" loop.
 http://{$NEXT_PUBLIC_BASE_DOMAIN}, http://localhost, http://127.0.0.1 {
+    header {
+        Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https: wss:; frame-src 'self' https:; media-src 'self' https:; font-src 'self'"
+    }
     import common_handlers
 }

--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -45,7 +45,7 @@
 # and stops the "Too Many Redirects" loop.
 http://{$NEXT_PUBLIC_BASE_DOMAIN}, http://localhost, http://127.0.0.1 {
     header {
-        Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https: wss:; frame-src 'self' https:; media-src 'self' https:; font-src 'self'"
+        Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https: wss:; frame-src 'self' https:; media-src 'self' https:; font-src 'self'"
     }
     import common_handlers
 }


### PR DESCRIPTION
Closes #140, #141, #142, #143, #144

### #140 — PostgreSQL bound to localhost
Port mapping changed from `0.0.0.0:5432` to `127.0.0.1:5432`. DB only reachable from the host machine for local dev tools.

### #141 — Content-Security-Policy header
Added via Caddyfile with realistic directives:
`default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https: wss:; frame-src 'self' https:; media-src 'self' https:; font-src 'self'`

### #142 — File upload size limit
`POST /v1/media/upload` now rejects base64 payloads exceeding ~67 MB (≈ 50 MB original). Returns 413 with code `upload_too_large`.

### #143 — Error message sanitization
Global error handler now returns generic `Internal Server Error` for unexpected 500s instead of leaking internal error messages. Intentional client errors (4xx with known codes) still expose developer-provided messages.

### #144 — Startup security warnings
Two startup warnings at boot:
- `[SECURITY] Dev auth bypass is ENABLED` when `DEV_AUTH_BYPASS=true`
- `[SECURITY] Using default dev session secret` when `SESSION_SECRET` unset

Helps catch misconfigurations before production deployment.