### PR TITLE
chore: pin Synapse to v1.152.1, back up synapse DB, remove stale SQLite

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       retries: 5
 
   synapse:
-    image: matrixdotorg/synapse:latest
+    image: matrixdotorg/synapse:v1.152.1
     env_file:
       - .env.ops
     depends_on:

--- a/deploy/scripts/backup.sh
+++ b/deploy/scripts/backup.sh
@@ -4,6 +4,7 @@
 #
 # Environment:
 #   PGHOST / PGUSER / PGPASSWORD / PGDATABASE — passed by compose from .env.ops
+#   SYNAPSE_DATABASE — optional override for synapse DB name (default: synapse)
 #   BACKUP_DIR — optional override (default: /backups)
 #   RETENTION_DAILY — number of daily backups to keep (default: 7)
 #   RETENTION_WEEKLY — number of weekly (Sunday) backups to keep (default: 4)
@@ -13,11 +14,9 @@ set -euo pipefail
 BACKUP_DIR="${BACKUP_DIR:-/backups}"
 RETENTION_DAILY="${RETENTION_DAILY:-7}"
 RETENTION_WEEKLY="${RETENTION_WEEKLY:-4}"
+SYNAPSE_DATABASE="${SYNAPSE_DATABASE:-synapse}"
 TIMESTAMP=$(date +"%Y-%m-%d_%H%M%S")
 DOW=$(date +"%u")               # 1=Mon … 7=Sun
-BASENAME="skerry_${TIMESTAMP}"
-SQL_FILE="${BACKUP_DIR}/${BASENAME}.sql"
-GZ_FILE="${BACKUP_DIR}/${BASENAME}.sql.gz"
 LOG_TAG="[$(date '+%Y-%m-%d %H:%M:%S')] [backup]"
 
 # ── helpers ──────────────────────────────────────────────────────────
@@ -27,59 +26,68 @@ die()  { log "FAILURE: $*"; exit 1; }
 # ── ensure backup directory exists ───────────────────────────────────
 mkdir -p "${BACKUP_DIR}"
 
-# ── dump ─────────────────────────────────────────────────────────────
-log "Starting PostgreSQL dump (db=${PGDATABASE:-?} host=${PGHOST:-?})…"
+# ── dump all databases ──────────────────────────────────────────────
+# Dump both the main app database and the Synapse Matrix database.
+DATABASES=("${PGDATABASE:-skerry}" "${SYNAPSE_DATABASE}")
 
-if pg_dump --no-owner --no-acl > "${SQL_FILE}" 2>/tmp/pg_dump_stderr.log; then
-    :
-else
-    die "pg_dump failed — see /tmp/pg_dump_stderr.log"
-fi
+for DB in "${DATABASES[@]}"; do
+    BASENAME="${DB}_${TIMESTAMP}"
+    SQL_FILE="${BACKUP_DIR}/${BASENAME}.sql"
+    GZ_FILE="${BACKUP_DIR}/${BASENAME}.sql.gz"
 
-# ── compress ─────────────────────────────────────────────────────────
-gzip -f "${SQL_FILE}"
-SIZE=$(du -h "${GZ_FILE}" | cut -f1)
-log "Dump complete: ${GZ_FILE} (${SIZE})"
+    log "Dumping database: ${DB} (host=${PGHOST:-?})…"
 
-# ── retention ────────────────────────────────────────────────────────
-# 1. Daily retention: keep the last N daily backups (any day of week).
-log "Applying daily retention (keep ${RETENTION_DAILY})…"
-mapfile -t DAILY_FILES < <(find "${BACKUP_DIR}" -maxdepth 1 \
-    -name 'skerry_*.sql.gz' -type f | sort -r)
-
-DAILY_COUNT=0
-for f in "${DAILY_FILES[@]}"; do
-    DAILY_COUNT=$((DAILY_COUNT + 1))
-    if [ "${DAILY_COUNT}" -gt "${RETENTION_DAILY}" ]; then
-        log "  Pruning daily: $(basename "${f}")"
-        rm -f "${f}"
+    if PGDATABASE="${DB}" pg_dump --no-owner --no-acl > "${SQL_FILE}" 2>/tmp/pg_dump_stderr.log; then
+        :
+    else
+        die "pg_dump of ${DB} failed — see /tmp/pg_dump_stderr.log"
     fi
+
+    # ── compress ─────────────────────────────────────────────────────
+    gzip -f "${SQL_FILE}"
+    SIZE=$(du -h "${GZ_FILE}" | cut -f1)
+    log "  Dump complete: ${GZ_FILE} (${SIZE})"
 done
 
