### PR TITLE
feat: per-hub permissionMatrix overrides (#101)

### DIFF
--- a/apps/control-plane/migrations/1776700000000_045-hub-permission-overrides.js
+++ b/apps/control-plane/migrations/1776700000000_045-hub-permission-overrides.js
@@ -1,0 +1,15 @@
+export const up = (pgm) => {
+    pgm.createTable('hub_permission_overrides', {
+        hub_id: { type: 'text', notNull: true, references: 'hubs', onDelete: 'cascade' },
+        role: { type: 'text', notNull: true },
+        action: { type: 'text', notNull: true },
+        allowed: { type: 'boolean', notNull: true },
+    });
+    pgm.addConstraint('hub_permission_overrides', 'hub_permission_overrides_pk', {
+        primaryKey: ['hub_id', 'role', 'action'],
+    });
+};
+
+export const down = (pgm) => {
+    pgm.dropTable('hub_permission_overrides');
+};

--- a/apps/control-plane/src/routes/hub-routes.ts
+++ b/apps/control-plane/src/routes/hub-routes.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { requireAuth, requireInitialized } from "../auth/middleware.js";
 import {
   canManageHub,
+  clearHubPermissionOverrideCache,
 } from "../services/policy-service.js";
 import {
   transferHubOwnership,
@@ -323,5 +324,66 @@ export async function registerHubRoutes(app: FastifyInstance): Promise<void> {
     return {
       items: await listDelegationAuditEvents({ hubId: params.hubId })
     };
+  });
+
+  // --- Per-Hub Permission Overrides (#101) ---
+
+  app.get("/v1/hubs/:hubId/permission-overrides", initializedAuthHandlers, async (request, reply) => {
+    const params = z.object({ hubId: z.string().min(1) }).parse(request.params);
+    const allowed = await canManageHub({
+      productUserId: request.auth!.productUserId,
+      hubId: params.hubId
+    });
+    if (!allowed) {
+      reply.code(403).send({ message: "Forbidden: insufficient hub management scope." });
+      return;
+    }
+
+    const { withDb } = await import("../db/client.js");
+    const rows = await withDb(async (db) => {
+      const result = await db.query<{ role: string; action: string; allowed: boolean }>(
+        "select role, action, allowed from hub_permission_overrides where hub_id = $1 order by role, action",
+        [params.hubId]
+      );
+      return result.rows;
+    });
+    return { items: rows };
+  });
+
+  app.put("/v1/hubs/:hubId/permission-overrides", initializedAuthHandlers, async (request, reply) => {
+    const params = z.object({ hubId: z.string().min(1) }).parse(request.params);
+    const payload = z.object({
+      overrides: z.array(z.object({
+        role: z.string().min(1),
+        action: z.string().min(1),
+        allowed: z.boolean(),
+      }))
+    }).parse(request.body);
+
+    const allowed = await canManageHub({
+      productUserId: request.auth!.productUserId,
+      hubId: params.hubId
+    });
+    if (!allowed) {
+      reply.code(403).send({ message: "Forbidden: insufficient hub management scope." });
+      return;
+    }
+
+    const { withDb } = await import("../db/client.js");
+    await withDb(async (db) => {
+      for (const ov of payload.overrides) {
+        await db.query(
+          `insert into hub_permission_overrides (hub_id, role, action, allowed)
+           values ($1, $2, $3, $4)
+           on conflict (hub_id, role, action) do update set allowed = excluded.allowed`,
+          [params.hubId, ov.role, ov.action, ov.allowed]
+        );
+      }
+    });
+
+    // Invalidate the cache so the next permission check picks up changes
+    clearHubPermissionOverrideCache();
+
+    reply.code(204).send();
   });
 }

--- a/apps/control-plane/src/services/policy-service.ts
+++ b/apps/control-plane/src/services/policy-service.ts
@@ -386,8 +386,55 @@ async function resolveAccessLevel(
   return input.audienceTier === "visitor" ? "hidden" : "chat";
 }
 
