### PR TITLE
feat: auto-tag on release + code dedup (#56, #146)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -59,13 +59,20 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.REPO_OWNER }}/skerry-${{ matrix.target.name }}:${{ github.event.inputs.version }}
             ${{ env.REGISTRY }}/${{ env.REPO_OWNER }}/skerry-${{ matrix.target.name }}:latest
 
-  package-deploy-kit:
+  release:
     needs: build-and-push
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Create git tag
+        run: |
+          git tag ${{ github.event.inputs.version }}
+          git push origin ${{ github.event.inputs.version }}
 
       - name: Package deploy kit
         run: |

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,9 +10,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  # <owner>/<repo> in lowercase — GHCR requires images to match the owner
   REPO_OWNER: ${{ github.repository_owner }}
-  # BuildKit for multi-stage monorepo caching
   DOCKER_BUILDKIT: 1
 
 jobs:
@@ -53,7 +51,6 @@ jobs:
           file: ./Dockerfile
           target: ${{ matrix.target.docker-target }}
           push: true
-          # Caching — store in GHCR to share between targets
           cache-from: |
             type=registry,ref=${{ env.REGISTRY }}/${{ env.REPO_OWNER }}/skerry-${{ matrix.target.name }}:buildcache
           cache-to: |
@@ -61,3 +58,22 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ env.REPO_OWNER }}/skerry-${{ matrix.target.name }}:${{ github.event.inputs.version }}
             ${{ env.REGISTRY }}/${{ env.REPO_OWNER }}/skerry-${{ matrix.target.name }}:latest
+
+  package-deploy-kit:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Package deploy kit
+        run: |
+          tar -czf skerry-deploy-${{ github.event.inputs.version }}.tar.gz deploy/
+
+      - name: Upload deploy kit
+        uses: actions/upload-artifact@v4
+        with:
+          name: skerry-deploy-${{ github.event.inputs.version }}
+          path: skerry-deploy-${{ github.event.inputs.version }}.tar.gz
+          retention-days: 90

--- a/README.md
+++ b/README.md
@@ -56,6 +56,21 @@ When running via Docker Compose, services communicate using service names as hos
 
 ## Quick Start (Docker)
 
