### PR TITLE
feat: passkeys (WebAuthn) + TOTP 2FA with per-hub configuration (#73)

### DIFF
--- a/apps/control-plane/migrations/1776800000000_046-passkeys-and-totp.js
+++ b/apps/control-plane/migrations/1776800000000_046-passkeys-and-totp.js
@@ -1,0 +1,51 @@
+export const up = (pgm) => {
+    pgm.createTable('webauthn_credentials', {
+        id: { type: 'text', notNull: true, primaryKey: true },
+        hub_id: { type: 'text', notNull: true, references: 'hubs', onDelete: 'cascade' },
+        product_user_id: { type: 'text', notNull: true },
+        credential_id: { type: 'text', notNull: true, unique: true },
+        public_key: { type: 'text', notNull: true },
+        sign_count: { type: 'integer', notNull: true, default: 0 },
+        label: { type: 'text' },
+        has_pin: { type: 'boolean', notNull: true, default: false },
+        pin_hash: { type: 'text' },
+        created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+        last_used_at: { type: 'timestamptz' },
+    });
+
+    pgm.createTable('totp_secrets', {
+        hub_id: { type: 'text', notNull: true, references: 'hubs', onDelete: 'cascade' },
+        product_user_id: { type: 'text', notNull: true },
+        secret: { type: 'text', notNull: true },
+        enabled: { type: 'boolean', notNull: true, default: false },
+        created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    });
+    pgm.addConstraint('totp_secrets', 'totp_secrets_pk', {
+        primaryKey: ['hub_id', 'product_user_id'],
+    });
+
+    pgm.createTable('recovery_codes', {
+        id: { type: 'text', primaryKey: true },
+        hub_id: { type: 'text', notNull: true, references: 'hubs', onDelete: 'cascade' },
+        product_user_id: { type: 'text', notNull: true },
+        code_hash: { type: 'text', notNull: true },
+        used_at: { type: 'timestamptz' },
+        created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    });
+
+    pgm.addColumn('hubs', {
+        allow_passkey_login: { type: 'boolean', notNull: true, default: false },
+    });
+
+    pgm.addColumn('hub_permission_overrides', {
+        require_2fa: { type: 'boolean', notNull: true, default: false },
+    });
+};
+
+export const down = (pgm) => {
+    pgm.dropColumn('hub_permission_overrides', 'require_2fa');
+    pgm.dropColumn('hubs', 'allow_passkey_login');
+    pgm.dropTable('recovery_codes');
+    pgm.dropTable('totp_secrets');
+    pgm.dropTable('webauthn_credentials');
+};

--- a/apps/control-plane/package.json
+++ b/apps/control-plane/package.json
@@ -20,6 +20,7 @@
     "@aws-sdk/client-s3": "^3.998.0",
     "@fastify/cors": "^10.0.2",
     "@fastify/sensible": "^6.0.2",
+    "@simplewebauthn/server": "^13.3.0",
     "@skerry/shared": "workspace:*",
     "cheerio": "^1.2.0",
     "discord.js": "^14.25.1",
@@ -27,6 +28,7 @@
     "fastify": "^5.1.0",
     "livekit-server-sdk": "^2.15.0",
     "node-pg-migrate": "^8.0.4",
+    "otpauth": "^9.5.1",
     "pg": "^8.13.1",
     "web-push": "^3.6.7",
     "zod": "^3.24.1"

--- a/apps/control-plane/src/routes/auth-routes.ts
+++ b/apps/control-plane/src/routes/auth-routes.ts
@@ -719,4 +719,216 @@ export async function registerAuthRoutes(app: FastifyInstance): Promise<void> {
       throw error;
     }
   });