-export function bindingAllowsAction(binding: RoleBinding, action: PrivilegedAction): boolean {
-  return (permissionMatrix[binding.role] || []).includes(action);
+export function bindingAllowsAction(binding: RoleBinding, action: PrivilegedAction, hubId?: string | null): boolean {
+  const globalAllowed = (permissionMatrix[binding.role] || []).includes(action);
+  if (!globalAllowed && hubId) {
+    // Sync check from cache (loaded by bindingAllowsActionHubAware or hub routes)
+    const cached = overrideCache.get(hubId);
+    return cached?.get(`${binding.role}:${action}`) ?? false;
+  }
+  return globalAllowed;
+}
+
+export async function bindingAllowsActionHubAware(
+  binding: RoleBinding,
+  action: PrivilegedAction,
+  hubId: string
+): Promise<boolean> {
+  const globalAllowed = (permissionMatrix[binding.role] || []).includes(action);
+  if (!globalAllowed) {
+    // Check for per-hub override granting this action
+    const overrides = await loadHubPermissionOverrides(hubId);
+    return overrides.get(`${binding.role}:${action}`) ?? false;
+  }
+  return true;
+}
+
+let overrideCache = new Map<string, Map<string, boolean>>(); // hubId → (role:action → allowed)
+
+export function clearHubPermissionOverrideCache(): void {
+  overrideCache = new Map();
+}
+
+async function loadHubPermissionOverrides(hubId: string): Promise<Map<string, boolean>> {
+  const cached = overrideCache.get(hubId);
+  if (cached) return cached;
+
+  const map = new Map<string, boolean>();
+  const rows = await withDb(async (db) => {
+    const result = await db.query<{ role: string; action: string; allowed: boolean }>(
+      "select role, action, allowed from hub_permission_overrides where hub_id = $1",
+      [hubId]
+    );
+    return result.rows;
+  });
+
+  for (const row of rows) {
+    map.set(`${row.role}:${row.action}`, row.allowed);
+  }
+
+  overrideCache.set(hubId, map);
+  return map;
 }
 
 export async function grantRole(input: {
@@ -628,6 +675,11 @@ export async function isActionAllowed(input: {
   authContext?: ScopedAuthContext;
 }): Promise<boolean> {
   return withDb(async (db) => {
+    // Warm the permission override cache for this hub
+    if (input.scope.hubId) {
+      await loadHubPermissionOverrides(input.scope.hubId);
+    }
+
     // 1. Get Effective Roles & Owner Suspension Status
     const roles = await getEffectiveRoleBindings(db, {
       productUserId: input.productUserId,
@@ -649,7 +701,7 @@ export async function isActionAllowed(input: {
 
     // 2. Check traditional permission matrix first (for management actions)
     const isRoleAllowedByMatrix = roles.some((binding) =>
-      bindingAllowsAction(binding, input.action) &&
+      bindingAllowsAction(binding, input.action, input.scope.hubId) &&
       bindingMatchesScope(binding, input.scope)
     );
 


### PR DESCRIPTION
Hub owners can now grant additional privileged actions to specific roles on a per-hub basis.

**Example:** Hub owner wants space_moderators to see the audit log:
```
PUT /v1/hubs/:id/permission-overrides
{ "overrides": [{ "role": "space_moderator", "action": "audit.read", "allowed": true }] }
```

**How it works:**
- hub_permission_overrides table stores (hub_id, role, action, allowed)
- bindingAllowsAction checks per-hub cache when hubId is provided
- Cache warmed before permission checks, invalidated on PUT
- If no overrides exist → global permissionMatrix applies unchanged

**Routes:**
- GET /v1/hubs/:hubId/permission-overrides (hub_owner/admin)
- PUT /v1/hubs/:hubId/permission-overrides (replaces all overrides)

Closes #101.