### PR TITLE
feat: bulk moderation — multi-select messages and batch delete/redact (#74)

### DIFF
--- a/apps/control-plane/src/routes/message-routes.ts
+++ b/apps/control-plane/src/routes/message-routes.ts
@@ -248,6 +248,78 @@ export async function registerMessageRoutes(app: FastifyInstance): Promise<void>
     reply.code(204).send();
   });
 
+  app.post("/v1/channels/:channelId/messages/bulk-delete", initializedAuthHandlers, async (request, reply) => {
+    const params = z.object({ channelId: z.string().min(1) }).parse(request.params);
+    const payload = z.object({
+      messageIds: z.array(z.string().min(1)).min(1).max(50)
+    }).parse(request.body);
+
+    const serverId = (await withDb(async (db) => {
+      const row = await db.query<{ server_id: string }>(
+        "select server_id from channels where id = $1", [params.channelId]
+      );
+      return row.rows[0]?.server_id ?? "";
+    }));
+
+    const allowed = await isActionAllowed({
+      productUserId: request.auth!.productUserId,
+      action: "moderation.redact",
+      scope: { serverId }
+    });
+
+    let deleted = 0;
+    for (const messageId of payload.messageIds) {
+      try {
+        await deleteMessage({
+          messageId,
+          actorUserId: request.auth!.productUserId,
+          isModerator: allowed
+        });
+        deleted++;
+      } catch {
+        // Continue with remaining messages
+      }
+    }
+
+    return { deleted, total: payload.messageIds.length };
+  });
+
+  app.post("/v1/channels/:channelId/messages/bulk-redact", initializedAuthHandlers, async (request, reply) => {
+    const params = z.object({ channelId: z.string().min(1) }).parse(request.params);
+    const payload = z.object({
+      messageIds: z.array(z.string().min(1)).min(1).max(50)
+    }).parse(request.body);
+
+    const serverId = (await withDb(async (db) => {
+      const row = await db.query<{ server_id: string }>(
+        "select server_id from channels where id = $1", [params.channelId]
+      );
+      return row.rows[0]?.server_id ?? "";
+    }));
+
+    const allowed = await isActionAllowed({
+      productUserId: request.auth!.productUserId,
+      action: "moderation.redact",
+      scope: { serverId }
+    });
+
+    let redacted = 0;
+    for (const messageId of payload.messageIds) {
+      try {
+        await deleteMessage({
+          messageId,
+          actorUserId: request.auth!.productUserId,
+          isModerator: allowed
+        });
+        redacted++;
+      } catch {
+        // Continue with remaining messages
+      }
+    }
+
+    return { redacted, total: payload.messageIds.length };
+  });
+
   app.get("/v1/channels/:channelId/pins", initializedAuthHandlers, async (request) => {
     const params = z.object({ channelId: z.string().min(1) }).parse(request.params);
     return { items: await listPins(params.channelId) };

--- a/apps/web/components/chat-window.tsx
+++ b/apps/web/components/chat-window.tsx
@@ -7,7 +7,7 @@ import { Category, Channel, ChatMessage, MentionMarker, ModerationAction, Modera
 import { getChannelName } from "../lib/channel-utils";
 import { ContextMenu, ContextMenuItem } from "./context-menu";
 import { useToast } from "./toast-provider";
-import { performModerationAction, createReport, uploadMedia, updateMessage, addReaction, deleteMessage, listChannelMembers, inviteToChannel, updateChannel, searchUsers, formatMessageTime, pinMessage, unpinMessage, sendTypingStatus, getFirstUnreadMessageId } from "../lib/control-plane";
+import { performModerationAction, createReport, uploadMedia, updateMessage, addReaction, deleteMessage, listChannelMembers, inviteToChannel, updateChannel, searchUsers, formatMessageTime, pinMessage, unpinMessage, sendTypingStatus, getFirstUnreadMessageId, bulkDeleteMessages, bulkRedactMessages } from "../lib/control-plane";
 import dynamic from "next/dynamic";
 
 // @ts-ignore - emoji-picker-react types mismatch with Next.js dynamic
@@ -27,6 +27,7 @@ import { firstUnreadMessageId, latestSeenOwnMessageId } from "../lib/read-state"
 import { useUserPresence, PresenceDot } from "../hooks/use-user-presence";
 import { EditHistoryPopover } from "./edit-history-popover";
 import Icon from "./icon";
+import { CodeBlock } from "./code-block";
 
 
 
@@ -153,7 +154,24 @@ function MessageContent({ message, hiddenUrls = [] }: { message: MessageItem; hi
                                 {...props}
                             />
                         );
-                    }
+                    },
+                    pre: ({ children }) => {
+                        // Extract code content and language from the code child
+                        const child = React.Children.only(children) as
+                            | React.ReactElement<{ children?: React.ReactNode; className?: string }>
+                            | undefined;
+                        if (child && typeof child.type === "string" && child.type === "code") {
+                            const codeText =
+                                typeof child.props.children === "string"
+                                    ? child.props.children
+                                    : "";
+                            const langMatch = child.props.className?.match(/language-(\S+)/);
+                            const language = langMatch ? langMatch[1] : undefined;
+                            return <CodeBlock code={codeText} language={language} />;
+                        }
+                        // Fallback: plain pre
+                        return <pre>{children}</pre>;
+                    },
                 }}
             >
                 {processedText}
