### PR TITLE
Cleanup: remove debug console.logs and eliminate 15 unsafe any casts

### DIFF
--- a/apps/control-plane/src/app.ts
+++ b/apps/control-plane/src/app.ts
@@ -75,7 +75,6 @@ export async function buildApp() {
   });
 
   app.addHook("onRequest", async (request) => {
-    console.log(`[DEBUG] Incoming Request: ${request.method} ${request.url}`);
     request.startTime = Date.now();
   });
 

--- a/apps/control-plane/src/app.ts
+++ b/apps/control-plane/src/app.ts
@@ -107,22 +107,28 @@ export async function buildApp() {
   app.addHook("preHandler", csrfGuard);
 
   app.setErrorHandler((error, request, reply) => {
-    // Determine if it's a real Error or something else (like a string or plain object)
-    const isStandardError = error instanceof Error;
-    
-    // Extract info from raw object if available
-    const rawStatusCode = (error as any)?.statusCode || (error as any)?.status;
-    const rawCode = (error as any)?.code;
-    const rawMessage = (error as any)?.message;
-
-    const parsedError = isStandardError ? error : new Error(typeof error === 'string' ? error : rawMessage || JSON.stringify(error) || "Unknown Error");
-    
-    // Propagate raw properties to the parsed error
-    if (!isStandardError) {
-      if (rawStatusCode) (parsedError as any).statusCode = rawStatusCode;
-      if (rawCode) (parsedError as any).code = rawCode;
-      Object.assign(parsedError, { raw: error });
+    // Errors can carry extra properties beyond the Error prototype:
+    // statusCode, code, message from Fastify/Zod, etc.
+    interface StructuredError extends Error {
+      statusCode?: number;
+      status?: number;
+      code?: string;
+      raw?: unknown;
     }
+    const structured = error as StructuredError;
+    const isStandardError = error instanceof Error;
+
+    // Extract info from raw object if available
+    const rawStatusCode = structured.statusCode ?? structured.status;
+    const rawCode = structured.code;
+    const rawMessage = structured.message;
+
+    const parsedError: StructuredError = isStandardError
+      ? structured
+      : Object.assign(
+          new Error(typeof error === 'string' ? error : rawMessage || JSON.stringify(error) || "Unknown Error"),
+          { statusCode: rawStatusCode, code: rawCode, raw: error }
+        );
 
     const statusCode = (() => {
       if (parsedError instanceof ZodError) {
@@ -131,8 +137,8 @@ export async function buildApp() {
       if (rawStatusCode && typeof rawStatusCode === "number") {
         return rawStatusCode;
       }
-      if ("statusCode" in parsedError && typeof (parsedError as any).statusCode === "number") {
-        return (parsedError as any).statusCode;
+      if (parsedError.statusCode && typeof parsedError.statusCode === "number") {
+        return parsedError.statusCode;
       }
       return 500;
     })();
@@ -140,7 +146,7 @@ export async function buildApp() {
     const code =
       parsedError instanceof ZodError
         ? "validation_error"
-        : "code" in parsedError && typeof parsedError.code === "string"
+        : parsedError.code && typeof parsedError.code === "string"
           ? parsedError.code
           : "internal_error";
 
@@ -154,11 +160,11 @@ export async function buildApp() {
         : isIntentional
           ? parsedError.message || STATUS_CODES[statusCode] || "Error"
           : "Internal Server Error";
-    
+
     // Detect request cancellation/abortion OR intentional rate limiting
-    const isAborted = request.raw.destroyed || reply.raw.writableEnded || 
-                     parsedError.message?.includes("aborted") || 
-                     (parsedError as any).code === "ECONNRESET" ||
+    const isAborted = request.raw.destroyed || reply.raw.writableEnded ||
+                     parsedError.message?.includes("aborted") ||
+                     ("code" in parsedError && (parsedError as StructuredError).code === "ECONNRESET") ||
                      statusCode === 429;
 
     // Log full error for 500s to allow diagnostics, but skip for aborted/throttled requests

--- a/apps/control-plane/src/auth/session.ts
+++ b/apps/control-plane/src/auth/session.ts
@@ -93,7 +93,6 @@ function secureFlag(reply: FastifyReply): string {
 export function getSession(request: FastifyRequest): SessionPayload | null {
   const cookieHeader = request.headers.cookie;
   if (!cookieHeader) {
-    console.log(`[AUTH DEBUG] No cookie header for ${request.method} ${request.url} id=${request.id}`);
     return null;
   }
 
@@ -103,15 +102,11 @@ export function getSession(request: FastifyRequest): SessionPayload | null {
 
   const raw = skerryRaw || legacyRaw;
   if (!raw) {
-    console.log(`[AUTH DEBUG] session missing in header for ${request.method} ${request.url} id=${request.id}`);
     return null;
   }
 
   const token = raw.replace("skerry_session=", "").replace("escapehatch_session=", "");
   const payload = verify(token);
-  if (!payload) {
-    console.log(`[AUTH DEBUG] Session token verification failed for ${request.method} ${request.url} id=${request.id}`);
-  }
   return payload;
 }
 

--- a/apps/control-plane/src/services/discord-bot-client.ts
+++ b/apps/control-plane/src/services/discord-bot-client.ts
@@ -3,6 +3,13 @@ import { config } from "../config.js";
 import { relayDiscordMessageToMappedChannel } from "./discord-bridge-service.js";
 import { logEvent } from "./observability-service.js";
 import { withDb } from "../db/client.js";
+
+/** Discord thread channels expose parentId even though the base Channel type doesn't. */
+interface ChannelWithParent { parentId: string; }
+
+function parentIdOf(channel: { isThread(): boolean } & { parentId?: string | null }): string | undefined {
+  return channel.isThread() ? (channel as ChannelWithParent).parentId : undefined;
+}
 import fs from "node:fs";
 import path from "node:path";
 import { findEmojiByName } from "./chat/emoji-service.js";
@@ -56,7 +63,7 @@ export async function startDiscordBot() {
             if (message.author.bot) return;
 
             // Find all servers that have a mapping for this Discord channel (or its parent if it's a thread)
-            const discordChannelIdForMapping = message.channel.isThread() ? (message.channel as any).parentId : message.channelId;
+            const discordChannelIdForMapping = parentIdOf(message.channel) ?? message.channelId;
             const serverIds = await withDb(async (db) => {
                 const rows = await db.query<{ server_id: string }>(
                     "select server_id from discord_bridge_channel_mappings where guild_id = $1 and discord_channel_id = $2 and enabled = true",
@@ -125,7 +132,7 @@ export async function startDiscordBot() {
 
                     await relayDiscordMessageToMappedChannel({
                         serverId,
-                        discordChannelId: message.channel.isThread() ? (message.channel as any).parentId : message.channelId,
+                        discordChannelId: parentIdOf(message.channel) ?? message.channelId,
                         authorId: message.author.id,
                         authorName: message.member?.displayName ?? message.author.displayName ?? message.author.username,
                         authorAvatarUrl: message.author.displayAvatarURL({ extension: 'webp', size: 128 }),
@@ -184,7 +191,7 @@ export async function startDiscordBot() {
 
             if (!contentChanged && !pinChanged) return;
 
-            const discordChannelIdForMapping = newMessage.channel.isThread() ? (newMessage.channel as any).parentId : newMessage.channelId;
+            const discordChannelIdForMapping = parentIdOf(newMessage.channel) ?? newMessage.channelId;
             const serverIds = await withDb(async (db) => {
                 const rows = await db.query<{ server_id: string }>(
                     "select server_id from discord_bridge_channel_mappings where guild_id = $1 and discord_channel_id = $2 and enabled = true",
@@ -243,7 +250,7 @@ export async function startDiscordBot() {
 
             if (message.author?.bot) return;
 
-            const discordChannelIdForMapping = message.channel.isThread() ? (message.channel as any).parentId : channelId;
+            const discordChannelIdForMapping = parentIdOf(message.channel) ?? channelId;
             const serverIds = await withDb(async (db) => {
                 const rows = await db.query<{ server_id: string }>(
                     "select server_id from discord_bridge_channel_mappings where guild_id = $1 and discord_channel_id = $2 and enabled = true",
@@ -283,7 +290,7 @@ export async function startDiscordBot() {
             const emoji = encodeDiscordReactionEmoji(reaction.emoji);
             if (!emoji) return;
 
-            const discordChannelIdForMapping = message.channel.isThread() ? (message.channel as any).parentId : channelId;
+            const discordChannelIdForMapping = parentIdOf(message.channel) ?? channelId;
             const serverIds = await withDb(async (db) => {
                 const rows = await db.query<{ server_id: string }>(
                     "select server_id from discord_bridge_channel_mappings where guild_id = $1 and discord_channel_id = $2 and enabled = true",
@@ -342,7 +349,7 @@ export async function startDiscordBot() {
             const emoji = encodeDiscordReactionEmoji(reaction.emoji);
             if (!emoji) return;
 
-            const discordChannelIdForMapping = message.channel.isThread() ? (message.channel as any).parentId : message.channelId;
+            const discordChannelIdForMapping = parentIdOf(message.channel) ?? message.channelId;
             const serverIds = await withDb(async (db) => {
                 const rows = await db.query<{ server_id: string }>(
                     "select server_id from discord_bridge_channel_mappings where guild_id = $1 and discord_channel_id = $2 and enabled = true",
@@ -388,7 +395,7 @@ export async function startDiscordBot() {
         client.on(Events.TypingStart, async (typing) => {
             if (typing.user.bot) return;
 
-            const discordChannelIdForMapping = typing.channel.isThread() ? (typing.channel as any).parentId : typing.channel.id;
+            const discordChannelIdForMapping = parentIdOf(typing.channel) ?? typing.channel.id;
             const serverIds = await withDb(async (db) => {
                 const rows = await db.query<{ server_id: string }>(
                     "select server_id from discord_bridge_channel_mappings where guild_id = $1 and discord_channel_id = $2 and enabled = true",

--- a/apps/web/components/chat-client.tsx
+++ b/apps/web/components/chat-client.tsx
@@ -296,9 +296,6 @@ export function ChatClient() {
   } = mutations;
 
   const dispatch = useCallback((action: any) => {
-    if (action.type?.startsWith("SET_VOICE_") || action.type === "SET_LOADING") {
-      console.log("[ChatClient] DISPATCH:", action.type, action.payload);
-    }
     originalDispatch(action);
   }, [originalDispatch]);
 
@@ -598,12 +595,6 @@ export function ChatClient() {
 
     // 5. If we reach here, the URL has DRIFTED to an unexpected value.
     // This is likely user navigation (Back/Forward). Sync back to the URL.
-    console.log("[ChatClient] True URL drift detected! Syncing state to URL.", { 
-      current: currentUrlSelection, 
-      previous: previousUrlRef.current,
-      target: targetUrlSelectionRef.current,
-      state: stateUrlMapping
-    });
 
     targetUrlSelectionRef.current = null;
     previousUrlRef.current = currentUrlSelection;

--- a/apps/web/components/chat-window.tsx
+++ b/apps/web/components/chat-window.tsx
@@ -825,7 +825,7 @@ export function ChatWindow({
                 label: "Direct Message",
                 icon: "message-square",
                 onClick: () => {
-                    console.log("DM user", userContextMenu.userId);
+                    // TODO: implement DM creation from user context menu
                 }
             }
         ];
@@ -835,7 +835,7 @@ export function ChatWindow({
                 label: "Ignore / Block",
                 icon: "ban",
                 onClick: () => {
-                    console.log("Block user", userContextMenu.userId);
+                    // TODO: implement block from user context menu
                 }
             });
         }

--- a/apps/web/components/gif-player.tsx
+++ b/apps/web/components/gif-player.tsx
@@ -45,7 +45,6 @@ export function GifPlayer({ src, alt, className, style, onClick }: GifPlayerProp
             style={style}
             onClick={onClick}
             onError={() => {
-                console.log("GifPlayer: Image failed, trying video fallback", src);
                 setUseVideo(true);
             }}
         />

--- a/apps/web/hooks/use-chat-mutations.ts
+++ b/apps/web/hooks/use-chat-mutations.ts
@@ -82,19 +82,14 @@ export function useChatMutations({
     const firstHub = hubs?.[0];
     if (!effectiveHubId && hubs && hubs.length === 1 && firstHub) {
         effectiveHubId = firstHub.id;
-        console.log('[handleCreateSpace] Auto-selecting single available hub:', effectiveHubId);
     }
 
-    console.log('[handleCreateSpace] Submitting...', { effectiveHubId, spaceName });
-    
     if (!effectiveHubId || !spaceName.trim()) {
       const errorMsg = !effectiveHubId ? "No hub selected" : "Space name is empty";
       console.warn(`[handleCreateSpace] Aborting: ${errorMsg} (hubs count: ${hubs?.length ?? 0}, selectedHubId: ${selectedHubIdForCreate})`);
       showToast(`Please select a hub and enter a space name (${errorMsg})`, "error");
       return;
     }
-
-    console.log(`[handleCreateSpace] Initiating creation on hub: ${effectiveHubId} name: ${spaceName}`);
 
     dispatch({ type: "SET_CREATING_SPACE", payload: true });
     dispatch({ type: "SET_ERROR", payload: null });


### PR DESCRIPTION
Closes #51, #52

### #51 — Remove debug console.log calls
- app.ts: [DEBUG] Incoming Request on every HTTP request (noisiest)
- session.ts: [AUTH DEBUG] on every unauthenticated request (x3)
- chat-client.tsx: [ChatClient] DISPATCH on state changes + URL drift log
- chat-window.tsx: DM/Block user stub logs
- gif-player.tsx: GifPlayer fallback log
- use-chat-mutations.ts: create-space flow debug logs (x3)

Kept: startup config, security warnings, structured logEvent output, warning/error-level logging.

### #52 — Eliminate unsafe any/as-any casts (15 eliminated)
- app.ts error handler: 8 as-any -> typed `StructuredError` interface
- discord-bot-client.ts: 7 (channel as any).parentId -> `parentIdOf()` helper with `ChannelWithParent` interface

Net: 274 -> 259 remaining