### PR TITLE
feat: custom emoji management UI with Discord bridge pull

### DIFF
--- a/apps/control-plane/src/routes/domain-routes.ts
+++ b/apps/control-plane/src/routes/domain-routes.ts
@@ -3,6 +3,7 @@ import { registerSystemRoutes } from "./system-routes.js";
 import { registerUserRoutes } from "./user-routes.js";
 import { registerHubRoutes } from "./hub-routes.js";
 import { registerServerRoutes } from "./server-routes.js";
+import { registerEmojiRoutes } from "./emoji-routes.js";
 import { registerChannelRoutes } from "./channel-routes.js";
 import { registerChannelInitRoutes } from "./channel-init-routes.js";
 import { registerMessageRoutes } from "./message-routes.js";
@@ -28,6 +29,7 @@ export async function registerDomainRoutes(app: FastifyInstance): Promise<void> 
   await registerUserRoutes(app);
   await registerHubRoutes(app);
   await registerServerRoutes(app);
+  await registerEmojiRoutes(app);
   await registerChannelRoutes(app);
   await registerChannelInitRoutes(app);
   await registerMessageRoutes(app);

--- a/apps/control-plane/src/routes/emoji-routes.ts
+++ b/apps/control-plane/src/routes/emoji-routes.ts
@@ -1,0 +1,129 @@
+import type { FastifyInstance } from "fastify";
+import { z } from "zod";
+import { requireAuth, requireInitialized } from "../auth/middleware.js";
+import { canEditServerSettings } from "../services/policy-service.js";
+import {
+  createServerEmoji,
+  listServerEmojis,
+  deleteServerEmoji,
+  listDiscordGuildEmojis,
+  pullAllDiscordEmojis
+} from "../services/extension-service.js";
+import { getDiscordBridgeConnection } from "../services/discord-bridge-service.js";
+
+export async function registerEmojiRoutes(app: FastifyInstance): Promise<void> {
+  const initializedAuthHandlers = { preHandler: [requireAuth, requireInitialized] };
+
+  // ── Server Emoji CRUD ──
+
+  app.get("/v1/servers/:serverId/emojis", initializedAuthHandlers, async (request) => {
+    const params = z.object({ serverId: z.string().min(1) }).parse(request.params);
+    const items = await listServerEmojis(params.serverId);
+    return { items };
+  });
+
+  app.post("/v1/servers/:serverId/emojis", initializedAuthHandlers, async (request, reply) => {
+    const params = z.object({ serverId: z.string().min(1) }).parse(request.params);
+    const payload = z.object({
+      name: z.string().min(1).max(32).regex(/^[a-zA-Z0-9_-]+$/, "Emoji name must be alphanumeric with underscores/hyphens"),
+      url: z.string().url()
+    }).parse(request.body);
+
+    const allowed = await canEditServerSettings({
+      productUserId: request.auth!.productUserId,
+      serverId: params.serverId,
+      authContext: request.auth
+    });
+    if (!allowed) {
+      reply.code(403).send({ message: "Forbidden: insufficient space management scope." });
+      return;
+    }
+
+    const emoji = await createServerEmoji({
+      serverId: params.serverId,
+      name: payload.name,
+      url: payload.url
+    });
+    reply.code(201);
+    return emoji;
+  });
+
+  app.delete("/v1/servers/:serverId/emojis/:emojiId", initializedAuthHandlers, async (request, reply) => {
+    const params = z.object({
+      serverId: z.string().min(1),
+      emojiId: z.string().min(1)
+    }).parse(request.params);
+
+    const allowed = await canEditServerSettings({
+      productUserId: request.auth!.productUserId,
+      serverId: params.serverId,
+      authContext: request.auth
+    });
+    if (!allowed) {
+      reply.code(403).send({ message: "Forbidden: insufficient space management scope." });
+      return;
+    }
+
+    await deleteServerEmoji(params.serverId, params.emojiId);
+    reply.code(204).send();
+  });
+
+  // ── Discord Bridge Emoji ──
+
+  app.get("/v1/servers/:serverId/discord-emojis", initializedAuthHandlers, async (request, reply) => {
+    const params = z.object({ serverId: z.string().min(1) }).parse(request.params);
+
+    const allowed = await canEditServerSettings({
+      productUserId: request.auth!.productUserId,
+      serverId: params.serverId,
+      authContext: request.auth
+    });
+    if (!allowed) {
+      reply.code(403).send({ message: "Forbidden: insufficient space management scope." });
+      return;
+    }
+
+    const connection = await getDiscordBridgeConnection(params.serverId);
+    if (!connection || !connection.guildId) {
+      return { items: [], message: "No Discord bridge connection for this space." };
+    }
+
+    try {
+      const items = await listDiscordGuildEmojis(params.serverId, connection.guildId);
+      return { items };
+    } catch (error) {
+      reply.code(503).send({
+        message: error instanceof Error ? error.message : "Failed to fetch Discord emojis."
+      });
+    }
+  });
+
+  app.post("/v1/servers/:serverId/discord-emojis/pull-all", initializedAuthHandlers, async (request, reply) => {
+    const params = z.object({ serverId: z.string().min(1) }).parse(request.params);
+
+    const allowed = await canEditServerSettings({
+      productUserId: request.auth!.productUserId,
+      serverId: params.serverId,
+      authContext: request.auth
+    });
+    if (!allowed) {
+      reply.code(403).send({ message: "Forbidden: insufficient space management scope." });
+      return;
+    }
+
+    const connection = await getDiscordBridgeConnection(params.serverId);
+    if (!connection || !connection.guildId) {
+      reply.code(400).send({ message: "No Discord bridge connection for this space." });
+      return;
+    }
+
+    try {
+      const result = await pullAllDiscordEmojis(params.serverId, connection.guildId);
+      return result;
+    } catch (error) {
+      reply.code(503).send({
+        message: error instanceof Error ? error.message : "Failed to pull Discord emojis."
+      });
+    }
+  });
+}