+
+  // --- WebAuthn / Passkeys (#73) ---
+
+  const {
+    beginRegistration,
+    completeRegistration,
+    beginAuthentication,
+    completeAuthentication,
+    listCredentials,
+    removeCredential,
+  } = await import("../services/webauthn-service.js");
+
+  const {
+    beginTotpEnrollment,
+    verifyTotpEnrollment,
+    verifyTotp,
+    hasTotpEnabled,
+    removeTotp,
+  } = await import("../services/totp-service.js");
+
+  const {
+    generateRecoveryCodes,
+    redeemRecoveryCode,
+    countRecoveryCodes,
+  } = await import("../services/recovery-service.js");
+
+  const { setSessionCookie } = await import("../auth/session.js");
+
+  // Register a new passkey
+  app.post("/v1/hubs/:hubId/webauthn/register/begin", { preHandler: requireAuth }, async (request, reply) => {
+    const params = z.object({ hubId: z.string().min(1) }).parse(request.params);
+    const opts = await beginRegistration({
+      hubId: params.hubId,
+      productUserId: request.auth!.productUserId,
+    });
+    return opts;
+  });
+
+  app.post("/v1/hubs/:hubId/webauthn/register/complete", { preHandler: requireAuth }, async (request, reply) => {
+    const params = z.object({ hubId: z.string().min(1) }).parse(request.params);
+    const payload = z.object({
+      response: z.any(),
+      label: z.string().max(40).optional(),
+      pin: z.string().min(4).max(8).optional(),
+    }).parse(request.body);
+
+    const credential = await completeRegistration({
+      hubId: params.hubId,
+      productUserId: request.auth!.productUserId,
+      response: payload.response,
+      label: payload.label,
+      pin: payload.pin,
+    });
+
+    const remaining = await countRecoveryCodes(params.hubId, request.auth!.productUserId);
+    let recoveryCodes: string[] | undefined;
+    if (remaining === 0) {
+      recoveryCodes = await generateRecoveryCodes(params.hubId, request.auth!.productUserId);
+    }
+
+    return { credential, recoveryCodes };
+  });
+
+  // Passkey login
+  app.post("/v1/hubs/:hubId/webauthn/authenticate/begin", async (request, reply) => {
+    const params = z.object({ hubId: z.string().min(1) }).parse(request.params);
+    const query = z.object({ productUserId: z.string().optional() }).parse(request.query ?? {});
+
+    const opts = await beginAuthentication({
+      hubId: params.hubId,
+      productUserId: query.productUserId,
+    });
+    return opts;
+  });
+
+  app.post("/v1/hubs/:hubId/webauthn/authenticate/complete", async (request, reply) => {
+    const params = z.object({ hubId: z.string().min(1) }).parse(request.params);
+    const payload = z.object({ response: z.any() }).parse(request.body);
+
+    const { withDb } = await import("../db/client.js");
+    const hubRow = await withDb(async (db) => {
+      const result = await db.query<{ allow_passkey_login: boolean }>(
+        "select allow_passkey_login from hubs where id = $1", [params.hubId]
+      );
+      return result.rows[0] ?? null;
+    });
+
+    if (!hubRow?.allow_passkey_login) {
+      reply.code(403).send({ message: "Passkey login is not enabled on this hub.", code: "passkey_disabled" });
+      return;
+    }
+
+    try {
+      const result = await completeAuthentication({
+        hubId: params.hubId,
+        response: payload.response,
+      });
+
+      setSessionCookie(reply, {
+        productUserId: result.productUserId,
+        provider: "webauthn",
+        oidcSubject: result.credentialId,
+      });
+
+      return { productUserId: result.productUserId, authenticated: true };
+    } catch (err) {
+      reply.code(401).send({ message: "Authentication failed.", code: "webauthn_failed" });
+    }
+  });
+
+  // List credentials
+  app.get("/v1/hubs/:hubId/webauthn/credentials", { preHandler: requireAuth }, async (request) => {
+    const params = z.object({ hubId: z.string().min(1) }).parse(request.params);
+    return { items: await listCredentials(params.hubId, request.auth!.productUserId) };
+  });
+
+  // Remove a credential
+  app.delete("/v1/hubs/:hubId/webauthn/credentials/:id", { preHandler: requireAuth }, async (request, reply) => {
+    const params = z.object({ hubId: z.string().min(1), id: z.string().min(1) }).parse(request.params);
+    await removeCredential(params.id, request.auth!.productUserId);
+    reply.code(204).send();
+  });
+
+  // --- TOTP (#73) ---
+
+  app.post("/v1/hubs/:hubId/totp/enroll", { preHandler: requireAuth }, async (request) => {
+    const params = z.object({ hubId: z.string().min(1) }).parse(request.params);
+    return await beginTotpEnrollment({
+      hubId: params.hubId,
+      productUserId: request.auth!.productUserId,
+    });
+  });
+
+  app.post("/v1/hubs/:hubId/totp/verify-enrollment", { preHandler: requireAuth }, async (request, reply) => {
+    const params = z.object({ hubId: z.string().min(1) }).parse(request.params);
+    const payload = z.object({ code: z.string().length(6) }).parse(request.body);
+    const ok = await verifyTotpEnrollment({
+      hubId: params.hubId,
+      productUserId: request.auth!.productUserId,
+      code: payload.code,
+    });
+    if (!ok) {
+      reply.code(400).send({ message: "Invalid code.", code: "totp_invalid" });
+      return;
+    }
+    return { enrolled: true };
+  });
+
+  app.post("/v1/hubs/:hubId/totp/verify", { preHandler: requireAuth }, async (request, reply) => {
+    const params = z.object({ hubId: z.string().min(1) }).parse(request.params);
+    const payload = z.object({ code: z.string().length(6) }).parse(request.body);
+    const ok = await verifyTotp({
+      hubId: params.hubId,
+      productUserId: request.auth!.productUserId,
+      code: payload.code,
+    });
+    if (!ok) {
+      reply.code(400).send({ message: "Invalid code.", code: "totp_invalid" });
+      return;
+    }
+    return { verified: true };
+  });
+
+  app.delete("/v1/hubs/:hubId/totp", { preHandler: requireAuth }, async (request, reply) => {
+    const params = z.object({ hubId: z.string().min(1) }).parse(request.params);
+    await removeTotp(params.hubId, request.auth!.productUserId);
+    reply.code(204).send();
+  });
+
+  // --- Recovery codes (#73) ---
+
+  app.post("/v1/hubs/:hubId/recovery/redeem", async (request, reply) => {
+    const params = z.object({ hubId: z.string().min(1) }).parse(request.params);
+    const payload = z.object({ code: z.string().min(1) }).parse(request.body);
+
+    const { withDb } = await import("../db/client.js");
+    const rows = await withDb(async (db) => {
+      const result = await db.query<{ product_user_id: string; code_hash: string }>(
+        "select product_user_id, code_hash from recovery_codes where hub_id = $1 and used_at is null",
+        [params.hubId]
+      );
+      return result.rows;
+    });
+
+    let foundUserId: string | null = null;
+    const { bcryptVerify } = await import("../services/webauthn-service.js");
+    for (const row of rows) {
+      if (await bcryptVerify(payload.code, row.code_hash)) {
+        foundUserId = row.product_user_id;
+        await withDb(async (db) => {
+          await db.query(
+            "update recovery_codes set used_at = now() where product_user_id = $1 and hub_id = $2 and used_at is null",
+            [row.product_user_id, params.hubId]
+          );
+        });
+        break;
+      }
+    }
+
+    if (!foundUserId) {
+      reply.code(400).send({ message: "Invalid recovery code.", code: "recovery_invalid" });
+      return;
+    }
+
+    setSessionCookie(reply, {
+      productUserId: foundUserId,
+      provider: "recovery",
+      oidcSubject: foundUserId,
+    });
+
+    return { productUserId: foundUserId, authenticated: true };
+  });
 }

