### PR TITLE
fix(control-plane): seed reaction-only Discord emojis into seen registry (#70)

### DIFF
--- a/apps/control-plane/src/services/discord-bot-client.ts
+++ b/apps/control-plane/src/services/discord-bot-client.ts
@@ -290,6 +290,22 @@ export async function startDiscordBot() {
             const emoji = encodeDiscordReactionEmoji(reaction.emoji);
             if (!emoji) return;
 
+            // Seed custom emoji into seen registry so name-based lookups
+            // (findEmojiByName, getOrMirrorExternalEmoji) work for emojis
+            // encountered only via reactions — issue #70.
+            if (reaction.emoji.id) {
+                withDb(async (db) => {
+                    await db.query(
+                        `insert into discord_seen_emojis (id, name, is_animated, source_guild_id, last_seen_at)
+                         values ($1, $2, $3, $4, now())
+                         on conflict (id) do update set name = $2, is_animated = $3, last_seen_at = now()`,
+                        [reaction.emoji.id, reaction.emoji.name, reaction.emoji.animated ?? false, guildId]
+                    );
+                }).catch(err => {
+                    console.error("[Discord Bridge] Failed to seed reaction emoji into seen registry:", err);
+                });
+            }
+
             const discordChannelIdForMapping = parentIdOf(message.channel) ?? channelId;
             const serverIds = await withDb(async (db) => {
                 const rows = await db.query<{ server_id: string }>(


### PR DESCRIPTION
Closes #70

Custom Discord emojis used only in reactions were never recorded in `discord_seen_emojis`, breaking name-based lookups (`findEmojiByName`, `getOrMirrorExternalEmoji`). The table was only seeded during message content processing.

**Fix**: Added a fire-and-forget UPSERT in the `MessageReactionAdd` handler. When a reaction uses a custom emoji (has an `id` field), it seeds `id`, `name`, `is_animated`, and `source_guild_id` — same pattern as the existing message-content path. Wrapped in `.catch()` so a DB hiccup doesn't block the reaction relay.

**Skipped**: Follow-up #1 (one-shot backfill of 3 zombieTwerk rows) — test server is being replaced by production, making manual backfill unnecessary.