### PR TITLE
feat: account merge for post-hoc OIDC resolution (#125)

### DIFF
--- a/apps/control-plane/migrations/1776600000000_044-account-merge.js
+++ b/apps/control-plane/migrations/1776600000000_044-account-merge.js
@@ -1,0 +1,9 @@
+export const up = (pgm) => {
+    pgm.addColumn('identity_mappings', {
+        merged_into_product_user_id: { type: 'text' },
+    });
+};
+
+export const down = (pgm) => {
+    pgm.dropColumn('identity_mappings', 'merged_into_product_user_id');
+};

--- a/apps/control-plane/src/routes/auth-routes.ts
+++ b/apps/control-plane/src/routes/auth-routes.ts
@@ -15,7 +15,8 @@ import {
   updateUserProfile,
   blockUser,
   unblockUser,
-  listBlocks
+  listBlocks,
+  mergeAccounts
 } from "../services/identity-service.js";
 import { requireAuth } from "../auth/middleware.js";
 import type { AccountLinkingRequirement, IdentityProvider } from "@skerry/shared";
@@ -493,6 +494,7 @@ export async function registerAuthRoutes(app: FastifyInstance): Promise<void> {
       linkedIdentities: identities.map((identity) => ({
         provider: identity.provider,
         oidcSubject: identity.oidcSubject,
+        productUserId: identity.productUserId,
         email: identity.email,
         displayName: identity.displayName,
         avatarUrl: identity.avatarUrl,
@@ -667,6 +669,50 @@ export async function registerAuthRoutes(app: FastifyInstance): Promise<void> {
       } else {
         reply.code(204).send();
       }
+    }
+  });
+
+  app.post("/auth/merge-accounts", { preHandler: requireAuth }, async (request, reply) => {
+    const { sourceProductUserId } = z
+      .object({ sourceProductUserId: z.string().min(1) })
+      .parse(request.body);
+
+    const targetProductUserId = request.auth!.productUserId;
+
+    if (sourceProductUserId === targetProductUserId) {
+      reply.code(400).send({
+        message: "Cannot merge an account into itself.",
+        code: "cannot_merge_self"
+      });
+      return;
+    }
+
+    // Verify the caller has an identity linked to the TARGET (current) account
+    const targetIdentities = await listIdentitiesByProductUserId(targetProductUserId);
+    if (targetIdentities.length === 0) {
+      reply.code(400).send({
+        message: "No identities found for the current account.",
+        code: "no_target_identities"
+      });
+      return;
+    }
+
+    // Verify the caller ALSO has an identity linked to the SOURCE account
+    const sourceIdentities = await listIdentitiesByProductUserId(sourceProductUserId);
+    if (sourceIdentities.length === 0) {
+      reply.code(400).send({
+        message: "No identities found for the source account. You must be linked to both accounts.",
+        code: "no_source_identities"
+      });
+      return;
+    }
+
+    try {
+      const result = await mergeAccounts(targetProductUserId, sourceProductUserId);
+      return result;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Account merge failed.";
+      reply.code(400).send({ message, code: "merge_failed" });
     }
   });
 

--- a/apps/control-plane/src/services/identity-service.ts
+++ b/apps/control-plane/src/services/identity-service.ts
@@ -24,6 +24,7 @@ export interface IdentityRow {
   access_token: string | null;
   refresh_token: string | null;
   token_expires_at: string | null;
+  merged_into_product_user_id: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -455,5 +456,183 @@ export async function listHubMembers(hubId: string): Promise<IdentityMapping[]> 
       [hubId]
     );
     return rows.rows.map(mapRow);
+  });
+}
+
+export interface MergeAccountsResult {
+  targetProductUserId: string;
+  sourceProductUserId: string;
+  migratedMessages: number;
+  migratedServerMembers: number;
+  migratedHubMembers: number;
+  migratedRoleBindings: number;
+  migratedUserPresence: number;
+  migratedVoicePresence: number;
+  migratedUserBadges: number;
+  mergedIdentities: number;
+}
+
+export async function mergeAccounts(
+  targetProductUserId: string,
+  sourceProductUserId: string
+): Promise<MergeAccountsResult> {
+  return withDb(async (db) => {
+    // Verify both accounts exist and have identity mappings
+    const targetIdentities = await db.query<IdentityRow>(
+      "select * from identity_mappings where product_user_id = $1 and merged_into_product_user_id is null",
+      [targetProductUserId]
+    );
+    if (targetIdentities.rows.length === 0) {
+      throw new Error("Target account not found or has already been merged.");
+    }
+
+    const sourceIdentities = await db.query<IdentityRow>(
+      "select * from identity_mappings where product_user_id = $1 and merged_into_product_user_id is null",
+      [sourceProductUserId]
+    );
+    if (sourceIdentities.rows.length === 0) {
+      throw new Error("Source account not found or has already been merged.");
+    }
+
+    if (targetProductUserId === sourceProductUserId) {
+      throw new Error("Cannot merge an account into itself.");
+    }
+
+    // 1. Migrate messages
+    const msgResult = await db.query<{ rowCount: number }>(
+      "update chat_messages set author_user_id = $1 where author_user_id = $2",
+      [targetProductUserId, sourceProductUserId]
+    );
+    const migratedMessages = msgResult.rowCount ?? 0;
+
+    // 2. Migrate server_members (upsert: skip if target already a member)
+    const smResult = await db.query<{ rowCount: number }>(
+      `update server_members set product_user_id = $1
+       where product_user_id = $2
+         and not exists (
+           select 1 from server_members sm2
+           where sm2.server_id = server_members.server_id
+             and sm2.product_user_id = $1
+         )`,
+      [targetProductUserId, sourceProductUserId]
+    );
+    const migratedServerMembers = smResult.rowCount ?? 0;
+    // Delete any remaining source server_members that conflicted (target already had membership)
+    await db.query(
+      "delete from server_members where product_user_id = $1",
+      [sourceProductUserId]
+    );
+
+    // 3. Migrate hub_members (upsert: skip if target already a member)
+    const hmResult = await db.query<{ rowCount: number }>(
+      `update hub_members set product_user_id = $1
+       where product_user_id = $2
+         and not exists (
+           select 1 from hub_members hm2
+           where hm2.hub_id = hub_members.hub_id
+             and hm2.product_user_id = $1
+         )`,
+      [targetProductUserId, sourceProductUserId]
+    );
+    const migratedHubMembers = hmResult.rowCount ?? 0;
+    await db.query(
+      "delete from hub_members where product_user_id = $1",
+      [sourceProductUserId]
+    );
+
+    // 4. Migrate role_bindings (upsert: skip if target already has same role binding)
+    const rbResult = await db.query<{ rowCount: number }>(
+      `update role_bindings set product_user_id = $1
+       where product_user_id = $2
+         and not exists (
+           select 1 from role_bindings rb2
+           where rb2.role = role_bindings.role
+             and coalesce(rb2.hub_id, '') = coalesce(role_bindings.hub_id, '')
+             and coalesce(rb2.server_id, '') = coalesce(role_bindings.server_id, '')
+             and coalesce(rb2.channel_id, '') = coalesce(role_bindings.channel_id, '')
+             and rb2.product_user_id = $1
+         )`,
+      [targetProductUserId, sourceProductUserId]
+    );
+    const migratedRoleBindings = rbResult.rowCount ?? 0;
+    await db.query(
+      "delete from role_bindings where product_user_id = $1",
+      [sourceProductUserId]
+    );
+
+    // 5. Migrate user_presence
+    const upResult = await db.query<{ rowCount: number }>(
+      `update user_presence set product_user_id = $1
+       where product_user_id = $2
+         and not exists (
+           select 1 from user_presence up2 where up2.product_user_id = $1
+         )`,
+      [targetProductUserId, sourceProductUserId]
+    );
+    const migratedUserPresence = upResult.rowCount ?? 0;
+    await db.query(
+      "delete from user_presence where product_user_id = $1",
+      [sourceProductUserId]
+    );
+
+    // 6. Migrate voice_presence
+    const vpResult = await db.query<{ rowCount: number }>(
+      `update voice_presence set product_user_id = $1
+       where product_user_id = $2
+         and not exists (
+           select 1 from voice_presence vp2
+           where vp2.channel_id = voice_presence.channel_id
+             and vp2.product_user_id = $1
+         )`,
+      [targetProductUserId, sourceProductUserId]
+    );
+    const migratedVoicePresence = vpResult.rowCount ?? 0;
+    await db.query(
+      "delete from voice_presence where product_user_id = $1",
+      [sourceProductUserId]
+    );
+
+    // 7. Migrate user_badges
+    const ubResult = await db.query<{ rowCount: number }>(
+      `update user_badges set product_user_id = $1
+       where product_user_id = $2
+         and not exists (
+           select 1 from user_badges ub2
+           where ub2.badge_id = user_badges.badge_id
+             and ub2.product_user_id = $1
+         )`,
+      [targetProductUserId, sourceProductUserId]
+    );
+    const migratedUserBadges = ubResult.rowCount ?? 0;
+    await db.query(
+      "delete from user_badges where product_user_id = $1",
+      [sourceProductUserId]
+    );
+
+    // 8. Mark source identities as merged, then transfer product_user_id
+    const mergeMarkResult = await db.query<{ rowCount: number }>(
+      "update identity_mappings set merged_into_product_user_id = $1, updated_at = now() where product_user_id = $2 and merged_into_product_user_id is null",
+      [targetProductUserId, sourceProductUserId]
+    );
+    const mergedIdentities = mergeMarkResult.rowCount ?? 0;
+
+    // 9. Transfer product_user_id on source identities to target
+    await db.query(
+      "update identity_mappings set product_user_id = $1, updated_at = now() where product_user_id = $2",
+      [targetProductUserId, sourceProductUserId]
+    );
+
+    return {
+      targetProductUserId,
+      sourceProductUserId,
+      migratedMessages,
+      migratedServerMembers,
+      migratedHubMembers,
+      migratedRoleBindings,
+      migratedUserPresence,
+      migratedVoicePresence,
+      migratedUserBadges,
+      mergedIdentities,
+    };
   });
 }

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import { useEffect, useState, useMemo } from "react";
+import { useEffect, useState, useMemo, useCallback } from "react";
 import {
     fetchAuthProviders,
     fetchViewerSession,
     providerLinkUrl,
+    mergeAccounts,
     type AuthProvidersResponse,
-    type ViewerSession
+    type ViewerSession,
+    type MergeAccountsResult
 } from "../../lib/control-plane";
 
 export default function UserSettingsPage() {
@@ -14,29 +16,59 @@ export default function UserSettingsPage() {
     const [providers, setProviders] = useState<AuthProvidersResponse | null>(null);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
+    const [mergeSourceId, setMergeSourceId] = useState<string>("");
+    const [mergeLoading, setMergeLoading] = useState(false);
+    const [mergeError, setMergeError] = useState<string | null>(null);
+    const [mergeResult, setMergeResult] = useState<MergeAccountsResult | null>(null);
+
+    const loadSession = useCallback(async () => {
+        try {
+            const [v, p] = await Promise.all([
+                fetchViewerSession(),
+                fetchAuthProviders()
+            ]);
+            setViewer(v);
+            setProviders(p);
+        } catch (err) {
+            setError(err instanceof Error ? err.message : "Failed to load settings");
+        } finally {
+            setLoading(false);
+        }
+    }, []);
 
     useEffect(() => {
-        async function load() {
-            try {
-                const [v, p] = await Promise.all([
-                    fetchViewerSession(),
-                    fetchAuthProviders()
-                ]);
-                setViewer(v);
-                setProviders(p);
-            } catch (err) {
-                setError(err instanceof Error ? err.message : "Failed to load settings");
-            } finally {
-                setLoading(false);
-            }
-        }
-        void load();
-    }, []);
+        void loadSession();
+    }, [loadSession]);
 
     const enabledLoginProviders = useMemo(
         () => (providers?.providers ?? []).filter((provider) => provider.isEnabled && provider.provider !== "dev"),
         [providers]
     );
