### PR TITLE
feat: PostgreSQL backup automation with retention (#133)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -49,6 +49,67 @@ docker compose pull
 docker compose --env-file .env.ops up -d
 ```
 
+## Backup & Restore
+
+### Where backups are stored
+
+Backups are stored in the `pg_backups` Docker volume, mounted at `/backups` inside
+the `db-backup` container.  You can inspect them with:
+
+```bash
+docker compose exec db-backup ls -lh /backups/
+```
+
+To copy a backup locally:
+
+```bash
+docker compose cp db-backup:/backups/skerry_YYYY-MM-DD_HHMMSS.sql.gz .
+```
+
+### Schedule and retention
+
+The `db-backup` service uses the `postgres:16` image.  It wakes every day at
+02:00 UTC, runs `pg_dump`, gzips the output, and stores it as:
+
+    skerry_YYYY-MM-DD_HHMMSS.sql.gz
+
+Retention policy (applied after every successful dump):
+
+- **Daily** — keep the 7 most recent backups (any day of week).
+- **Weekly** — keep up to 4 Sunday backups (Sunday = the day on which the
+  backup timestamp falls), regardless of daily age.
+
+You can override the defaults via environment in `.env`:
+
+```
+RETENTION_DAILY=7    # number of daily backups to keep
+RETENTION_WEEKLY=4   # number of Sunday backups to keep
+```
+
+### Restore
+
+To restore the latest backup:
+
+```bash
+# 1. Copy the backup into the postgres container
+gunzip -c skerry_YYYY-MM-DD_HHMMSS.sql.gz | \
+  docker compose exec -T postgres psql -U skerry -d skerry
+```
+
+Or, from a specific backup file already inside the db-backup container:
+
+```bash
+docker compose exec db-backup sh -c 'gunzip -c /backups/skerry_YYYY-MM-DD_HHMMSS.sql.gz' | \
+  docker compose exec -T postgres psql -U skerry -d skerry
+```
+
+**Important:** Restoring overwrites the current database.  Take a fresh backup
+first if you need to preserve the current state:
+
+```bash
+docker compose exec db-backup /usr/local/bin/backup.sh
+```
+
 ## Files
 
 ```

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -147,17 +147,40 @@ services:
       - sticker_cache:/app/cache/stickers
 
   db-backup:
-    image: postgres:16-alpine
+    image: postgres:16
     container_name: skerry-db-backup
     restart: unless-stopped
     volumes:
-      - ./scripts/backup-db.sh:/usr/local/bin/backup-db.sh:ro
+      - ./scripts/backup.sh:/usr/local/bin/backup.sh:ro
       - pg_backups:/backups
+    environment:
+      PGHOST: postgres
+      PGUSER: ${POSTGRES_USER:-skerry}
+      PGPASSWORD: ${POSTGRES_PASSWORD}
+      PGDATABASE: ${POSTGRES_DB:-skerry}
     env_file:
       - .env.ops
-    entrypoint: ["sh", "-c", "while true; do /usr/local/bin/backup-db.sh; sleep 86400; done"]
+    entrypoint:
+      - sh
+      - -c
+      - |
+        while true; do
+          # Calculate seconds until next 02:00 UTC
+          now_secs=$(date +%s)
+          target=$(date -d "tomorrow 02:00" +%s 2>/dev/null || echo $((now_secs + 86400)))
+          sleep_secs=$((target - now_secs))
+          if [ "$sleep_secs" -lt 60 ]; then
+            # Already past 2am or close — run after a short delay
+            sleep_secs=60
+          fi
+          echo "[$(date -Iseconds)] db-backup: sleeping ${sleep_secs}s until next 02:00 UTC run"
+          sleep "${sleep_secs}"
+          echo "[$(date -Iseconds)] db-backup: starting scheduled backup"
+          /usr/local/bin/backup.sh
+        done
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
 
 networks:
   default:

--- a/deploy/scripts/backup.sh
+++ b/deploy/scripts/backup.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# skerry-backup — PostgreSQL backup with daily/weekly retention.
+# Runs from the db-backup service in docker-compose.
+#
+# Environment:
+#   PGHOST / PGUSER / PGPASSWORD / PGDATABASE — passed by compose from .env.ops
+#   BACKUP_DIR — optional override (default: /backups)
+#   RETENTION_DAILY — number of daily backups to keep (default: 7)
+#   RETENTION_WEEKLY — number of weekly (Sunday) backups to keep (default: 4)
+set -euo pipefail
+
+# ── config ───────────────────────────────────────────────────────────
+BACKUP_DIR="${BACKUP_DIR:-/backups}"
+RETENTION_DAILY="${RETENTION_DAILY:-7}"
+RETENTION_WEEKLY="${RETENTION_WEEKLY:-4}"
+TIMESTAMP=$(date +"%Y-%m-%d_%H%M%S")
+DOW=$(date +"%u")               # 1=Mon … 7=Sun
+BASENAME="skerry_${TIMESTAMP}"
+SQL_FILE="${BACKUP_DIR}/${BASENAME}.sql"
+GZ_FILE="${BACKUP_DIR}/${BASENAME}.sql.gz"
+LOG_TAG="[$(date '+%Y-%m-%d %H:%M:%S')] [backup]"
+
+# ── helpers ──────────────────────────────────────────────────────────
+log()  { echo "${LOG_TAG} $*"; }
+die()  { log "FAILURE: $*"; exit 1; }
+
+# ── ensure backup directory exists ───────────────────────────────────
+mkdir -p "${BACKUP_DIR}"
+
+# ── dump ─────────────────────────────────────────────────────────────
+log "Starting PostgreSQL dump (db=${PGDATABASE:-?} host=${PGHOST:-?})…"
+
+if pg_dump --no-owner --no-acl > "${SQL_FILE}" 2>/tmp/pg_dump_stderr.log; then
+    :
+else
+    die "pg_dump failed — see /tmp/pg_dump_stderr.log"
+fi
+
+# ── compress ─────────────────────────────────────────────────────────
+gzip -f "${SQL_FILE}"
+SIZE=$(du -h "${GZ_FILE}" | cut -f1)
+log "Dump complete: ${GZ_FILE} (${SIZE})"
+
+# ── retention ────────────────────────────────────────────────────────
+# 1. Daily retention: keep the last N daily backups (any day of week).
+log "Applying daily retention (keep ${RETENTION_DAILY})…"
+mapfile -t DAILY_FILES < <(find "${BACKUP_DIR}" -maxdepth 1 \
+    -name 'skerry_*.sql.gz' -type f | sort -r)
+
+DAILY_COUNT=0
+for f in "${DAILY_FILES[@]}"; do
+    DAILY_COUNT=$((DAILY_COUNT + 1))
+    if [ "${DAILY_COUNT}" -gt "${RETENTION_DAILY}" ]; then
+        log "  Pruning daily: $(basename "${f}")"
+        rm -f "${f}"
+    fi
+done
+
+# 2. Weekly retention: keep the last N Sunday backups.
+#    A Sunday backup is one whose filename timestamp falls on a Sunday.
+if [ "${RETENTION_WEEKLY}" -gt 0 ]; then
+    log "Applying weekly retention (keep ${RETENTION_WEEKLY} Sundays)…"
+    mapfile -t SUNDAY_FILES < <(find "${BACKUP_DIR}" -maxdepth 1 \
+        -name 'skerry_*.sql.gz' -type f | while read -r f; do
+        # Extract date part: skerry_YYYY-MM-DD_HHMMSS.sql.gz → YYYY-MM-DD
+        bn=$(basename "${f}" .sql.gz)
+        dt=${bn#skerry_}              # YYYY-MM-DD_HHMMSS
+        dt=${dt%_*}                    # YYYY-MM-DD
+        # Check if it's a Sunday (date -d "$dt" +%u → 7)
+        if [ "$(date -d "${dt}" +%u 2>/dev/null || true)" = "7" ]; then
+            echo "${f}"
+        fi
+    done | sort -r)
+
+    WEEKLY_COUNT=0
+    for f in "${SUNDAY_FILES[@]}"; do
+        WEEKLY_COUNT=$((WEEKLY_COUNT + 1))
+        if [ "${WEEKLY_COUNT}" -gt "${RETENTION_WEEKLY}" ]; then
+            log "  Pruning weekly (Sunday): $(basename "${f}")"
+            rm -f "${f}"
+        fi
+    done
+fi
+
+log "Backup completed successfully."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -158,18 +158,33 @@ services:
       - sticker_cache:/app/cache/stickers
 
   db-backup:
-    image: postgres:16-alpine
+    image: postgres:16
     container_name: skerry-db-backup
     restart: unless-stopped
     volumes:
-      - ./scripts/backup-db.sh:/usr/local/bin/backup-db.sh:ro
+      - ./deploy/scripts/backup.sh:/usr/local/bin/backup.sh:ro
       - pg_backups:/backups
     environment:
-      - PGHOST=postgres
-      - PGUSER=${POSTGRES_USER}
-      - PGPASSWORD=${POSTGRES_PASSWORD}
-      - PGDATABASE=${POSTGRES_DB}
-    entrypoint: ["sh", "-c", "while true; do /usr/local/bin/backup-db.sh; sleep 86400; done"]
+      PGHOST: postgres
+      PGUSER: ${POSTGRES_USER}
+      PGPASSWORD: ${POSTGRES_PASSWORD}
+      PGDATABASE: ${POSTGRES_DB}
+    entrypoint:
+      - sh
+      - -c
+      - |
+        while true; do
+          now_secs=$(date +%s)
+          target=$(date -d "tomorrow 02:00" +%s 2>/dev/null || echo $((now_secs + 86400)))
+          sleep_secs=$((target - now_secs))
+          if [ "$sleep_secs" -lt 60 ]; then
+            sleep_secs=60
+          fi
+          echo "[$(date -Iseconds)] db-backup: sleeping ${sleep_secs}s until next 02:00 UTC run"
+          sleep "${sleep_secs}"
+          echo "[$(date -Iseconds)] db-backup: starting scheduled backup"
+          /usr/local/bin/backup.sh
+        done
     depends_on:
       - postgres
 


### PR DESCRIPTION
## What

Automated PostgreSQL backup with retention policy, wired into the deploy compose stack.

## Changes

- deploy/scripts/backup.sh — pg_dump script with timestamped gzipped dumps, 7 daily + 4 weekly retention, strict error handling
- deploy/docker-compose.yml — db-backup service running daily at 02:00 UTC
- deploy/README.md — restore procedure via docker compose exec postgres psql

Closes #133.