### PR TITLE
fix: use env_file for control-plane, not variable substitution

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -67,9 +67,9 @@ services:
     networks:
       - default
       - backend
+    env_file:
+      - .env.ops
     environment:
-      DATABASE_URL: ${DATABASE_URL}
-      SESSION_SECRET: ${SESSION_SECRET}
       SYNAPSE_AS_REGISTRATION_PATH: /app/docker/synapse/skerry-appservice.yaml
     depends_on:
       postgres:


### PR DESCRIPTION
control-plane was the only service using ${VARIABLE} substitution instead of `env_file: .env.ops`. Required `--env-file` on the docker compose command. Fixed to match web, synapse, postgres, and caddy.