### PR TITLE
fix: display actual OIDC provider name on link-or-create page (#107)

### DIFF
--- a/apps/control-plane/src/routes/auth-routes.ts
+++ b/apps/control-plane/src/routes/auth-routes.ts
@@ -353,6 +353,7 @@ export async function registerAuthRoutes(app: FastifyInstance): Promise<void> {
             tokenExpiresAt: exchanged.tokenExpiresAt ?? null,
           });
           const dest = new URL("/auth/link-or-create", config.webBaseUrl);
+          dest.searchParams.set("provider", profile.provider);
           reply.redirect(dest.toString(), 302);
           return;
         }


### PR DESCRIPTION
The interstitial page reads the provider from the query string, but the redirect URL was bare — it always showed 'another provider'.

Single-line fix: appends `?provider=github|google|discord` to the redirect URL.

Closes #107.