### PR TITLE
feat: allow space admins/moderators to issue scoped invites (#105)

### DIFF
--- a/apps/control-plane/src/routes/invite-routes.ts
+++ b/apps/control-plane/src/routes/invite-routes.ts
@@ -31,10 +31,6 @@ export async function registerInviteRoutes(app: FastifyInstance): Promise<void> 
 
     const productUserId = request.auth!.productUserId;
     const isHubManager = await canManageHub({ productUserId, hubId: params.hubId });
-    if (!isHubManager) {
-      reply.code(403).send({ message: "Forbidden: insufficient hub management scope." });
-      return;
-    }
 
     if (payload.defaultServerId) {
       const serverRow = await withDb((db) =>
@@ -86,6 +82,10 @@ export async function registerInviteRoutes(app: FastifyInstance): Promise<void> 
           return;
         }
       }
+    } else if (!isHubManager) {
+      // Non-space-scoped roles (or bare invites) still require hub-manager authority.
+      reply.code(403).send({ message: "Forbidden: only hub managers can issue unscoped invites." });
+      return;
     }
 
     const badgeIds = payload.defaultBadgeIds ?? [];


### PR DESCRIPTION
## What

Activates the dead `canManageServerRoles` branch in `POST /v1/hubs/:hubId/invites`. Previously the endpoint required `canManageHub` for all invites, making the space-scoped authorization branch unreachable.

## New behavior

| Caller | Invite role | Result |
|--------|-------------|--------|
| Hub manager | any/none | allowed |
| Space admin/mod | space_admin / space_moderator (own server) | allowed |
| Space admin/mod | unscoped (member / none) | 403 |
| Regular member | any | 403 |

## Changes

Two modifications in `invite-routes.ts`:
1. Removed the early `if (!isHubManager)` 403 gate (was blocking all non-hub-managers)
2. Added `else if (!isHubManager)` fallback after the space-scoped block to reject non-hub-managers issuing unscoped invites

The existing `canManageServerRoles` branch (previously dead) now activates when the role is space-scoped and the caller is not a hub manager.

Closes #105.