### PR TITLE
feat: migrate Synapse from SQLite to PostgreSQL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,10 +49,6 @@ jobs:
       - name: Bring up test stack (Docker)
         run: pnpm test:env:up
 
-      - name: Capture Synapse logs (debug)
-        if: always()
-        run: docker compose -f docker-compose-test.yml logs synapse || true
-
       - name: Install Playwright browsers
         run: pnpm --filter @skerry/web exec playwright install --with-deps chromium
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,10 @@ jobs:
       - name: Bring up test stack (Docker)
         run: pnpm test:env:up
 
+      - name: Capture Synapse logs (debug)
+        if: always()
+        run: docker compose -f docker-compose-test.yml logs synapse || true
+
       - name: Install Playwright browsers
         run: pnpm --filter @skerry/web exec playwright install --with-deps chromium
 
@@ -76,4 +80,4 @@ jobs:
 
       - name: Tear down test stack
         if: always()
-        run: pnpm test:env:down
+        run: pnpm test:env:down && docker compose -f docker-compose-test.yml down -v || true

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -19,6 +19,7 @@ services:
         condition: service_completed_successfully
     volumes:
       - pg_data:/var/lib/postgresql/data
+      - ./docker/postgres-init:/docker-entrypoint-initdb.d
     deploy:
       resources:
         limits:
@@ -38,7 +39,6 @@ services:
         condition: service_healthy
     volumes:
       - ./docker/synapse:/data
-      - synapse_data:/var/lib/synapse
     deploy:
       resources:
         limits:
@@ -191,7 +191,6 @@ networks:
 volumes:
   pg_data:
   pg_backups:
-  synapse_data:
   livekit_data:
   caddy_data:
   caddy_config:

--- a/deploy/docker/synapse/homeserver.yaml
+++ b/deploy/docker/synapse/homeserver.yaml
@@ -11,9 +11,14 @@ listeners:
     type: http
     x_forwarded: false
 database:
-  name: sqlite3
+  name: psycopg2
   args:
-    database: /data/homeserver.db
+    user: skerry
+    password: __POSTGRES_PASSWORD__
+    database: synapse
+    host: postgres
+    cp_min: 5
+    cp_max: 10
 log_config: "/data/hub-localhost.log.config"
 media_store_path: /data/media_store
 registration_shared_secret: "JcOYCz8LxB_f+,N1e~Y#W^r.CKDb@:udYg3RZkCqc;Nl5Dn&jx"

--- a/deploy/scripts/init.sh
+++ b/deploy/scripts/init.sh
@@ -137,6 +137,12 @@ if [ ! -f "$SYNAPSE_SIGNING_KEY" ]; then
   chmod 644 "$SYNAPSE_SIGNING_KEY"
 fi
 
+# ---------- substitute Synapse PostgreSQL password ----------
+SYNAPSE_HOMESERVER="${SYNAPSE_CONFIG_DIR}/homeserver.yaml"
+if [ -f "$SYNAPSE_HOMESERVER" ]; then
+  sed -i "s/__POSTGRES_PASSWORD__/${POSTGRES_PASSWORD}/g" "$SYNAPSE_HOMESERVER"
+fi
+
 echo "skerry-init: .env.ops is ready"
 if [ "$OPS_EXISTED" = false ]; then
   echo ""

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -10,17 +10,12 @@ services:
       - "5433:5432"
     volumes:
       - pg_data_test:/var/lib/postgresql/data
+      - ./docker/postgres-init:/docker-entrypoint-initdb.d
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
       interval: 5s
       timeout: 5s
       retries: 5
-
-  synapse-init:
-    image: alpine:latest
-    volumes:
-      - synapse_data_test:/var/lib/synapse
-    command: chown -R 991:991 /var/lib/synapse
 
   synapse:
     image: matrixdotorg/synapse:latest
@@ -29,14 +24,11 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-      synapse-init:
-        condition: service_completed_successfully
     environment:
       SYNAPSE_SERVER_NAME: hub-localhost
       SYNAPSE_REPORT_STATS: "no"
     volumes:
-      - ./docker/synapse-test:/data:ro
-      - synapse_data_test:/var/lib/synapse
+      - ./docker/synapse-test:/data
     ports:
       - "8008:8008"
     healthcheck:
@@ -114,4 +106,3 @@ volumes:
   pg_data_test:
   caddy_data_test:
   caddy_config_test:
-  synapse_data_test:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     #   - "127.0.0.1:5432:5432"
     volumes:
       - pg_data:/var/lib/postgresql/data
+      - ./docker/postgres-init:/docker-entrypoint-initdb.d
     deploy:
       resources:
         limits:
@@ -28,7 +29,8 @@ services:
     env_file:
       - .env
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
     environment:
       SYNAPSE_SERVER_NAME: hub-localhost
       SYNAPSE_REPORT_STATS: "no"

--- a/docker/postgres-init/01-create-synapse-db.sh
+++ b/docker/postgres-init/01-create-synapse-db.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Creates the "synapse" database on the postgres container for Synapse.
+# Mounted at /docker-entrypoint-initdb.d/ — runs only when the data dir is empty.
+set -e
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-'EOSQL'
+    CREATE DATABASE synapse
+        WITH LC_COLLATE 'C'
+             LC_CTYPE 'C'
+             TEMPLATE template0;
+EOSQL
+
+echo "synapse database created."

--- a/docker/synapse-test/homeserver.yaml
+++ b/docker/synapse-test/homeserver.yaml
@@ -1,7 +1,7 @@
 # Configuration file for Synapse.
 server_name: "hub-localhost"
 cors_allow_origins: ["*"]
-pid_file: /var/lib/synapse/homeserver.pid
+pid_file: /data/homeserver.pid
 listeners:
   - port: 8008
     resources:
@@ -11,11 +11,16 @@ listeners:
     type: http
     x_forwarded: false
 database:
-  name: sqlite3
+  name: psycopg2
   args:
-    database: /var/lib/synapse/homeserver.db
+    user: postgres
+    password: test_password
+    database: synapse
+    host: postgres
+    cp_min: 5
+    cp_max: 10
 log_config: "/data/hub-localhost.log.config"
-media_store_path: /var/lib/synapse/media_store
+media_store_path: /data/media_store
 registration_shared_secret: "JcOYCz8LxB_f+,N1e~Y#W^r.CKDb@:udYg3RZkCqc;Nl5Dn&jx"
 report_stats: false
 macaroon_secret_key: "l,gRdq;ARsYoaF~dBj9D0&s-BHlHv;m__RnPbhxwr=9VfpaC2D"

--- a/docker/synapse/homeserver.yaml
+++ b/docker/synapse/homeserver.yaml
@@ -11,9 +11,14 @@ listeners:
     type: http
     x_forwarded: false
 database:
-  name: sqlite3
+  name: psycopg2
   args:
-    database: /data/homeserver.db
+    user: postgres
+    password: temporary_battery_horse_staple_password
+    database: synapse
+    host: postgres
+    cp_min: 5
+    cp_max: 10
 log_config: "/data/hub-localhost.log.config"
 media_store_path: /data/media_store
 registration_shared_secret: "JcOYCz8LxB_f+,N1e~Y#W^r.CKDb@:udYg3RZkCqc;Nl5Dn&jx"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "pnpm -r lint",
     "typecheck": "pnpm -r typecheck",
     "test": "pnpm -r test",
-    "test:env:up": "chmod -R 777 docker/synapse-test/media_store && docker compose -f docker-compose-test.yml up -d --build",
+    "test:env:up": "mkdir -p docker/synapse-test/media_store && chmod -R 777 docker/synapse-test/media_store && docker compose -f docker-compose-test.yml up -d --build",
     "test:env:down": "docker compose -f docker-compose-test.yml down",
     "test:e2e": "pnpm --filter @skerry/web test:e2e",
     "test:e2e:reset": "bash scripts/reset-test-env.sh",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "pnpm -r lint",
     "typecheck": "pnpm -r typecheck",
     "test": "pnpm -r test",
-    "test:env:up": "docker compose -f docker-compose-test.yml up -d --build",
+    "test:env:up": "chmod -R 777 docker/synapse-test/media_store && docker compose -f docker-compose-test.yml up -d --build",
     "test:env:down": "docker compose -f docker-compose-test.yml down",
     "test:e2e": "pnpm --filter @skerry/web test:e2e",
     "test:e2e:reset": "bash scripts/reset-test-env.sh",


### PR DESCRIPTION
## Summary

Switches Synapse from SQLite to PostgreSQL, using a separate `synapse` database on the existing postgres:16 container.

## Changes

- **New**: `docker/postgres-init/01-create-synapse-db.sh` — creates `synapse` DB with C collation on first container init
- **3 homeserver.yaml files**: database section rewritten from `sqlite3` to `psycopg2`
- **3 compose files**: postgres mounts init script, synapse depends on postgres with health condition
- **Test compose**: removed `synapse-init` service and `synapse_data_test` volume
- **Deploy compose**: removed `synapse_data` volume, init.sh now substitutes `__POSTGRES_PASSWORD__` in homeserver.yaml

## Testing

- E2E tests pass against postgres-backed Synapse
- `pnpm typecheck` and `pnpm build` clean
- Docker compose config parses for all three compose files
- Synapse auto-creates its schema on first start — no `port_db` needed