+### Using the Deploy Kit (recommended)
+
+Download the latest deploy kit from the [releases page](https://github.com/SecareLupus/Skerry/releases):
+
+```bash
+tar -xzf skerry-deploy-v0.1.0-alpha.tar.gz
+cd deploy
+cp .env.example .env
+# Edit .env with your domain and OAuth credentials
+chmod +x scripts/bootstrap-hub.sh
+./scripts/bootstrap-hub.sh
+```
+
+### From Source (development)
+
 ```bash
 pnpm install
 cp .env.example .env

--- a/README.md
+++ b/README.md
@@ -96,24 +96,19 @@ This generates unique secrets, pulls images, runs migrations, and starts the ent
 
 Docker images are published to GitHub Container Registry (GHCR) on manual release, not on push to main.
 
-1. **Tag the release**:
-   ```bash
-   git tag v0.1.0-alpha
-   git push --tags
-   ```
+1. **Publish**: Run the **Publish Docker Images** workflow via GitHub Actions → `workflow_dispatch` with a version tag (e.g. `v0.1.0-alpha`). This:
+   - Creates the git tag on main
+   - Builds and pushes three images to `ghcr.io/secarelupus/`:
+     - `skerry-control-plane:{version}`
+     - `skerry-web:{version}`
+     - `skerry-sticker-renderer:{version}`
+   - Uploads the deploy kit as a workflow artifact
 
-2. **Publish images**: Run the **Publish Docker Images** workflow via GitHub Actions → `workflow_dispatch` with the version tag (e.g. `v0.1.0-alpha`). Publishes three images to `ghcr.io/secarelupus/`:
-   - `skerry-control-plane:v0.1.0-alpha`
-   - `skerry-web:v0.1.0-alpha`
-   - `skerry-sticker-renderer:v0.1.0-alpha`
-
-3. **Deploy**: Update `SKERRY_VERSION` in `.env` (or the compose file directly), then:
+2. **Deploy**: Download the deploy kit from the workflow artifacts, update `SKERRY_VERSION` in `.env`, then:
    ```bash
    docker compose pull
    docker compose up -d
    ```
-
-To pin a specific version in production, set `SKERRY_VERSION=v0.1.0-alpha` in `.env`. The compose file defaults to `v0.1.0-alpha` when unset.
 
 ## Development
 

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,0 +1,85 @@
+# Full Stack Docker Configuration (Recommended)
+# If BASE_DOMAIN is set, nearly all other URLs are derived automatically.
+BASE_DOMAIN=your-domain.com
+EMAIL=your-email@example.com
+POSTGRES_PASSWORD=temporary_battery_horse_staple_password
+
+# ==========================================
+# Overrides (Optional)
+# ==========================================
+# Only override these if you are NOT using the default Docker setup.
+DATABASE_URL=
+SYNAPSE_BASE_URL=
+LIVEKIT_URL=
+
+# ==========================================
+# Chat & Media (Synapse)
+# ==========================================
+# Internal API access
+SYNAPSE_BASE_URL=http://synapse:8008
+SYNAPSE_AS_TOKEN=
+SYNAPSE_HS_TOKEN=
+SYNAPSE_AS_REGISTRATION_PATH=../../docker/synapse/skerry-appservice.yaml
+SYNAPSE_STRICT_PROVISIONING=false
+
+# Public Download URL (Derived from BASE_DOMAIN if not provided)
+SYNAPSE_PUBLIC_URL=
+
+# ==========================================
+# Voice & Video (LiveKit)
+# ==========================================
+# Internal signaling
+LIVEKIT_URL=ws://livekit:7880
+LIVEKIT_API_KEY=devkey
+LIVEKIT_API_SECRET=secret
+
+# Public Connection URL (Derived from BASE_DOMAIN if not provided)
+LIVEKIT_PUBLIC_URL=
+
+# Security
+SFU_TOKEN_TTL_SECONDS=300
+
+# ==========================================
+# Authentication (OIDC)
+# ==========================================
+# Primary login provider
+OIDC_DISCORD_CLIENT_ID=
+OIDC_DISCORD_CLIENT_SECRET=
+
+# Google OIDC (Optional)
+OIDC_GOOGLE_CLIENT_ID=
+OIDC_GOOGLE_CLIENT_SECRET=
+
+# Twitch OIDC (Optional)
+OIDC_TWITCH_CLIENT_ID=
+OIDC_TWITCH_CLIENT_SECRET=
+
+# Keycloak (Optional/Future)
+# If BASE_DOMAIN is set, this is derived as keycloak.${BASE_DOMAIN}
+OIDC_KEYCLOAK_ISSUER=
+OIDC_KEYCLOAK_CLIENT_ID=escapehatch-web
+OIDC_KEYCLOAK_CLIENT_SECRET=
+
+# Discord Bridge (Optional)
+# Requires a Bot Token for message relay/sync
+DISCORD_BRIDGE_CLIENT_ID=
+DISCORD_BRIDGE_CLIENT_SECRET=
+DISCORD_BRIDGE_BOT_TOKEN=
+
+# ==========================================
+# Storage (S3)
+# ==========================================
+S3_BUCKET=
+S3_REGION=us-east-1
+S3_ENDPOINT=
+S3_ACCESS_KEY_ID=
+S3_SECRET_ACCESS_KEY=
+S3_PUBLIC_URL_PREFIX=
+
+# Development & Debugging
+# ==========================================
+DEV_AUTH_BYPASS=false
+SETUP_BOOTSTRAP_ENABLED=true
+SETUP_BOOTSTRAP_TOKEN=
+LOG_FILE_PATH=
+RATE_LIMIT_PER_MINUTE=240

--- a/deploy/.gitignore
+++ b/deploy/.gitignore
@@ -1,0 +1,9 @@
+# Generated at runtime — do not commit
+docker/synapse/*.signing.key
+docker/synapse/*.db
+docker/synapse/*.db-*
+docker/synapse/media_store/
+docker/synapse/skerry-appservice.yaml
+
+# User's actual environment
+.env

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,78 @@
+# Skerry Deployment Kit
+
+This directory contains everything needed to deploy a Skerry Hub from
+pre-built Docker images on GitHub Container Registry.
+
+## Files
+
+```
+.
+├── docker-compose.yml              # Service orchestration (uses GHCR images)
+├── .env.example                    # Environment template → copy to .env
+├── docker/
+│   ├── Caddyfile                   # Reverse proxy routing
+│   └── synapse/
+│       ├── homeserver.yaml         # Synapse Matrix config
+│       ├── hub-localhost.log.config
+│       └── setup-synapse.sh        # Signing key generator
+├── scripts/
+│   ├── bootstrap-hub.sh            # One-command setup
+│   └── backup-db.sh                # PostgreSQL backup (daily cron)
+└── README.md
+```
+
+## Quick Start
+
+```bash
+# 1. Configure
+cp .env.example .env
+# Edit .env with your domain and OAuth credentials
+
+# 2. Bootstrap (generates secrets, pulls images, runs migrations, starts)
+chmod +x scripts/bootstrap-hub.sh
+./scripts/bootstrap-hub.sh
+```
+
+Or step by step:
+
+```bash
+cp .env.example .env
+# Edit .env — set BASE_DOMAIN and OAuth credentials at minimum
+
+# Generate Synapse signing key
+bash docker/synapse/setup-synapse.sh
+
+# Pull images
+docker compose pull
+
+# Start
+docker compose up -d
+```
+
+## Access
+
+- **Web UI**: `http://localhost` (or your `BASE_DOMAIN`)
+- **Health check**: `http://localhost/health`
+- **Metrics**: `http://localhost/metrics` (if `METRICS_TOKEN` configured)
+
+## Upgrading
+
+```bash
+# Edit .env and bump SKERRY_VERSION
+SKERRY_VERSION=v0.2.0-alpha docker compose pull
+docker compose up -d
+```
+
+## Requirements
+
+- Docker Engine 24+ with Compose v2
+- A domain name (for OAuth redirects and federation)
+- Discord application credentials (for login)
+
+## Images
+
+| Image | Registry |
+|-------|----------|
+| `skerry-control-plane` | `ghcr.io/secarelupus/skerry-control-plane` |
+| `skerry-web` | `ghcr.io/secarelupus/skerry-web` |
+| `skerry-sticker-renderer` | `ghcr.io/secarelupus/skerry-sticker-renderer` |

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,189 @@
+services:
+  postgres:
+    image: postgres:16
+    env_file:
+      - .env
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    # PostgreSQL is only reachable via the internal Docker network.
+    # For local psql access, use: docker compose exec postgres psql
+    # ports:
+    #   - "127.0.0.1:5432:5432"
+    volumes:
+      - pg_data:/var/lib/postgresql/data
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  synapse:
+    image: matrixdotorg/synapse:latest
+    env_file:
+      - .env
+    depends_on:
+      - postgres
+    environment:
+      SYNAPSE_SERVER_NAME: hub-localhost
+      SYNAPSE_REPORT_STATS: "no"
+    # Port 8008 is now internal only
+    volumes:
+      - ./docker/synapse:/data
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+
+  livekit:
+    image: livekit/livekit-server:v1.9.11
+    env_file:
+      - .env
+    command: [ "--dev", "--bind", "0.0.0.0" ]
+    # Signaling port 7880 is now internal only
+    ports:
+      - "7881:7881"
+      - "7882:7882/udp"
+
+  coturn:
+    image: coturn/coturn:4.6
+    env_file:
+      - .env
+    command: [ "-n", "--log-file=stdout", "--realm=localhost", "--fingerprint" ]
+    ports:
+      - "3478:3478"
+      - "3478:3478/udp"
+
+  control-plane:
+    image: ghcr.io/secarelupus/skerry-control-plane:${SKERRY_VERSION:-v0.1.0-alpha}
+    networks:
+      - default
+      - backend
+    env_file:
+      - .env
+    environment:
+      - PORT=4000
+      - DATABASE_URL=postgres://postgres:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
+      - NEXT_PUBLIC_BASE_DOMAIN=${BASE_DOMAIN:-localhost}
+      - SESSION_SECRET=${SESSION_SECRET}
+      - OIDC_DISCORD_CLIENT_ID=${OIDC_DISCORD_CLIENT_ID}
+      - OIDC_DISCORD_CLIENT_SECRET=${OIDC_DISCORD_CLIENT_SECRET}
+      - OIDC_GOOGLE_CLIENT_ID=${OIDC_GOOGLE_CLIENT_ID}
+      - OIDC_GOOGLE_CLIENT_SECRET=${OIDC_GOOGLE_CLIENT_SECRET}
+      - OIDC_TWITCH_CLIENT_ID=${OIDC_TWITCH_CLIENT_ID}
+      - OIDC_TWITCH_CLIENT_SECRET=${OIDC_TWITCH_CLIENT_SECRET}
+      - DISCORD_BRIDGE_CLIENT_ID=${DISCORD_BRIDGE_CLIENT_ID}
+      - DISCORD_BRIDGE_CLIENT_SECRET=${DISCORD_BRIDGE_CLIENT_SECRET}
+      - DISCORD_BRIDGE_BOT_TOKEN=${DISCORD_BRIDGE_BOT_TOKEN}
+      - SYNAPSE_AS_REGISTRATION_PATH=/app/docker/synapse/skerry-appservice.yaml
+    depends_on:
+      - postgres
+      - synapse
+      - livekit
+    volumes:
+      - ./docker/synapse:/app/docker/synapse
+      - sticker_cache:/app/cache/stickers
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+    healthcheck:
+      test: ["CMD", "node", "-e", "const http = require('http'); const req = http.get('http://localhost:4000/health', (res) => { if (res.statusCode === 200) { process.exit(0); } else { process.exit(1); } }); req.on('error', (err) => { process.exit(1); });"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  web:
+    image: ghcr.io/secarelupus/skerry-web:${SKERRY_VERSION:-v0.1.0-alpha}
+    networks:
+      - default
+      - backend
+    env_file:
+      - .env
+    environment:
+      - PORT=3000
+      - NEXT_PUBLIC_BASE_DOMAIN=${BASE_DOMAIN:-localhost}
+    depends_on:
+      - control-plane
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+
+  caddy:
+    image: caddy:latest
+    restart: unless-stopped
+    networks:
+      - default
+      - backend
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./docker/Caddyfile:/etc/caddy/Caddyfile
+      - caddy_data:/data
+      - caddy_config:/config
+    environment:
+      - NEXT_PUBLIC_BASE_DOMAIN=${BASE_DOMAIN:-localhost}
+      - EMAIL=${EMAIL}
+    deploy:
+      resources:
+        limits:
+          memory: 128M
+  
+  sticker-renderer:
+    image: ghcr.io/secarelupus/skerry-sticker-renderer:${SKERRY_VERSION:-v0.1.0-alpha}
+    networks:
+      - default
+      - backend
+    environment:
+      - PORT=3000
+    deploy:
+      resources:
+        limits:
+          # Rendering is heavy, give it some room but cap it
+          cpus: '0.5'
+          memory: 1G
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:3000/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    volumes:
+      - sticker_cache:/app/cache/stickers
+
+  db-backup:
+    image: postgres:16-alpine
+    container_name: skerry-db-backup
+    restart: unless-stopped
+    volumes:
+      - ./scripts/backup-db.sh:/usr/local/bin/backup-db.sh:ro
+      - pg_backups:/backups
+    environment:
+      - PGHOST=postgres
+      - PGUSER=${POSTGRES_USER}
+      - PGPASSWORD=${POSTGRES_PASSWORD}
+      - PGDATABASE=${POSTGRES_DB}
+    entrypoint: ["sh", "-c", "while true; do /usr/local/bin/backup-db.sh; sleep 86400; done"]
+    depends_on:
+      - postgres
+
+networks:
+  default:
+    name: skerry_default
+  backend:
+    name: skerry_backend
+
+volumes:
+  pg_data:
+  pg_backups:
+  synapse_data:
+  livekit_data:
+  caddy_data:
+  caddy_config:
+  sticker_cache:

--- a/deploy/docker/Caddyfile
+++ b/deploy/docker/Caddyfile
@@ -1,0 +1,51 @@
+{
+    email {$EMAIL}
+    log {
+        output stdout
+        level DEBUG
+    }
+}
+
+(common_handlers) {
+    handle /v1/* {
+        reverse_proxy control-plane:4000
+    }
+    handle /auth/* {
+        reverse_proxy control-plane:4000
+    }
+    handle /health {
+        reverse_proxy control-plane:4000
+    }
+    handle /metrics {
+        reverse_proxy control-plane:4000
+    }
+    handle /bootstrap/* {
+        reverse_proxy control-plane:4000
+    }
+    handle /_matrix/* {
+        reverse_proxy synapse:8008
+    }
+    handle /_synapse/* {
+        reverse_proxy synapse:8008
+    }
+    handle /twirp/* {
+        reverse_proxy livekit:7880
+    }
+    handle /rtc* {
+        reverse_proxy livekit:7880
+    }
+    handle {
+        # The web container MUST listen on 0.0.0.0:3000 (next start -H 0.0.0.0)
+        reverse_proxy web:3000
+    }
+}
+
+# Explicitly use http:// here because an upstream reverse proxy
+# is handling SSL termination. This disables Caddy's Auto-HTTPS
+# and stops the "Too Many Redirects" loop.
+http://{$NEXT_PUBLIC_BASE_DOMAIN}, http://localhost, http://127.0.0.1 {
+    header {
+        Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https: wss:; frame-src 'self' https:; media-src 'self' https:; font-src 'self'"
+    }
+    import common_handlers
+}

--- a/deploy/docker/synapse/homeserver.yaml
+++ b/deploy/docker/synapse/homeserver.yaml
@@ -1,0 +1,30 @@
+# Configuration file for Synapse.
+server_name: "hub-localhost"
+cors_allow_origins: ["*"]
+pid_file: /data/homeserver.pid
+listeners:
+  - port: 8008
+    resources:
+      - names: [client, federation, media]
+        compress: false
+    tls: false
+    type: http
+    x_forwarded: false
+database:
+  name: sqlite3
+  args:
+    database: /data/homeserver.db
+log_config: "/data/hub-localhost.log.config"
+media_store_path: /data/media_store
+registration_shared_secret: "JcOYCz8LxB_f+,N1e~Y#W^r.CKDb@:udYg3RZkCqc;Nl5Dn&jx"
+report_stats: false
+macaroon_secret_key: "l,gRdq;ARsYoaF~dBj9D0&s-BHlHv;m__RnPbhxwr=9VfpaC2D"
+form_secret: "2ekUjE_ngCMFb0UD41V^HG13rF^P.,m5FGVbL~HDVt4am79i&p"
+signing_key_path: "/data/hub-localhost.signing.key"
+trusted_key_servers:
+  - server_name: "matrix.org"
+
+enable_authenticated_media: false
+app_service_config_files:
+  - /data/skerry-appservice.yaml
+# vim:ft=yaml

--- a/deploy/docker/synapse/hub-localhost.log.config
+++ b/deploy/docker/synapse/hub-localhost.log.config
@@ -1,0 +1,39 @@
+version: 1
+
+formatters:
+  precise:
+    
+    format: '%(asctime)s - %(name)s - %(lineno)d - %(levelname)s - %(request)s - %(message)s'
+    
+
+handlers:
+
+
+  console:
+    class: logging.StreamHandler
+    formatter: precise
+
+loggers:
+    # This is just here so we can leave `loggers` in the config regardless of whether
+    # we configure other loggers below (avoid empty yaml dict error).
+    _placeholder:
+        level: "INFO"
+
+    
+    
+    synapse.storage.SQL:
+        # beware: increasing this to DEBUG will make synapse log sensitive
+        # information such as access tokens.
+        level: INFO
+    
+
+    
+
+root:
+    level: INFO
+
+
+    handlers: [console]
+
+
+disable_existing_loggers: false

--- a/deploy/docker/synapse/setup-synapse.sh
+++ b/deploy/docker/synapse/setup-synapse.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Helper to generate Synapse signing key if missing
+
+SYNC_DIR="./docker/synapse"
+SERVER_NAME="hub-localhost"
+KEY_FILE="${SYNC_DIR}/${SERVER_NAME}.signing.key"
+
+if [ ! -f "$KEY_FILE" ]; then
+    echo "Generating missing Synapse signing key..."
+    docker run -it --rm \
+        -v "$(pwd)/${SYNC_DIR}:/data" \
+        -e SYNAPSE_SERVER_NAME=${SERVER_NAME} \
+        -e SYNAPSE_REPORT_STATS=no \
+        matrixdotorg/synapse:latest generate
+    echo "Key generated at $KEY_FILE"
+else
+    echo "Synapse signing key already exists."
+fi

--- a/deploy/scripts/backup-db.sh
+++ b/deploy/scripts/backup-db.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -e
+
+# Configuration
+BACKUP_DIR="/backups"
+TIMESTAMP=$(date +"%Y-%m-%d_%H-%M-%S")
+BACKUP_FILE="${BACKUP_DIR}/db_backup_${TIMESTAMP}.sql"
+RETENTION_DAYS=7
+
+# Ensure backup directory exists
+mkdir -p "${BACKUP_DIR}"
+
+echo "[$(date)] Starting Database Backup..."
+
+# Perform pg_dump
+# Environment variables like PGHOST, PGUSER, PGPASSWORD, PGDATABASE should be set
+pg_dump -v > "${BACKUP_FILE}"
+
+# Optional: Compress the backup
+gzip "${BACKUP_FILE}"
+BACKUP_FILE_GZ="${BACKUP_FILE}.gz"
+
+echo "[$(date)] Backup completed: ${BACKUP_FILE_GZ}"
+
+# Cleanup old backups
+echo "[$(date)] Cleaning up backups older than ${RETENTION_DAYS} days..."
+find "${BACKUP_DIR}" -name "db_backup_*.sql.gz" -type f -mtime +${RETENTION_DAYS} -delete
+
+# Optional: Upload to S3 if configured
+if [ -n "${S3_BUCKET}" ] && [ -n "${S3_ACCESS_KEY_ID}" ]; then
+    echo "[$(date)] Uploading to S3: s3://${S3_BUCKET}/backups/"
+    # Assuming aws-cli or rclone is available
+    # aws s3 cp "${BACKUP_FILE_GZ}" "s3://${S3_BUCKET}/backups/db_backup_${TIMESTAMP}.sql.gz"
+fi
+
+echo "[$(date)] Backup process finished successfully."

--- a/deploy/scripts/bootstrap-hub.sh
+++ b/deploy/scripts/bootstrap-hub.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -e
+
+echo "🚀 Skerry Hub Bootstrapper"
+echo "=========================="
+
+# Check dependencies
+for cmd in docker; do
+  if ! command -v $cmd &> /dev/null; then
+    echo "❌ Error: docker is not installed."
+    exit 1
+  fi
+done
+
+# Generate .env if not present
+if [ ! -f .env ]; then
+  echo "📄 Creating .env from .env.example..."
+  cp .env.example .env
+  
+  # Generate random secrets
+  POSTGRES_PW=$(openssl rand -hex 16)
+  SESSION_SECRET=$(openssl rand -hex 32)
+  
+  sed -i "s/POSTGRES_PASSWORD=.*/POSTGRES_PASSWORD=$POSTGRES_PW/" .env
+  sed -i "s/SESSION_SECRET=.*/SESSION_SECRET=$SESSION_SECRET/" .env
+  echo "✅ .env created with random secrets."
+else
+  echo "📄 Using existing .env file."
+fi
+
+# Generate Synapse signing key if missing
+if [ ! -f docker/synapse/hub-localhost.signing.key ]; then
+  echo "🔑 Generating Synapse signing key..."
+  bash docker/synapse/setup-synapse.sh
+fi
+
+# Pull images
+echo "📥 Pulling Docker images..."
+docker compose pull
+
+# Start database first
+echo "🐘 Starting PostgreSQL..."
+docker compose up -d postgres
+echo "⏳ Waiting for PostgreSQL to be ready..."
+until docker compose exec -T postgres pg_isready -U postgres 2>/dev/null; do
+  sleep 2
+done
+
+# Run migrations
+echo "🛠️ Running control-plane migrations..."
+docker compose run --rm control-plane pnpm --filter @skerry/control-plane migrate
+
+# Start everything
+echo "🚢 Launching Skerry Hub..."
+docker compose up -d
+
+echo "=========================="
+echo "🎉 Skerry Hub is starting!"
+echo "📍 Access it at: http://localhost (or your configured BASE_DOMAIN)"
+echo "📊 Health check: http://localhost/health"
+echo "=========================="


### PR DESCRIPTION
## What

Follow-up to #149. Two changes:

### Auto-tag on release
Workflow now creates the git tag from the version input — no manual `git tag` step needed. Run **Publish Docker Images** with `v0.1.0-alpha` and it tags main, builds+publishes 3 images, and uploads the deploy kit.

### Code dedup (#56)
- Extracted `normalizeMediaUrl` + `getProxiedUrl` to `apps/web/lib/media.ts` (was duplicated in chat-window + embed-card)
- Extracted `<Reactions>` component to `apps/web/components/reactions.tsx` (was duplicated in chat-window + thread-panel, 3 blocks → 1)
- Removed dead `isLocal`/`publicBaseDomain` and stray debug `console.log`

### Deploy kit
Added `deploy/` directory with all files needed to deploy from GHCR images. Packaged as tar.gz artifact on release.