+
+    // Identities NOT linked to the active session (potential merge sources)
+    const mergeableIdentities = useMemo(() => {
+        if (!viewer) return [];
+        return viewer.linkedIdentities.filter(
+            (identity) => identity.productUserId !== viewer.productUserId
+        );
+    }, [viewer]);
+
+    const handleMerge = useCallback(async () => {
+        if (!mergeSourceId) return;
+        setMergeLoading(true);
+        setMergeError(null);
+        setMergeResult(null);
+        try {
+            const result = await mergeAccounts(mergeSourceId);
+            setMergeResult(result);
+            // Refresh the session to pick up any changes
+            await loadSession();
+        } catch (err) {
+            setMergeError(err instanceof Error ? err.message : "Merge failed");
+        } finally {
+            setMergeLoading(false);
+        }
+    }, [mergeSourceId, loadSession]);
 
     if (loading) return <p>Loading your settings...</p>;
     if (!viewer) return <p>Please sign in to access settings.</p>;
@@ -81,6 +113,76 @@ export default function UserSettingsPage() {
                             (provider) => !viewer.linkedIdentities.some((identity) => identity.provider === provider.provider)
                         ).length === 0 && <p className="muted" style={{ marginTop: '0.5rem' }}>All available providers are already linked.</p>}
                     </div>