--- a/apps/control-plane/src/services/recovery-service.ts
+++ b/apps/control-plane/src/services/recovery-service.ts
@@ -1,0 +1,70 @@
+import crypto from "node:crypto";
+import { withDb } from "../db/client.js";
+import { bcryptHash, bcryptVerify } from "./webauthn-service.js";
+
+const RECOVERY_CODE_COUNT = 8;
+const RECOVERY_CODE_BYTES = 10; // 20 hex chars per code
+
+/**
+ * Generate recovery codes for a user on a hub. Returns the plaintext codes 
+ * once; stores only hashes.
+ */
+export async function generateRecoveryCodes(hubId: string, productUserId: string): Promise<string[]> {
+    const codes: string[] = [];
+    for (let i = 0; i < RECOVERY_CODE_COUNT; i++) {
+        codes.push(crypto.randomBytes(RECOVERY_CODE_BYTES).toString("hex"));
+    }
+
+    await withDb(async (db) => {
+        for (const code of codes) {
+            const hash = await bcryptHash(code);
+            await db.query(
+                `insert into recovery_codes (id, hub_id, product_user_id, code_hash)
+                 values ($1, $2, $3, $4)`,
+                [`rec_${crypto.randomUUID().replaceAll("-", "")}`, hubId, productUserId, hash]
+            );
+        }
+    });
+
+    return codes;
+}
+
+/**
+ * Verify and consume a recovery code. Returns true if valid and unused.
+ */
+export async function redeemRecoveryCode(hubId: string, productUserId: string, code: string): Promise<boolean> {
+    const rows = await withDb(async (db) => {
+        const result = await db.query<{ id: string; code_hash: string }>(
+            "select id, code_hash from recovery_codes where product_user_id = $1 and hub_id = $2 and used_at is null",
+            [productUserId, hubId]
+        );
+        return result.rows;
+    });
+
+    for (const row of rows) {
+        if (await bcryptVerify(code, row.code_hash)) {
+            await withDb(async (db) => {
+                await db.query(
+                    "update recovery_codes set used_at = now() where id = $1",
+                    [row.id]
+                );
+            });
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
+ * Count unused recovery codes for a user on a hub.
+ */
+export async function countRecoveryCodes(hubId: string, productUserId: string): Promise<number> {
+    return withDb(async (db) => {
+        const result = await db.query<{ count: string }>(
+            "select count(*) as count from recovery_codes where product_user_id = $1 and hub_id = $2 and used_at is null",
+            [productUserId, hubId]
+        );
+        return parseInt(result.rows[0]?.count ?? "0", 10);
+    });
+}

--- a/apps/control-plane/src/services/totp-service.ts
+++ b/apps/control-plane/src/services/totp-service.ts
@@ -1,0 +1,131 @@
+import { TOTP } from "otpauth";
+import crypto from "node:crypto";
+import { withDb } from "../db/client.js";
+
+const ISSUER = "Skerry";
+
+/**
+ * Generate a new TOTP secret for enrollment. Returns the secret (for QR) 
+ * and a verification token to confirm enrollment.
+ */
+export async function beginTotpEnrollment(input: {
+    hubId: string;
+    productUserId: string;
+    email?: string | null;
+}): Promise<{ secret: string; uri: string }> {
+    const secret = new TOTP({
+        issuer: ISSUER,
+        label: input.email ?? input.productUserId,
+        algorithm: "SHA1",
+        digits: 6,
+        period: 30,
+    });
+    const secretStr = secret.secret as unknown as string;
+
+    const uri = `otpauth://totp/${ISSUER}:${encodeURIComponent(input.email ?? input.productUserId)}?secret=${secretStr}&issuer=${ISSUER}&algorithm=SHA1&digits=6&period=30`;
+
+    // Store the secret (unverified) so it can be confirmed
+    await withDb(async (db) => {
+        await db.query(
+            `insert into totp_secrets (hub_id, product_user_id, secret, enabled)
+             values ($1, $2, $3, false)
+             on conflict (hub_id, product_user_id)
+             do update set secret = excluded.secret, enabled = false`,
+            [input.hubId, input.productUserId, secretStr]
+        );
+    });
+
+    return { secret: secretStr, uri };
+}
+
+/**
+ * Verify a TOTP code to confirm enrollment.
+ */
+export async function verifyTotpEnrollment(input: {
+    hubId: string;
+    productUserId: string;
+    code: string;
+}): Promise<boolean> {
+    const row = await withDb(async (db) => {
+        const result = await db.query<{ secret: string }>(
+            "select secret from totp_secrets where hub_id = $1 and product_user_id = $2",
+            [input.hubId, input.productUserId]
+        );
+        return result.rows[0] ?? null;
+    });
+
+    if (!row) return false;
+
+    const totp = new TOTP({
+        issuer: ISSUER,
+        secret: row.secret,
+        algorithm: "SHA1",
+        digits: 6,
+        period: 30,
+    });
+
+    const delta = totp.validate({ token: input.code, window: 1 });
+    if (delta === null) return false;
+
+    // Mark as enabled
+    await withDb(async (db) => {
+        await db.query(
+            "update totp_secrets set enabled = true where hub_id = $1 and product_user_id = $2",
+            [input.hubId, input.productUserId]
+        );
+    });
+
+    return true;
+}
+
+/**
+ * Verify a TOTP code for 2FA enforcement.
+ */
+export async function verifyTotp(input: {
+    hubId: string;
+    productUserId: string;
+    code: string;
+}): Promise<boolean> {
+    const row = await withDb(async (db) => {
+        const result = await db.query<{ secret: string; enabled: boolean }>(
+            "select secret, enabled from totp_secrets where hub_id = $1 and product_user_id = $2",
+            [input.hubId, input.productUserId]
+        );
+        return result.rows[0] ?? null;
+    });
+
+    if (!row || !row.enabled) return false;
+
+    const totp = new TOTP({
+        issuer: ISSUER,
+        secret: row.secret,
+        algorithm: "SHA1",
+        digits: 6,
+        period: 30,
+    });
+
+    return totp.validate({ token: input.code, window: 1 }) !== null;
+}
+
+/**
+ * Check if a user has TOTP enrolled and enabled on a hub.
+ */
+export async function hasTotpEnabled(hubId: string, productUserId: string): Promise<boolean> {
+    const row = await withDb(async (db) => {
+        const result = await db.query<{ enabled: boolean }>(
+            "select enabled from totp_secrets where hub_id = $1 and product_user_id = $2",
+            [hubId, productUserId]
+        );
+        return result.rows[0] ?? null;
+    });
+    return row?.enabled ?? false;
+}
+
+/**
+ * Disable TOTP for a user on a hub.
+ */
+export async function removeTotp(hubId: string, productUserId: string): Promise<void> {
+    await withDb(async (db) => {
+        await db.query("delete from totp_secrets where hub_id = $1 and product_user_id = $2", [hubId, productUserId]);
+    });
+}

--- a/apps/control-plane/src/services/webauthn-service.ts
+++ b/apps/control-plane/src/services/webauthn-service.ts
@@ -1,0 +1,295 @@
+import crypto from "node:crypto";
+import {
+    generateRegistrationOptions,
+    verifyRegistrationResponse,
+    generateAuthenticationOptions,
+    verifyAuthenticationResponse,
+} from "@simplewebauthn/server";
+import type {
+    AuthenticatorTransportFuture,
+    RegistrationResponseJSON,
+    AuthenticationResponseJSON,
+} from "@simplewebauthn/server";
+import { withDb } from "../db/client.js";
+import { config } from "../config.js";
+
+export interface WebAuthnCredential {
+    id: string;
+    hubId: string;
+    productUserId: string;
+    credentialId: string;
+    publicKey: string;
+    signCount: number;
+    label: string | null;
+    hasPin: boolean;
+    pinHash: string | null;
+    createdAt: string;
+    lastUsedAt: string | null;
+}
+
+const rpName = config.synapse.serverName || "Skerry";
+const rpID = config.webBaseUrl ? new URL(config.webBaseUrl).hostname : "localhost";
+const rpOrigin = config.webBaseUrl || "http://localhost:8080";
+
+/**
+ * Generate credential creation options for the browser.
+ */
+export async function beginRegistration(input: {
+    hubId: string;
+    productUserId: string;
+    email?: string | null;
+}): Promise<PublicKeyCredentialCreationOptions> {
+    const existing = await withDb(async (db) => {
+        const result = await db.query<{ credential_id: string }>(
+            "select credential_id from webauthn_credentials where product_user_id = $1 and hub_id = $2",
+            [input.productUserId, input.hubId]
+        );
+        return result.rows;
+    });
+
+    const opts = await generateRegistrationOptions({
+        rpName,
+        rpID,
+        userID: Buffer.from(input.productUserId),
+        userName: input.email ?? input.productUserId,
+        userDisplayName: input.email ?? input.productUserId,
+        attestationType: "none",
+        excludeCredentials: existing.map((c) => ({
+            id: c.credential_id,
+            type: "public-key",
+        })),
+        authenticatorSelection: {
+            residentKey: "preferred",
+            userVerification: "preferred",
+        },
+    });
+
+    // Store challenge temporarily
+    await storeChallenge(input.hubId, input.productUserId, opts.challenge);
+
+    return opts as unknown as PublicKeyCredentialCreationOptions;
+}
+
+/**
+ * Verify a registration response and store the credential.
+ */
+export async function completeRegistration(input: {
+    hubId: string;
+    productUserId: string;
+    response: RegistrationResponseJSON;
+    label?: string;
+    pin?: string;
+}): Promise<WebAuthnCredential> {
+    const challenge = await popChallenge(input.hubId, input.productUserId);
+    if (!challenge) {
+        throw new Error("Registration challenge expired. Please try again.");
+    }
+
+    const verification = await verifyRegistrationResponse({
+        response: input.response,
+        expectedChallenge: challenge,
+        expectedOrigin: rpOrigin,
+        expectedRPID: rpID,
+    });
+
+    if (!verification.verified || !verification.registrationInfo) {
+        throw new Error("Registration verification failed.");
+    }
+
+    const { credential } = verification.registrationInfo;
+    const id = `wac_${crypto.randomUUID().replaceAll("-", "")}`;
+    const pinHash = input.pin ? await bcryptHash(input.pin) : null;
+
+    await withDb(async (db) => {
+        await db.query(
+            `insert into webauthn_credentials (id, hub_id, product_user_id, credential_id, public_key, sign_count, label, has_pin, pin_hash)
+             values ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+            [
+                id,
+                input.hubId,
+                input.productUserId,
+                credential.id,
+                Buffer.from(credential.publicKey).toString("base64"),
+                credential.counter,
+                input.label ?? null,
+                !!input.pin,
+                pinHash,
+            ]
+        );
+    });
+
+    return {
+        id,
+        hubId: input.hubId,
+        productUserId: input.productUserId,
+        credentialId: credential.id,
+        publicKey: Buffer.from(credential.publicKey).toString("base64"),
+        signCount: credential.counter,
+        label: input.label ?? null,
+        hasPin: !!input.pin,
+        pinHash,
+        createdAt: new Date().toISOString(),
+        lastUsedAt: null,
+    };
+}
+
+/**
+ * Generate authentication options for passkey login.
+ */
+export async function beginAuthentication(input: {
+    hubId: string;
+    productUserId?: string;
+}): Promise<PublicKeyCredentialRequestOptions> {
+    let credentials: { credential_id: string }[] = [];
+
+    if (input.productUserId) {
+        credentials = await withDb(async (db) => {
+            const result = await db.query<{ credential_id: string }>(
+                "select credential_id from webauthn_credentials where product_user_id = $1 and hub_id = $2",
+                [input.productUserId, input.hubId]
+            );
+            return result.rows;
+        });
+    }
+
+    const opts = await generateAuthenticationOptions({
+        rpID,
+        allowCredentials: credentials.map((c) => ({
+            id: c.credential_id,
+            type: "public-key",
+        })),
+        userVerification: "preferred",
+    });
+
+    await storeChallenge(input.hubId, input.productUserId ?? "__any__", opts.challenge);
+
+    return opts as unknown as PublicKeyCredentialRequestOptions;
+}
+
+/**
+ * Verify an authentication assertion and return the authenticated productUserId.
+ */
+export async function completeAuthentication(input: {
+    hubId: string;
+    response: AuthenticationResponseJSON;
+}): Promise<{ productUserId: string; credentialId: string }> {
+    const challenge = await popChallenge(input.hubId, "__any__");
+    if (!challenge) {
+        throw new Error("Authentication challenge expired. Please try again.");
+    }
+
+    const credential = await withDb(async (db) => {
+        const result = await db.query<WebAuthnCredential>(
+            "select * from webauthn_credentials where credential_id = $1 and hub_id = $2",
+            [input.response.id, input.hubId]
+        );
+        return result.rows[0] ?? null;
+    });
+
+    if (!credential) {
+        throw new Error("Unknown credential. This passkey is not registered on this hub.");
+    }
+
+    const verification = await verifyAuthenticationResponse({
+        response: input.response,
+        expectedChallenge: challenge,
+        expectedOrigin: rpOrigin,
+        expectedRPID: rpID,
+        credential: {
+            id: credential.credentialId,
+            publicKey: Buffer.from(credential.publicKey, "base64"),
+            counter: credential.signCount,
+        },
+    });
+
+    if (!verification.verified) {
+        throw new Error("Authentication verification failed.");
+    }
+
+    // Update sign count
+    await withDb(async (db) => {
+        await db.query(
+            `update webauthn_credentials set sign_count = $1, last_used_at = now()
+             where credential_id = $2 and hub_id = $3`,
+            [verification.authenticationInfo.newCounter, input.response.id, input.hubId]
+        );
+    });
+
+    return { productUserId: credential.productUserId, credentialId: credential.credentialId };
+}
+
+/**
+ * List credentials for a user on a hub.
+ */
+export async function listCredentials(hubId: string, productUserId: string): Promise<WebAuthnCredential[]> {
+    return withDb(async (db) => {
+        const result = await db.query<WebAuthnCredential>(
+            `select id, hub_id as "hubId", product_user_id as "productUserId", credential_id as "credentialId",
+                    public_key as "publicKey", sign_count as "signCount", label, has_pin as "hasPin",
+                    pin_hash as "pinHash", created_at as "createdAt", last_used_at as "lastUsedAt"
+             from webauthn_credentials
+             where product_user_id = $1 and hub_id = $2
+             order by created_at desc`,
+            [productUserId, hubId]
+        );
+        return result.rows;
+    });
+}
+
+/**
+ * Remove a credential.
+ */
+export async function removeCredential(id: string, productUserId: string): Promise<void> {
+    await withDb(async (db) => {
+        await db.query("delete from webauthn_credentials where id = $1 and product_user_id = $2", [id, productUserId]);
+    });
+}
+
+// --- Challenge store (in-memory — fine for single-node deployment) ---
+
+const challengeStore = new Map<string, { challenge: string; expiresAt: number }>();
+
+function challengeKey(hubId: string, productUserId: string): string {
+    return `${hubId}:${productUserId}`;
+}
+
+async function storeChallenge(hubId: string, productUserId: string, challenge: string): Promise<void> {
+    challengeStore.set(challengeKey(hubId, productUserId), {
+        challenge,
+        expiresAt: Date.now() + 5 * 60 * 1000, // 5 minutes
+    });
+}
+
+async function popChallenge(hubId: string, productUserId: string): Promise<string | null> {
+    const key = challengeKey(hubId, productUserId);
+    const entry = challengeStore.get(key);
+    if (!entry || Date.now() > entry.expiresAt) {
+        challengeStore.delete(key);
+        return null;
+    }
+    challengeStore.delete(key);
+    return entry.challenge;
+}
+
+// --- Minimal bcrypt via Node crypto ---
+
+export async function bcryptHash(input: string): Promise<string> {
+    const salt = crypto.randomBytes(16).toString("hex");
+    return new Promise((resolve, reject) => {
+        crypto.scrypt(input, salt, 64, (err, derived) => {
+            if (err) reject(err);
+            else resolve(`${salt}:${derived.toString("hex")}`);
+        });
+    });
+}
+
+export async function bcryptVerify(input: string, hash: string): Promise<boolean> {
+    const [salt, expected] = hash.split(":");
+    if (!salt || !expected) return false;
+    return new Promise((resolve, reject) => {
+        crypto.scrypt(input, salt, 64, (err, derived) => {
+            if (err) reject(err);
+            else resolve(derived.toString("hex") === expected);
+        });
+    });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@fastify/sensible':
         specifier: ^6.0.2
         version: 6.0.4
+      '@simplewebauthn/server':
+        specifier: ^13.3.0
+        version: 13.3.0
       '@skerry/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -56,6 +59,9 @@ importers:
       node-pg-migrate:
         specifier: ^8.0.4
         version: 8.0.4(@types/pg@8.16.0)(pg@8.18.0)
+      otpauth:
+        specifier: ^9.5.1
+        version: 9.5.1
       pg:
         specifier: ^8.13.1
         version: 8.18.0
@@ -619,6 +625,9 @@ packages:
   '@fastify/sensible@6.0.4':
     resolution: {integrity: sha512-1vxcCUlPMew6WroK8fq+LVOwbsLtX+lmuRuqpcp6eYqu6vmkLwbKTdBWAZwbeaSgCfW4tzUpTIHLLvTiQQ1BwQ==}
 
+  '@hexagon/base64@1.1.28':
+    resolution: {integrity: sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==}
+
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
     engines: {node: '>=10.10.0'}
@@ -639,6 +648,9 @@ packages:
   '@isaacs/cliui@9.0.0':
     resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
     engines: {node: '>=18'}
+
+  '@levischuck/tiny-cbor@0.2.11':
+    resolution: {integrity: sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==}
 
   '@livekit/mutex@1.1.1':
     resolution: {integrity: sha512-EsshAucklmpuUAfkABPxJNhzj9v2sG7JuzFDL4ML1oJQSV14sqrpTYnsaOudMAw9yOaW53NU3QQTlUQoRs4czw==}
@@ -717,6 +729,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@noble/hashes@2.2.0':
+    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
+    engines: {node: '>= 20.19.0'}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -736,6 +752,46 @@ packages:
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
+
+  '@peculiar/asn1-android@2.7.0':
+    resolution: {integrity: sha512-iD3VskhVQnM4nE3PN9cBdPTR7JrqZy3FYk+uD2CeG6DUqKoANqaEfx0f7izPmW+Qm5JBM35ek+viLCmjy18ByQ==}
+
+  '@peculiar/asn1-cms@2.7.0':
+    resolution: {integrity: sha512-hew63shtzzvBcSHbhm+cyAmKe6AIfinT9hzEqSPjDC6opTTMKmTkQ0gHuN2KsWlvqiKw1S/fS94fhag/FJkioQ==}
+
+  '@peculiar/asn1-csr@2.7.0':
+    resolution: {integrity: sha512-VVsAyGqErT9D1SY4aEqozThXMVI+ssVRiv2DDeYuvpBKLIgZ3hYs3Ay3u/VSoKq6ESFi9cf6rf3IOOzfwh7oMA==}
+
+  '@peculiar/asn1-ecc@2.7.0':
+    resolution: {integrity: sha512-n7KEs/Q/wrB415cxy4fHOBhegp4NdJ15fkJPwcB/3/8iNBQC2L/N7SChJPKDJPZGYH0jD4Tg4/0vnHmwghnbKw==}
+
+  '@peculiar/asn1-pfx@2.7.0':
+    resolution: {integrity: sha512-V/nrlQVmhg7lYAsM7E13UDL5erAwFv6kCIVFqNaMIHSVi7dngcT839JkRTkQBqznMG98l2XjxYk74ZztAohZzA==}
+
+  '@peculiar/asn1-pkcs8@2.7.0':
+    resolution: {integrity: sha512-9GTl1nE8Mx1kTZ+7QyYatDyKsm34QcWRBFkY1iPvWC3X4Dona5s/tlLiQsx5WzVdZqiMBZNYT0buyw4/vbhnjw==}
+
+  '@peculiar/asn1-pkcs9@2.7.0':
+    resolution: {integrity: sha512-Bh7m+OuIaSEllPQcSd9OSp93F4ROWH7sbITWV8MI+8dwsjE5111/87VxiWVvYFKyww3vp39geLv9ENqhwWHcew==}
+
+  '@peculiar/asn1-rsa@2.7.0':
+    resolution: {integrity: sha512-/qvENQrXyTZURjMqSeofHul0JJt2sNSzSwk36pl2olkHbaioMQgrASDZAlHXl0xUlnVbHj0uGgOrBMTb5x2aJQ==}
+
+  '@peculiar/asn1-schema@2.7.0':
+    resolution: {integrity: sha512-W8ZfWzLmQnrcky+eh3tni4IozMdqBDiHWU0N+vve/UGjMaUs8c0L7A2oEdkBXS8rTpWDpK/aoI3DG/L/hxmxPg==}
+
+  '@peculiar/asn1-x509-attr@2.7.0':
+    resolution: {integrity: sha512-NS8e7SOgXipkzUPLF/sce7ukpMpWjhxYsH0n6Y+bHYo4TTxOb95Zv7hqwSuL212mj5YxovjdOKQOgH1As3E94w==}
+
+  '@peculiar/asn1-x509@2.7.0':
+    resolution: {integrity: sha512-mUn9RRrkGDnG4ALfunDmzyRW5dg+sWCj/pfnCCqEHYbkGxEpvUt6iVJv8Yw1cyp6SWZ26ZE5oSmI5SqEaen15g==}
+
+  '@peculiar/utils@2.0.3':
+    resolution: {integrity: sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==}
+
+  '@peculiar/x509@1.14.3':
+    resolution: {integrity: sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==}
+    engines: {node: '>=20.0.0'}
 
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
@@ -766,6 +822,10 @@ packages:
   '@sapphire/snowflake@3.5.3':
     resolution: {integrity: sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==}
     engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
+
+  '@simplewebauthn/server@13.3.0':
+    resolution: {integrity: sha512-MLHYFrYG8/wK2i+86XMhiecK72nMaHKKt4bo+7Q1TbuG9iGjlSdfkPWKO5ZFE/BX+ygCJ7pr8H/AJeyAj1EaTQ==}
+    engines: {node: '>=20.0.0'}
 
   '@smithy/abort-controller@4.2.10':
     resolution: {integrity: sha512-qocxM/X4XGATqQtUkbE9SPUB6wekBi+FyJOMbPj0AhvyvFGYEmOlz6VB22iMePCQsFmMIvFSeViDvA7mZJG47g==}
@@ -1317,6 +1377,10 @@ packages:
 
   asn1.js@5.4.1:
     resolution: {integrity: sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==}
+
+  asn1js@3.0.10:
+    resolution: {integrity: sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==}
+    engines: {node: '>=12.0.0'}
 
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
@@ -2590,6 +2654,9 @@ packages:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
+  otpauth@9.5.1:
+    resolution: {integrity: sha512-fJmDAHc8wImfqqqOXIlBvT1dEKrZK0Cmb2VEgScpNTolCz0PHh6ExUZGv4sLtOsWNaHCQlD+rRqaPgnoxFoZjQ==}
+
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
@@ -2765,6 +2832,13 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  pvtsutils@1.3.6:
+    resolution: {integrity: sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==}
+
+  pvutils@1.1.5:
+    resolution: {integrity: sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==}
+    engines: {node: '>=16.0.0'}
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
@@ -2802,6 +2876,9 @@ packages:
   real-require@0.2.0:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
+
+  reflect-metadata@0.2.2:
+    resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -3112,6 +3189,9 @@ packages:
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
 
+  tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -3119,6 +3199,10 @@ packages:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
+
+  tsyringe@4.10.0:
+    resolution: {integrity: sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==}
+    engines: {node: '>= 6.0.0'}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -3971,6 +4055,8 @@ snapshots:
       type-is: 2.0.1
       vary: 1.1.2
 
+  '@hexagon/base64@1.1.28': {}
+
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
@@ -3993,6 +4079,8 @@ snapshots:
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
   '@isaacs/cliui@9.0.0': {}
+
+  '@levischuck/tiny-cbor@0.2.11': {}
 
   '@livekit/mutex@1.1.1': {}
 
@@ -4044,6 +4132,8 @@ snapshots:
   '@next/swc-win32-x64-msvc@14.2.30':
     optional: true
 
+  '@noble/hashes@2.2.0': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -4059,6 +4149,106 @@ snapshots:
   '@nolyfill/is-core-module@1.0.39': {}
 
   '@opentelemetry/api@1.9.1': {}
+
+  '@peculiar/asn1-android@2.7.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.7.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-cms@2.7.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-x509': 2.7.0
+      '@peculiar/asn1-x509-attr': 2.7.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-csr@2.7.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-x509': 2.7.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-ecc@2.7.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-x509': 2.7.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-pfx@2.7.0':
+    dependencies:
+      '@peculiar/asn1-cms': 2.7.0
+      '@peculiar/asn1-pkcs8': 2.7.0
+      '@peculiar/asn1-rsa': 2.7.0
+      '@peculiar/asn1-schema': 2.7.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-pkcs8@2.7.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-x509': 2.7.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-pkcs9@2.7.0':
+    dependencies:
+      '@peculiar/asn1-cms': 2.7.0
+      '@peculiar/asn1-pfx': 2.7.0
+      '@peculiar/asn1-pkcs8': 2.7.0
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-x509': 2.7.0
+      '@peculiar/asn1-x509-attr': 2.7.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-rsa@2.7.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-x509': 2.7.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-schema@2.7.0':
+    dependencies:
+      '@peculiar/utils': 2.0.3
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-x509-attr@2.7.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-x509': 2.7.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-x509@2.7.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/utils': 2.0.3
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/utils@2.0.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@peculiar/x509@1.14.3':
+    dependencies:
+      '@peculiar/asn1-cms': 2.7.0
+      '@peculiar/asn1-csr': 2.7.0
+      '@peculiar/asn1-ecc': 2.7.0
+      '@peculiar/asn1-pkcs9': 2.7.0
+      '@peculiar/asn1-rsa': 2.7.0
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-x509': 2.7.0
+      pvtsutils: 1.3.6
+      reflect-metadata: 0.2.2
+      tslib: 2.8.1
+      tsyringe: 4.10.0
 
   '@pinojs/redact@0.4.0': {}
 
@@ -4081,6 +4271,17 @@ snapshots:
       lodash: 4.17.23
 
   '@sapphire/snowflake@3.5.3': {}
+
+  '@simplewebauthn/server@13.3.0':
+    dependencies:
+      '@hexagon/base64': 1.1.28
+      '@levischuck/tiny-cbor': 0.2.11
+      '@peculiar/asn1-android': 2.7.0
+      '@peculiar/asn1-ecc': 2.7.0
+      '@peculiar/asn1-rsa': 2.7.0
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-x509': 2.7.0
+      '@peculiar/x509': 1.14.3
 
   '@smithy/abort-controller@4.2.10':
     dependencies:
@@ -4779,6 +4980,12 @@ snapshots:
       inherits: 2.0.4
       minimalistic-assert: 1.0.1
       safer-buffer: 2.1.2
+
+  asn1js@3.0.10:
+    dependencies:
+      pvtsutils: 1.3.6
+      pvutils: 1.1.5
+      tslib: 2.8.1
 
   ast-types-flow@0.0.8: {}
 
@@ -6429,6 +6636,10 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
+  otpauth@9.5.1:
+    dependencies:
+      '@noble/hashes': 2.2.0
+
   own-keys@1.0.1:
     dependencies:
       get-intrinsic: 1.3.0
@@ -6604,6 +6815,12 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  pvtsutils@1.3.6:
+    dependencies:
+      tslib: 2.8.1
+
+  pvutils@1.1.5: {}
+
   queue-microtask@1.2.3: {}
 
   quick-format-unescaped@4.0.4: {}
@@ -6646,6 +6863,8 @@ snapshots:
       loose-envify: 1.4.0
 
   real-require@0.2.0: {}
+
+  reflect-metadata@0.2.2: {}
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -6989,6 +7208,8 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
+  tslib@1.14.1: {}
+
   tslib@2.8.1: {}
 
   tsx@4.21.0:
@@ -6997,6 +7218,10 @@ snapshots:
       get-tsconfig: 4.13.6
     optionalDependencies:
       fsevents: 2.3.3
+
+  tsyringe@4.10.0:
+    dependencies:
+      tslib: 1.14.1
 
   type-check@0.4.0:
     dependencies:


### PR DESCRIPTION
WebAuthn passkeys and TOTP for 2FA enforcement and passwordless login.

**Passkeys:**
- Register via WebAuthn (platform or cross-platform authenticators)
- Passkey-as-primary login when hub enables `allow_passkey_login`
- Discovery via resident keys (no username needed)
- Multiple credentials per user, per hub

**TOTP:**
- Standard 6-digit TOTP (Google Authenticator compatible)
- Enroll via QR code, verify to activate
- Available for 2FA enforcement at privileged actions

**Recovery:**
- 8 one-time recovery codes generated at first passkey enrollment
- Hashed storage, single-use redemption

**Per-Hub Settings:**
- `allow_passkey_login` on hubs (toggle in Hub Settings)
- `require_2fa` per role override (extends #101 permission overrides)

Closes #73.