--- a/apps/control-plane/src/services/extension-service.ts
+++ b/apps/control-plane/src/services/extension-service.ts
@@ -1,6 +1,6 @@
 import crypto from "node:crypto";
 import { withDb } from "../db/client.js";
-import type { ServerEmoji, ServerSticker, Webhook, FollowedAnnouncement } from "@skerry/shared";
+import type { ServerEmoji, ServerSticker, Webhook, FollowedAnnouncement, DiscordGuildEmoji } from "@skerry/shared";
 
 function randomId(prefix: string): string {
   return `${prefix}_${crypto.randomUUID().replaceAll("-", "")}`;
@@ -100,6 +100,92 @@ export async function deleteServerEmoji(serverId: string, emojiId: string): Prom
   await withDb(async (db) => {
     await db.query("delete from server_emojis where id = $1 and server_id = $2", [emojiId, serverId]);
   });
+}
+
+export async function listDiscordGuildEmojis(serverId: string, guildId: string): Promise<DiscordGuildEmoji[]> {
+  const { getDiscordBotClient } = await import("./discord-bot-client.js");
+  const client = getDiscordBotClient();
+  if (!client || !client.isReady()) {
+    throw new Error("Discord bot is not ready; cannot fetch guild emojis.");
+  }
+
+  const guild = await client.guilds.fetch(guildId);
+  if (!guild) {
+    throw new Error(`Guild ${guildId} not found by bot.`);
+  }
+
+  const discordEmojis = await guild.emojis.fetch();
+
+  // Check which Discord emojis are already pulled into server_emojis
+  const pulled = await withDb(async (db) => {
+    const rows = await db.query<{ name: string }>(
+      "select name from server_emojis where server_id = $1",
+      [serverId]
+    );
+    return new Set(rows.rows.map(r => r.name));
+  });
+
+  const result: DiscordGuildEmoji[] = [];
+  for (const [, emoji] of discordEmojis) {
+    const ext = emoji.animated ? "gif" : "webp";
+    result.push({
+      id: emoji.id,
+      name: emoji.name ?? emoji.id,
+      isAnimated: emoji.animated ?? false,
+      isMirrored: pulled.has(emoji.name ?? ""),
+      url: `https://cdn.discordapp.com/emojis/${emoji.id}.${ext}?size=96&quality=lossless`
+    });
+  }
+  return result;
+}
+
+export async function pullAllDiscordEmojis(serverId: string, guildId: string): Promise<{ pulled: number; skipped: number }> {
+  const { getDiscordBotClient } = await import("./discord-bot-client.js");
+  const client = getDiscordBotClient();
+  if (!client || !client.isReady()) {
+    throw new Error("Discord bot is not ready; cannot pull guild emojis.");
+  }
+
+  const guild = await client.guilds.fetch(guildId);
+  if (!guild) {
+    throw new Error(`Guild ${guildId} not found by bot.`);
+  }
+
+  const discordEmojis = await guild.emojis.fetch();
+
+  // Get existing emoji names for this server
+  const existingNames = await withDb(async (db) => {
+    const rows = await db.query<{ name: string }>(
+      "select name from server_emojis where server_id = $1",
+      [serverId]
+    );
+    return new Set(rows.rows.map(r => r.name));
+  });
+
+  let pulled = 0;
+  let skipped = 0;
+
+  for (const [, emoji] of discordEmojis) {
+    const name = emoji.name ?? emoji.id;
+    if (existingNames.has(name)) {
+      skipped++;
+      continue;
+    }
+
+    const ext = emoji.animated ? "gif" : "webp";
+    const url = `https://cdn.discordapp.com/emojis/${emoji.id}.${ext}?size=96&quality=lossless`;
+
+    try {
+      await createServerEmoji({ serverId, name, url });
+      existingNames.add(name);
+      pulled++;
+    } catch (err) {
+      // Name collision — skip
+      skipped++;
+    }
+  }
+
+  return { pulled, skipped };
 }
 
 export async function createServerSticker(input: {

--- a/apps/web/app/settings/layout.tsx
+++ b/apps/web/app/settings/layout.tsx
@@ -45,6 +45,12 @@ export default function SettingsLayout({
       hidden: !canManageCurrentSpace || !selectedServerId 
     },
     { 
+      label: "Space Emojis", 
+      href: `/settings/spaces/${selectedServerId}/emojis`, 
+      icon: "smile-plus", 
+      hidden: !canManageCurrentSpace || !selectedServerId 
+    },
+    { 
       label: "Space Badges", 
       href: `/settings/spaces/${selectedServerId}/badges`, 
       icon: "award", 

--- a/apps/web/app/settings/spaces/[id]/emojis/page.tsx
+++ b/apps/web/app/settings/spaces/[id]/emojis/page.tsx
@@ -1,0 +1,302 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { useParams } from "next/navigation";
+import {
+  listServerEmojis,
+  createServerEmoji,
+  deleteServerEmoji,
+  listDiscordEmojis,
+  pullAllDiscordEmojis,
+  uploadMedia
+} from "../../../../../lib/control-plane";
+import { useChat } from "../../../../../context/chat-context";
+import { useToast } from "../../../../../components/toast-provider";
+import type { ServerEmoji, DiscordGuildEmoji } from "@skerry/shared";
+
+export default function SpaceEmojisPage() {
+  const params = useParams();
+  const serverId = params.id as string;
+  const { state } = useChat();
+  const { servers } = state;
+  const { showToast } = useToast();
+
+  const [emojis, setEmojis] = useState<ServerEmoji[]>([]);
+  const [discordEmojis, setDiscordEmojis] = useState<DiscordGuildEmoji[]>([]);
+  const [discordMessage, setDiscordMessage] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [discordLoading, setDiscordLoading] = useState(false);
+  const [pulling, setPulling] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [showCreate, setShowCreate] = useState(false);
+
+  const server = servers.find(s => s.id === serverId);
+
+  const loadEmojis = useCallback(async () => {
+    if (!serverId) return;
+    try {
+      const { items } = await listServerEmojis(serverId);
+      setEmojis(items);
+    } catch (err) {
+      console.error("Failed to load emojis", err);
+    } finally {
+      setLoading(false);
+    }
+  }, [serverId]);
+
+  const loadDiscordEmojis = useCallback(async () => {
+    if (!serverId) return;
+    setDiscordLoading(true);
+    try {
+      const { items, message } = await listDiscordEmojis(serverId);
+      setDiscordEmojis(items);
+      setDiscordMessage(message ?? null);
+    } catch (err) {
+      console.error("Failed to load Discord emojis", err);
+    } finally {
+      setDiscordLoading(false);
+    }
+  }, [serverId]);
+
+  useEffect(() => {
+    void loadEmojis();
+    void loadDiscordEmojis();
+  }, [loadEmojis, loadDiscordEmojis]);
+
+  const handleUpload = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const formData = new FormData(e.currentTarget);
+    const name = (formData.get("name") as string).trim();
+    const file = formData.get("file") as File;
+
+    if (!name || !file) return;
+    if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
+      showToast("Emoji name must be alphanumeric with underscores/hyphens", "error");
+      return;
+    }
+
+    setUploading(true);
+    try {
+      const upload = await uploadMedia(serverId, file);
+      await createServerEmoji(serverId, name, upload.url);
+      showToast("Emoji added", "success");
+      setShowCreate(false);
+      (e.target as HTMLFormElement).reset();
+      await loadEmojis();
+    } catch (err) {
+      showToast("Failed to upload emoji", "error");
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const handleDelete = async (emojiId: string, name: string) => {
+    if (!confirm(`Delete emoji ":${name}:"? This cannot be undone.`)) return;
+    try {
+      await deleteServerEmoji(serverId, emojiId);
+      setEmojis(prev => prev.filter(e => e.id !== emojiId));
+      showToast("Emoji deleted", "success");
+    } catch (err) {
+      showToast("Failed to delete emoji", "error");
+    }
+  };
+
+  const handlePullAll = async () => {
+    const unmirroredCount = discordEmojis.filter(e => !e.isMirrored).length;
+    if (unmirroredCount === 0) {
+      showToast("All Discord emojis are already pulled", "success");
+      return;
+    }
+
+    if (!confirm(`Pull ${unmirroredCount} Discord emoji(s) into this space?`)) return;
+
+    setPulling(true);
+    try {
+      const result = await pullAllDiscordEmojis(serverId);
+      showToast(`Pulled ${result.pulled} emojis (${result.skipped} skipped)`, "success");
+      await loadEmojis();
+      await loadDiscordEmojis();
+    } catch (err) {
+      showToast("Failed to pull Discord emojis", "error");
+    } finally {
+      setPulling(false);
+    }
+  };
+
+  if (loading) return <p>Loading emojis...</p>;
+
+  return (
+    <div className="settings-section">
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <div>
+          <h2>Custom Emojis</h2>
+          <p className="settings-description">
+            Manage custom emojis for {server?.name ?? "this space"}.
+            These emojis are scoped to this space and can be used in messages and reactions.
+          </p>
+        </div>
+        <button className="btn-primary" onClick={() => setShowCreate(true)}>
+          Upload Emoji
+        </button>
+      </div>
+
+      {/* Create form */}
+      {showCreate && (
+        <form
+          onSubmit={handleUpload}
+          className="settings-grid"
+          style={{ marginTop: '2rem', padding: '1.5rem', border: '1px solid var(--border)', borderRadius: '8px' }}
+        >
+          <h3>Add Emoji</h3>
+          <section className="settings-row">
+            <label htmlFor="emoji-name">Name</label>
+            <input
+              id="emoji-name"
+              name="name"
+              className="filter-input"
+              required
+              placeholder="e.g. pogchamp, kekw"
+              maxLength={32}
+              pattern="[a-zA-Z0-9_-]+"
+              title="Alphanumeric with underscores and hyphens only"
+            />
+            <p className="settings-description">Use :name: in messages to insert this emoji.</p>
+          </section>
+          <section className="settings-row">
+            <label htmlFor="emoji-file">Image</label>
+            <input
+              id="emoji-file"
+              name="file"
+              type="file"
+              accept="image/png,image/jpeg,image/gif,image/webp"
+              required
+              className="filter-input"
+            />
+            <p className="settings-description">PNG, JPEG, GIF, or WebP. Recommended: 128x128px.</p>
+          </section>
+          <div style={{ display: 'flex', gap: '0.5rem', marginTop: '1rem' }}>
+            <button type="submit" className="btn-primary" disabled={uploading}>
+              {uploading ? "Uploading..." : "Add Emoji"}
+            </button>
+            <button type="button" className="btn-secondary" onClick={() => setShowCreate(false)}>
+              Cancel
+            </button>
+          </div>
+        </form>
+      )}
+
+      {/* Native emoji list */}
+      <div style={{ marginTop: '2rem' }}>
+        <h3>Space Emojis ({emojis.length})</h3>
+        {emojis.length === 0 ? (
+          <p className="settings-description">No custom emojis yet. Upload one above, or pull from Discord below.</p>
+        ) : (
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(120px, 1fr))', gap: '0.75rem', marginTop: '1rem' }}>
+            {emojis.map(emoji => (
+              <div
+                key={emoji.id}
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                  gap: '0.25rem',
+                  padding: '0.75rem',
+                  border: '1px solid var(--border)',
+                  borderRadius: '8px',
+                  backgroundColor: 'var(--panel-bg-lighter)',
+                  position: 'relative'
+                }}
+              >
+                <img
+                  src={emoji.url}
+                  alt={`:${emoji.name}:`}
+                  style={{ width: '48px', height: '48px', objectFit: 'contain' }}
+                />
+                <span style={{ fontSize: '0.75rem', color: 'var(--text-muted)', textAlign: 'center', wordBreak: 'break-all' }}>
+                  :{emoji.name}:
+                </span>
+                <button
+                  className="btn-danger btn-small"
+                  onClick={() => handleDelete(emoji.id, emoji.name)}
+                  style={{
+                    position: 'absolute',
+                    top: '4px',
+                    right: '4px',
+                    fontSize: '0.7rem',
+                    padding: '2px 6px',
+                    borderRadius: '4px'
+                  }}
+                  title={`Delete :${emoji.name}:`}
+                >
+                  ×
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <hr style={{ margin: '3rem 0', border: 'none', borderTop: '1px solid var(--border)' }} />
+
+      {/* Discord emoji section */}
+      <div>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <h3>Discord Emojis</h3>
+          <button
+            className="btn-secondary"
+            onClick={handlePullAll}
+            disabled={pulling || discordEmojis.length === 0}
+          >
+            {pulling ? "Pulling..." : `Pull All (${discordEmojis.filter(e => !e.isMirrored).length})`}
+          </button>
+        </div>
+        <p className="settings-description">
+          Emojis available from the connected Discord guild. Already-pulled emojis are marked.
+        </p>
+
+        {discordLoading ? (
+          <p>Loading Discord emojis...</p>
+        ) : discordMessage ? (
+          <div className="alert-box warning" style={{ marginTop: '1rem' }}>
+            <p>{discordMessage}</p>
+          </div>
+        ) : discordEmojis.length === 0 ? (
+          <p className="settings-description" style={{ marginTop: '1rem' }}>No Discord emojis available.</p>
+        ) : (
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(120px, 1fr))', gap: '0.75rem', marginTop: '1rem' }}>
+            {discordEmojis.map(emoji => (
+              <div
+                key={emoji.id}
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                  gap: '0.25rem',
+                  padding: '0.75rem',
+                  border: `2px solid ${emoji.isMirrored ? 'var(--success)' : 'var(--border)'}`,
+                  borderRadius: '8px',
+                  backgroundColor: 'var(--panel-bg-lighter)',
+                  opacity: emoji.isMirrored ? 0.6 : 1
+                }}
+              >
+                <img
+                  src={emoji.url}
+                  alt={`:${emoji.name}:`}
+                  style={{ width: '48px', height: '48px', objectFit: 'contain' }}
+                />
+                <span style={{ fontSize: '0.75rem', color: 'var(--text-muted)', textAlign: 'center', wordBreak: 'break-all' }}>
+                  :{emoji.name}:
+                </span>
+                {emoji.isMirrored ? (
+                  <span style={{ fontSize: '0.65rem', color: 'var(--success)' }}>Pulled ✓</span>
+                ) : (
+                  <span style={{ fontSize: '0.65rem', color: 'var(--text-muted)' }}>Not pulled</span>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/chat-window.tsx
+++ b/apps/web/components/chat-window.tsx
@@ -7,7 +7,7 @@ import { Category, Channel, ChatMessage, MentionMarker, ModerationAction, Modera
 import { getChannelName } from "../lib/channel-utils";
 import { ContextMenu, ContextMenuItem } from "./context-menu";
 import { useToast } from "./toast-provider";
-import { performModerationAction, createReport, uploadMedia, updateMessage, addReaction, deleteMessage, listChannelMembers, inviteToChannel, updateChannel, searchUsers, formatMessageTime, pinMessage, unpinMessage, sendTypingStatus, getFirstUnreadMessageId, bulkDeleteMessages, bulkRedactMessages } from "../lib/control-plane";
+import { performModerationAction, createReport, uploadMedia, updateMessage, addReaction, deleteMessage, listChannelMembers, inviteToChannel, updateChannel, searchUsers, formatMessageTime, pinMessage, unpinMessage, sendTypingStatus, getFirstUnreadMessageId, bulkDeleteMessages, bulkRedactMessages, listServerEmojis as fetchServerEmojis } from "../lib/control-plane";
 import dynamic from "next/dynamic";
 
 // @ts-ignore - emoji-picker-react types mismatch with Next.js dynamic
@@ -313,10 +313,20 @@ export function ChatWindow({
     const [showEmojiPicker, setShowEmojiPicker] = useState(false);
     const [composerCursor, setComposerCursor] = useState(0);
     const pendingCursorRef = useRef<number | null>(null);
+
+    const [customEmojis, setCustomEmojis] = useState<Array<{ name: string; url: string }>>([]);
+    useEffect(() => {
+      if (!selectedServerId) { setCustomEmojis([]); return; }
+      fetchServerEmojis(selectedServerId)
+        .then(({ items }) => setCustomEmojis(items.map(e => ({ name: e.name, url: e.url }))))
+        .catch(() => setCustomEmojis([]));
+    }, [selectedServerId]);
+
     const autocomplete = useComposerAutocomplete({
         value: draftMessage,
         cursorPos: composerCursor,
         members,
+        customEmojis,
         setValue: (next) => setDraftMessage(next),
         setCursorPos: (pos) => {
             pendingCursorRef.current = pos;

--- a/apps/web/components/composer/autocomplete-popover.tsx
+++ b/apps/web/components/composer/autocomplete-popover.tsx
@@ -32,6 +32,9 @@ export function AutocompletePopover({ items, selectedIdx, onSelect, onHover }: P
           disabled={item.disabled}
         >
           {item.glyph && <span className="autocomplete-glyph" aria-hidden="true">{item.glyph}</span>}
+          {item.imageUrl && (
+            <img className="autocomplete-avatar" src={item.imageUrl} alt="" aria-hidden="true" style={{ width: '20px', height: '20px', objectFit: 'contain' }} />
+          )}
           {item.avatarUrl && (
             <img className="autocomplete-avatar" src={item.avatarUrl} alt="" aria-hidden="true" />
           )}

--- a/apps/web/hooks/use-composer-autocomplete.ts
+++ b/apps/web/hooks/use-composer-autocomplete.ts
@@ -3,12 +3,13 @@
 import { useCallback, useMemo, useState, useEffect } from "react";
 import type { ChatMember } from "../context/chat-context";
 import { detectActiveTrigger, applyCompletion, type ActiveTrigger } from "../lib/composer-autocomplete/triggers";
-import { mentionItems, emojiItems, type AutocompleteItem } from "../lib/composer-autocomplete/providers";
+import { mentionItems, emojiItems, type AutocompleteItem, type CustomEmojiEntry } from "../lib/composer-autocomplete/providers";
 
 interface UseComposerAutocompleteParams {
   value: string;
   cursorPos: number;
   members: ChatMember[];
+  customEmojis?: CustomEmojiEntry[];
   setValue: (next: string) => void;
   setCursorPos: (pos: number) => void;
 }
@@ -28,6 +29,7 @@ export function useComposerAutocomplete({
   value,
   cursorPos,
   members,
+  customEmojis,
   setValue,
   setCursorPos
 }: UseComposerAutocompleteParams): ComposerAutocompleteState {
@@ -42,9 +44,9 @@ export function useComposerAutocomplete({
   const items = useMemo<AutocompleteItem[]>(() => {
     if (!active || isDismissed) return [];
     if (active.kind === "mention") return mentionItems(active.query, members);
-    if (active.kind === "emoji") return emojiItems(active.query);
+    if (active.kind === "emoji") return emojiItems(active.query, 8, customEmojis);
     return [];
-  }, [active, members, isDismissed]);
+  }, [active, members, isDismissed, customEmojis]);
 
   useEffect(() => {
     setSelectedIdx(0);

--- a/apps/web/lib/composer-autocomplete/providers.ts
+++ b/apps/web/lib/composer-autocomplete/providers.ts
@@ -9,9 +9,15 @@ export interface AutocompleteItem {
   secondary?: string;
   glyph?: string;
   avatarUrl?: string;
+  imageUrl?: string;
   insertText: string;
   disabled?: boolean;
   disabledReason?: string;
+}
+
+export interface CustomEmojiEntry {
+  name: string;
+  url: string;
 }
 
 export function mentionItems(query: string, members: ChatMember[], limit = 8): AutocompleteItem[] {
@@ -55,13 +61,35 @@ export function mentionItems(query: string, members: ChatMember[], limit = 8): A
   return out.slice(0, limit);
 }
 
-export function emojiItems(query: string, limit = 8): AutocompleteItem[] {
-  const results: EmojiEntry[] = searchEmojis(query, limit);
-  return results.map((e) => ({
-    key: e.shortcode,
-    kind: "emoji" as const,
-    primary: `:${e.shortcode}:`,
-    glyph: e.glyph,
-    insertText: `:${e.shortcode}:`
-  }));
+export function emojiItems(query: string, limit = 8, customEmojis?: CustomEmojiEntry[]): AutocompleteItem[] {
+  const results: AutocompleteItem[] = [];
+
+  // Custom server emojis first
+  if (customEmojis && customEmojis.length > 0) {
+    const q = query.toLowerCase();
+    const matching = customEmojis.filter(e => e.name.toLowerCase().startsWith(q));
+    for (const ce of matching) {
+      results.push({
+        key: `custom:${ce.name}`,
+        kind: "emoji" as const,
+        primary: `:${ce.name}:`,
+        imageUrl: ce.url,
+        insertText: `:${ce.name}:`
+      });
+    }
+  }
+
+  // Unicode emojis
+  const unicode: EmojiEntry[] = searchEmojis(query, limit - results.length);
+  for (const e of unicode) {
+    results.push({
+      key: e.shortcode,
+      kind: "emoji" as const,
+      primary: `:${e.shortcode}:`,
+      glyph: e.glyph,
+      insertText: `:${e.shortcode}:`
+    });
+  }
+
+  return results.slice(0, limit);
 }

--- a/apps/web/lib/control-plane.ts
+++ b/apps/web/lib/control-plane.ts
@@ -1655,3 +1655,33 @@ export async function updatePermissionOverrides(
     body: JSON.stringify({ overrides }),
   });
 }
+
+// --- Server Emoji ---
+
+export async function listServerEmojis(serverId: string): Promise<{ items: import("@skerry/shared").ServerEmoji[] }> {
+  return apiFetch(`/v1/servers/${encodeURIComponent(serverId)}/emojis`);
+}
+
+export async function createServerEmoji(serverId: string, name: string, url: string): Promise<import("@skerry/shared").ServerEmoji> {
+  return apiFetch(`/v1/servers/${encodeURIComponent(serverId)}/emojis`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name, url }),
+  });
+}
+
+export async function deleteServerEmoji(serverId: string, emojiId: string): Promise<void> {
+  await apiFetch(`/v1/servers/${encodeURIComponent(serverId)}/emojis/${encodeURIComponent(emojiId)}`, {
+    method: "DELETE",
+  });
+}
+
+export async function listDiscordEmojis(serverId: string): Promise<{ items: import("@skerry/shared").DiscordGuildEmoji[]; message?: string }> {
+  return apiFetch(`/v1/servers/${encodeURIComponent(serverId)}/discord-emojis`);
+}
+
+export async function pullAllDiscordEmojis(serverId: string): Promise<{ pulled: number; skipped: number }> {
+  return apiFetch(`/v1/servers/${encodeURIComponent(serverId)}/discord-emojis/pull-all`, {
+    method: "POST",
+  });
+}

--- a/packages/shared/src/domain/contracts.ts
+++ b/packages/shared/src/domain/contracts.ts
@@ -569,6 +569,14 @@ export interface ServerEmoji {
     updatedAt: string;
 }
 
+export interface DiscordGuildEmoji {
+    id: string;
+    name: string;
+    isAnimated: boolean;
+    isMirrored: boolean; // Already mirrored into this space
+    url: string;
+}
+
 export interface ServerSticker {
     id: string;
     serverId: string;


### PR DESCRIPTION
Backend:
- **5 new endpoints** in `emoji-routes.ts`: CRUD for server emojis, list Discord guild emojis, pull-all
- **`listDiscordGuildEmojis`** and **`pullAllDiscordEmojis`** in extension-service (fetches from connected Discord guild via bot)
- **`DiscordGuildEmoji`** type added to shared contracts

Frontend:
- **Settings page** at `/settings/spaces/[id]/emojis` — upload form, emoji grid with delete, Discord section with Pull All button
- **Composer autocomplete** extended — server custom emojis appear alongside Unicode emojis when typing `:name`
- **Autocomplete popover** renders emoji images
- **Settings nav** item "Space Emojis"

Typecheck, lint, build, and web unit tests all pass.