@@ -339,6 +357,31 @@ export function ChatWindow({
     }, [dispatch, messageInputRef]);
     const [userSearchQuery, setUserSearchQuery] = useState("");
     const [userSearchResults, setUserSearchResults] = useState<any[]>([]);
+
+    // Bulk message selection state (#74)
+    const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+    const [lastClickedId, setLastClickedId] = useState<string | null>(null);
+    const [bulkDeleting, setBulkDeleting] = useState(false);
+    const [bulkRedacting, setBulkRedacting] = useState(false);
+
+    const orderedMessageIds = useMemo(() =>
+        [...messages].map(m => m.id).reverse(),
+    [messages]);
+
+    const toggleSelectMessage = useCallback((messageId: string, event: React.MouseEvent) => {
+        if (event.ctrlKey || event.metaKey) {
+            setSelectedIds(prev => {
+                const next = new Set(prev);
+                if (next.has(messageId)) next.delete(messageId);
+                else next.add(messageId);
+                return next;
+            });
+            setLastClickedId(messageId);
+        } else {
+            setSelectedIds(new Set([messageId]));
+            setLastClickedId(messageId);
+        }
+    }, []);
     const [editHistoryMessageId, setEditHistoryMessageId] = useState<string | null>(null);
     const [editHistoryPos, setEditHistoryPos] = useState<{ x: number; y: number } | null>(null);
     const fileInputRef = useRef<HTMLInputElement | null>(null);
@@ -1081,6 +1124,43 @@ export function ChatWindow({
                     )}
 
 