-# 2. Weekly retention: keep the last N Sunday backups.
-#    A Sunday backup is one whose filename timestamp falls on a Sunday.
-if [ "${RETENTION_WEEKLY}" -gt 0 ]; then
-    log "Applying weekly retention (keep ${RETENTION_WEEKLY} Sundays)…"
-    mapfile -t SUNDAY_FILES < <(find "${BACKUP_DIR}" -maxdepth 1 \
-        -name 'skerry_*.sql.gz' -type f | while read -r f; do
-        # Extract date part: skerry_YYYY-MM-DD_HHMMSS.sql.gz → YYYY-MM-DD
-        bn=$(basename "${f}" .sql.gz)
-        dt=${bn#skerry_}              # YYYY-MM-DD_HHMMSS
-        dt=${dt%_*}                    # YYYY-MM-DD
-        # Check if it's a Sunday (date -d "$dt" +%u → 7)
-        if [ "$(date -d "${dt}" +%u 2>/dev/null || true)" = "7" ]; then
-            echo "${f}"
-        fi
-    done | sort -r)
+# ── retention ────────────────────────────────────────────────────────
+# Apply retention per database prefix: skerry_* and synapse_*
+for PREFIX in "${PGDATABASE:-skerry}" "${SYNAPSE_DATABASE}"; do
+    # 1. Daily retention: keep the last N daily backups (any day of week).
+    log "Applying daily retention for ${PREFIX} (keep ${RETENTION_DAILY})…"
+    mapfile -t DAILY_FILES < <(find "${BACKUP_DIR}" -maxdepth 1 \
+        -name "${PREFIX}_*.sql.gz" -type f | sort -r)
 
-    WEEKLY_COUNT=0
-    for f in "${SUNDAY_FILES[@]}"; do
-        WEEKLY_COUNT=$((WEEKLY_COUNT + 1))
-        if [ "${WEEKLY_COUNT}" -gt "${RETENTION_WEEKLY}" ]; then
-            log "  Pruning weekly (Sunday): $(basename "${f}")"
+    DAILY_COUNT=0
+    for f in "${DAILY_FILES[@]}"; do
+        DAILY_COUNT=$((DAILY_COUNT + 1))
+        if [ "${DAILY_COUNT}" -gt "${RETENTION_DAILY}" ]; then
+            log "  Pruning daily: $(basename "${f}")"
             rm -f "${f}"
         fi
     done
-fi
+
+    # 2. Weekly retention: keep the last N Sunday backups.
+    if [ "${RETENTION_WEEKLY}" -gt 0 ]; then
+        log "Applying weekly retention for ${PREFIX} (keep ${RETENTION_WEEKLY} Sundays)…"
+        mapfile -t SUNDAY_FILES < <(find "${BACKUP_DIR}" -maxdepth 1 \
+            -name "${PREFIX}_*.sql.gz" -type f | while read -r f; do
+            bn=$(basename "${f}" .sql.gz)
+            dt=${bn#${PREFIX}_}           # YYYY-MM-DD_HHMMSS
+            dt=${dt%_*}                    # YYYY-MM-DD
+            if [ "$(date -d "${dt}" +%u 2>/dev/null || true)" = "7" ]; then
+                echo "${f}"
+            fi
+        done | sort -r)
+
+        WEEKLY_COUNT=0
+        for f in "${SUNDAY_FILES[@]}"; do
+            WEEKLY_COUNT=$((WEEKLY_COUNT + 1))
+            if [ "${WEEKLY_COUNT}" -gt "${RETENTION_WEEKLY}" ]; then
+                log "  Pruning weekly (Sunday): $(basename "${f}")"
+                rm -f "${f}"
+            fi
+        done
+    fi
+done
 
 log "Backup completed successfully."

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -18,7 +18,7 @@ services:
       retries: 5
 
   synapse:
-    image: matrixdotorg/synapse:latest
+    image: matrixdotorg/synapse:v1.152.1
     env_file:
       - .env.test
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       retries: 5
 
   synapse:
-    image: matrixdotorg/synapse:latest
+    image: matrixdotorg/synapse:v1.152.1
     env_file:
       - .env
     depends_on:


### PR DESCRIPTION
## Summary

Three pre-launch hardening changes following the SQLite → PostgreSQL migration (PR #175).

## Changes

### 1. Pin Synapse to v1.152.1

All three compose files now use `matrixdotorg/synapse:v1.152.1` instead of `:latest`. Prevents accidental major-version upgrades that could brick the schema on a routine `docker compose pull`.

### 2. Backup synapse database

`deploy/scripts/backup.sh` now dumps both the `skerry` and `synapse` databases. Without this, all Matrix rooms, messages, and user accounts were excluded from nightly backups.

The script was restructured to loop over databases and apply retention rules per-prefix (`skerry_*` and `synapse_*`).

### 3. Remove stale SQLite file

Deleted `docker/synapse/homeserver.db` (2.7 MB) — orphaned by the PostgreSQL migration.

## Testing

- `shellcheck` passes on backup.sh
- Docker compose config parses for all three files