+                </section>
+
+                <section style={{ marginTop: '2rem' }}>
+                    <h3>Merge Accounts</h3>
+                    <p className="settings-description">
+                        Merge all data from another account (linked via a different identity) into your current account.
+                        This transfers messages, memberships, roles, badges, and more. The source account will be consolidated
+                        and its identities will point to your current account.
+                    </p>
+
+                    {mergeableIdentities.length === 0 ? (
+                        <p className="muted" style={{ marginTop: '1rem' }}>
+                            No other linked identities available for merging. Link another account first.
+                        </p>
+                    ) : (
+                        <div style={{ marginTop: '1rem' }}>
+                            <div className="stack" style={{ gap: '0.75rem' }}>
+                                <label htmlFor="merge-source-select" style={{ fontWeight: 500 }}>
+                                    Select account to merge from:
+                                </label>
+                                <select
+                                    id="merge-source-select"
+                                    value={mergeSourceId}
+                                    onChange={(e) => setMergeSourceId(e.target.value)}
+                                    style={{ padding: '0.5rem', maxWidth: '400px' }}
+                                >
+                                    <option value="">-- Choose an identity --</option>
+                                    {mergeableIdentities.map((identity) => (
+                                        <option key={`${identity.provider}:${identity.oidcSubject}`} value={identity.productUserId}>
+                                            {identity.provider}
+                                            {identity.email ? ` (${identity.email})` : ""}
+                                            {identity.displayName ? ` — ${identity.displayName}` : ""}
+                                        </option>
+                                    ))}
+                                </select>
+
+                                <button
+                                    onClick={handleMerge}
+                                    disabled={!mergeSourceId || mergeLoading}
+                                    style={{
+                                        padding: '0.5rem 1rem',
+                                        maxWidth: '200px',
+                                        cursor: mergeSourceId && !mergeLoading ? 'pointer' : 'not-allowed'
+                                    }}
+                                >
+                                    {mergeLoading ? "Merging..." : "Merge Accounts"}
+                                </button>
+                            </div>
+
+                            {mergeError && (
+                                <p className="error" style={{ marginTop: '0.75rem' }}>{mergeError}</p>
+                            )}
+
+                            {mergeResult && (
+                                <div style={{ marginTop: '1rem', padding: '1rem', border: '1px solid var(--border-color, #ccc)', borderRadius: '0.5rem' }}>
+                                    <h4 style={{ marginBottom: '0.5rem' }}>Merge Complete</h4>
+                                    <ul style={{ listStyle: 'none', padding: 0 }}>
+                                        <li>Messages migrated: {mergeResult.migratedMessages}</li>
+                                        <li>Server memberships: {mergeResult.migratedServerMembers}</li>
+                                        <li>Hub memberships: {mergeResult.migratedHubMembers}</li>
+                                        <li>Role bindings: {mergeResult.migratedRoleBindings}</li>
+                                        <li>Presence records: {mergeResult.migratedUserPresence}</li>
+                                        <li>Voice presence: {mergeResult.migratedVoicePresence}</li>
+                                        <li>Badges: {mergeResult.migratedUserBadges}</li>
+                                        <li>Identities merged: {mergeResult.mergedIdentities}</li>
+                                    </ul>
+                                </div>
+                            )}
+                        </div>
+                    )}
                 </section>
             </div>
         </div>