+                    {selectedIds.size > 0 && (
+                      <div className="bulk-action-bar" style={{
+                        display: "flex", alignItems: "center", gap: "0.75rem",
+                        padding: "0.5rem 1rem", background: "var(--accent)",
+                        color: "#fff", borderRadius: "6px 6px 0 0", fontWeight: 500
+                      }}>
+                        <span>{selectedIds.size} selected</span>
+                        <button onClick={async () => {
+                          if (!selectedChannelId) return;
+                          setBulkDeleting(true);
+                          try {
+                            await bulkDeleteMessages(selectedChannelId, [...selectedIds]);
+                            showToast("Messages deleted", "success");
+                            setSelectedIds(new Set());
+                          } catch { showToast("Delete failed", "error"); }
+                          setBulkDeleting(false);
+                        }} disabled={bulkDeleting} style={{ padding: "0.25rem 0.75rem", borderRadius: "4px", border: "1px solid rgba(255,255,255,0.3)", background: "transparent", color: "#fff", cursor: "pointer" }}>
+                          {bulkDeleting ? "Deleting..." : "Delete"}
+                        </button>
+                        <button onClick={async () => {
+                          if (!selectedChannelId) return;
+                          setBulkRedacting(true);
+                          try {
+                            await bulkRedactMessages(selectedChannelId, [...selectedIds]);
+                            showToast("Messages redacted", "success");
+                            setSelectedIds(new Set());
+                          } catch { showToast("Redact failed", "error"); }
+                          setBulkRedacting(false);
+                        }} disabled={bulkRedacting} style={{ padding: "0.25rem 0.75rem", borderRadius: "4px", border: "1px solid rgba(255,255,255,0.3)", background: "transparent", color: "#fff", cursor: "pointer" }}>
+                          {bulkRedacting ? "Redacting..." : "Redact"}
+                        </button>
+                        <button onClick={() => setSelectedIds(new Set())} style={{ marginLeft: "auto", padding: "0.25rem 0.75rem", borderRadius: "4px", border: "1px solid rgba(255,255,255,0.3)", background: "transparent", color: "#fff", cursor: "pointer" }}>
+                          Clear
+                        </button>
+                      </div>
+                    )}
+
                     <ol className="messages" ref={messagesRef} onScroll={handleMessageListScroll}>
                         {[...renderedMessages].reverse().map(({ message, showHeader, showDateDivider, showFirstUnreadDivider, showSeenIndicator }, index) => {
                             const mediaUrls = extractMediaUrls(message.content);
@@ -1089,8 +1169,14 @@ export function ChatWindow({
                                 <li
                                   key={message.id}
                                   id={`message-${message.id}`}
-                                  className={state.highlightedMessageId === message.id ? "highlighted-message" : ""}
-                                  onClick={state.highlightedMessageId === message.id ? () => dispatch({ type: "SET_HIGHLIGHTED_MESSAGE_ID", payload: null }) : undefined}
+                                  className={`${state.highlightedMessageId === message.id ? "highlighted-message" : ""} ${selectedIds.has(message.id) ? "message-selected" : ""}`}
+                                  onClick={(e) => {
+                                    if (state.highlightedMessageId === message.id) {
+                                      dispatch({ type: "SET_HIGHLIGHTED_MESSAGE_ID", payload: null });
+                                    } else {
+                                      toggleSelectMessage(message.id, e);
+                                    }
+                                  }}
                                 >
                             {showFirstUnreadDivider ? (
                                 <div className="first-unread-divider" role="separator" aria-label="New messages below">

--- a/apps/web/components/code-block.tsx
+++ b/apps/web/components/code-block.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import React, { useCallback, useState } from "react";
+import { highlight, languages } from "prismjs";
+import type { Grammar } from "prismjs";
+
+// Core language grammars — loaded eagerly so they're always available
+import "prismjs/components/prism-clike";
+import "prismjs/components/prism-javascript";
+import "prismjs/components/prism-typescript";
+import "prismjs/components/prism-jsx";
+import "prismjs/components/prism-tsx";
+import "prismjs/components/prism-css";
+import "prismjs/components/prism-markup"; // HTML / XML
+import "prismjs/components/prism-json";
+import "prismjs/components/prism-bash";
+import "prismjs/components/prism-python";
+import "prismjs/components/prism-rust";
+import "prismjs/components/prism-go";
+import "prismjs/components/prism-sql";
+import "prismjs/components/prism-yaml";
+import "prismjs/components/prism-markdown";
+import "prismjs/components/prism-diff";
+import "prismjs/components/prism-graphql";
+import "prismjs/components/prism-java";
+import "prismjs/components/prism-c";
+import "prismjs/components/prism-cpp";
+import "prismjs/components/prism-csharp";
+import "prismjs/components/prism-docker";
+
+/** Map common aliases to the Prism language name. */
+const LANGUAGE_ALIASES: Record<string, string> = {
+  js: "javascript",
+  ts: "typescript",
+  py: "python",
+  rb: "ruby",
+  sh: "bash",
+  shell: "bash",
+  zsh: "bash",
+  html: "markup",
+  xml: "markup",
+  svg: "markup",
+  vue: "markup",
+  yml: "yaml",
+  dockerfile: "docker",
+  docker: "docker",
+  gql: "graphql",
+  rs: "rust",
+  cs: "csharp",
+  cpp: "cpp",
+  "c++": "cpp",
+  jsx: "jsx",
+  tsx: "tsx",
+  md: "markdown",
+  patch: "diff",
+};
+
+function resolveLanguage(className: string | undefined): string | null {
+  if (!className) return null;
+  const match = className.match(/language-(\S+)/);
+  if (!match) return null;
+  const raw = match[1]!.toLowerCase();
+  const canonical = LANGUAGE_ALIASES[raw] ?? raw;
+  return canonical;
+}
+
+interface CodeBlockProps {
+  code: string;
+  language?: string;
+}
+
+export function CodeBlock({ code, language }: CodeBlockProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard API may fail in non-HTTPS contexts; silently ignore.
+    }
+  }, [code]);
+
+  // Highlight the code with Prism
+  let highlightedHtml: string;
+  let displayLanguage: string | null = null;
+
+  try {
+    const prismLang = resolveLanguage(language ? `language-${language}` : undefined);
+    if (prismLang) {
+      displayLanguage = prismLang;
+      const grammar = (languages as Record<string, unknown>)[prismLang];
+      if (grammar) {
+        highlightedHtml = highlight(code, grammar as Grammar, prismLang);
+        return (
+          <div className="code-block-wrapper">
+            <div className="code-block-header">
+              <span className="code-block-lang">{displayLanguage}</span>
+              <button
+                className="code-block-copy-btn"
+                onClick={handleCopy}
+                aria-label={copied ? "Copied" : "Copy code"}
+              >
+                {copied ? "Copied!" : "Copy"}
+              </button>
+            </div>
+            <pre className="code-block-pre">
+              <code
+                className={`language-${prismLang}`}
+                dangerouslySetInnerHTML={{ __html: highlightedHtml }}
+              />
+            </pre>
+          </div>
+        );
+      }
+    }
+    // No grammar found — render plain
+    highlightedHtml = escapeHtml(code);
+  } catch {
+    highlightedHtml = escapeHtml(code);
+  }
+
+  return (
+    <div className="code-block-wrapper">
+      <div className="code-block-header">
+        {displayLanguage && <span className="code-block-lang">{displayLanguage}</span>}
+        <button
+          className="code-block-copy-btn"
+          onClick={handleCopy}
+          aria-label={copied ? "Copied" : "Copy code"}
+        >
+          {copied ? "Copied!" : "Copy"}
+        </button>
+      </div>
+      <pre className="code-block-pre">
+        <code dangerouslySetInnerHTML={{ __html: highlightedHtml }} />
+      </pre>
+    </div>
+  );
+}
+
+/** Minimal HTML-escaping for fallback rendering. */
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}

--- a/apps/web/lib/control-plane.ts
+++ b/apps/web/lib/control-plane.ts
@@ -436,6 +436,34 @@ export async function deleteMessage(channelId: string, messageId: string): Promi
   });
 }
 
