### PR TITLE
feat: 2FA Hub Settings UI + moderation wrapWith2fa wiring (#73 final)

### DIFF
--- a/apps/web/app/settings/hub/page.tsx
+++ b/apps/web/app/settings/hub/page.tsx
@@ -212,7 +212,7 @@ export default function HubSettingsPage() {
                             Allow passkey login
                         </label>
                         <p className="settings-description" style={{ marginLeft: '1.5rem' }}>
-                            Enables "Sign in with passkey" on the login page. Users must register a passkey in Security Settings first.
+                            Enables &ldquo;Sign in with passkey&rdquo; on the login page. Users must register a passkey in Security Settings first.
                         </p>
                     </div>
                 )}

--- a/apps/web/app/settings/hub/page.tsx
+++ b/apps/web/app/settings/hub/page.tsx
@@ -193,6 +193,37 @@ export default function HubSettingsPage() {
             </div>
 
             <HubOwnershipTransfer hubId={hubId} />
+
+            <hr style={{ margin: '2rem 0', border: 'none', borderTop: '1px solid var(--border)' }} />
+
+            <section style={{ marginTop: '1rem' }}>
+                <h3>Authentication &amp; 2FA</h3>
+
+                {settings && (
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem', marginTop: '0.75rem' }}>
+                        <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                            <input
+                                type="checkbox"
+                                checked={settings.allowPasskeyLogin ?? false}
+                                onChange={(e) => {
+                                    setSettings({ ...settings, allowPasskeyLogin: e.target.checked });
+                                }}
+                            />
+                            Allow passkey login
+                        </label>
+                        <p className="settings-description" style={{ marginLeft: '1.5rem' }}>
+                            Enables "Sign in with passkey" on the login page. Users must register a passkey in Security Settings first.
+                        </p>
+                    </div>
+                )}
+
+                <p className="settings-description" style={{ marginTop: '0.5rem' }}>
+                    Per-role 2FA requirements are configured via the{" "}
+                    <strong>Permission Overrides</strong> API.
+                    Set <code>require_2fa: true</code> for a role to enforce
+                    passkey or TOTP verification before privileged actions.
+                </p>
+            </section>
         </div>
     );
 }

--- a/apps/web/components/chat-client.tsx
+++ b/apps/web/components/chat-client.tsx
@@ -1082,21 +1082,7 @@ export function ChatClient() {
         <ContextMenu
           x={userContextMenu.x}
           y={userContextMenu.y}
-          items={userContextMenuItems.map(item => ({
-            ...item,
-            onClick: () => {
-              if (!item.onClick) return;
-              const hubId = state.hubs[0]?.id;
-              if (hubId && !pending2faToken) {
-                setPending2faAction({
-                  action: item.onClick,
-                  hubId,
-                });
-                return;
-              }
-              item.onClick();
-            }
-          }))}
+          items={userContextMenuItems}
           onClose={() => setUserContextMenu(null)}
         />
       )}

--- a/apps/web/components/chat-client.tsx
+++ b/apps/web/components/chat-client.tsx
@@ -528,11 +528,15 @@ export function ChatClient() {
 
   const handle2faVerified = useCallback((token: string) => {
     setPending2faToken(token);
+    sessionStorage.setItem("2fa_token", token);
     // Execute the pending action
     pending2faAction?.action();
     setPending2faAction(null);
     // Clear token after 5 minutes
-    setTimeout(() => setPending2faToken(null), 5 * 60 * 1000);
+    setTimeout(() => {
+      setPending2faToken(null);
+      sessionStorage.removeItem("2fa_token");
+    }, 5 * 60 * 1000);
   }, [pending2faAction]);
 
   const { toggleTheme } = useTheme();
@@ -1078,7 +1082,21 @@ export function ChatClient() {
         <ContextMenu
           x={userContextMenu.x}
           y={userContextMenu.y}
-          items={userContextMenuItems}
+          items={userContextMenuItems.map(item => ({
+            ...item,
+            onClick: () => {
+              if (!item.onClick) return;
+              const hubId = state.hubs[0]?.id;
+              if (hubId && !pending2faToken) {
+                setPending2faAction({
+                  action: item.onClick,
+                  hubId,
+                });
+                return;
+              }
+              item.onClick();
+            }
+          }))}
           onClose={() => setUserContextMenu(null)}
         />
       )}

--- a/apps/web/lib/control-plane.ts
+++ b/apps/web/lib/control-plane.ts
@@ -1636,3 +1636,22 @@ export async function verifyTotpEnrollment(hubId: string, code: string): Promise
 export async function removeTotp(hubId: string): Promise<void> {
   await apiFetch(`/v1/hubs/${encodeURIComponent(hubId)}/totp`, { method: "DELETE" });
 }
+
+// --- Permission Overrides (#101) ---
+
+export async function fetchPermissionOverrides(hubId: string): Promise<{
+  items: { role: string; action: string; allowed: boolean; require_2fa?: boolean }[];
+}> {
+  return apiFetch(`/v1/hubs/${encodeURIComponent(hubId)}/permission-overrides`);
+}
+
+export async function updatePermissionOverrides(
+  hubId: string,
+  overrides: { role: string; action: string; allowed: boolean; require_2fa?: boolean }[]
+): Promise<void> {
+  await apiFetch(`/v1/hubs/${encodeURIComponent(hubId)}/permission-overrides`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ overrides }),
+  });
+}


### PR DESCRIPTION
Final #73 piece — the Hub Settings UI and frontend wiring.

- Hub Settings: allow_passkey_login toggle with description
- Permission override docs explain per-role require_2fa via API
- Context menu moderation actions now require 2FA verification
  (TwoFactorModal appears before kick/ban/redact when no token)
- 2FA token stored in sessionStorage, auto-attached to all API calls
- Token expires after 5 minutes

Closes #73.