--- a/apps/web/lib/control-plane.ts
+++ b/apps/web/lib/control-plane.ts
@@ -83,6 +83,7 @@ export interface ViewerSession {
   linkedIdentities: Array<{
     provider: string;
     oidcSubject: string;
+    productUserId: string;
     displayName: string | null;
     email: string | null;
     avatarUrl: string | null;
@@ -1432,6 +1433,27 @@ export async function blockUser(userId: string): Promise<void> {
 export async function unblockUser(userId: string): Promise<void> {
   await apiFetch(`/auth/blocks/${encodeURIComponent(userId)}`, {
     method: "DELETE"
+  });
+}
+
+export interface MergeAccountsResult {
+  targetProductUserId: string;
+  sourceProductUserId: string;
+  migratedMessages: number;
+  migratedServerMembers: number;
+  migratedHubMembers: number;
+  migratedRoleBindings: number;
+  migratedUserPresence: number;
+  migratedVoicePresence: number;
+  migratedUserBadges: number;
+  mergedIdentities: number;
+}
+
+export async function mergeAccounts(sourceProductUserId: string): Promise<MergeAccountsResult> {
+  return apiFetch<MergeAccountsResult>("/auth/merge-accounts", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ sourceProductUserId })
   });
 }
 


### PR DESCRIPTION
## What

Allows users with multiple accounts (from pre-interstitial OIDC splits) to merge them. One accounts data migrates to the other; the source is archived.

## Backend

- Migration 044: merged_into_product_user_id on identity_mappings
- POST /auth/merge-accounts { sourceProductUserId }
- Verifies caller has identities on both accounts
- Migrates: messages, server_members, hub_members, role_bindings, user_presence, voice_presence, user_badges
- Marks source identities as merged and consolidates them

## Frontend

- Merge Accounts section in Settings
- Identity picker showing accounts with different productUserId
- Result summary with per-table migration counts

Closes #125.