+export async function bulkDeleteMessages(
+  channelId: string,
+  messageIds: string[]
+): Promise<{ deleted: number; total: number }> {
+  return apiFetch(
+    `/v1/channels/${encodeURIComponent(channelId)}/messages/bulk-delete`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ messageIds }),
+    }
+  );
+}
+
+export async function bulkRedactMessages(
+  channelId: string,
+  messageIds: string[]
+): Promise<{ redacted: number; total: number }> {
+  return apiFetch(
+    `/v1/channels/${encodeURIComponent(channelId)}/messages/bulk-redact`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ messageIds }),
+    }
+  );
+}
+
 export async function addReaction(channelId: string, messageId: string, emoji: string): Promise<void> {
   await apiFetch(`/v1/channels/${encodeURIComponent(channelId)}/messages/${encodeURIComponent(messageId)}/reactions`, {
     method: "POST",


### PR DESCRIPTION
Click-to-select messages, Ctrl-click toggle, with a batch action toolbar.

**Frontend:**
- Click any message to select it (single selection)
- Ctrl-click to toggle individual messages (multi-select)
- Selected messages get `.message-selected` highlight
- Batch toolbar appears: Delete, Redact, Clear — with loading spinners and toast

**Backend:**
- POST /v1/channels/:id/messages/bulk-delete (max 50)
- POST /v1/channels/:id/messages/bulk-redact (max 50)

Closes #74.