### PR TITLE
fix: remove postgres environment block that overrides env_file values

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -10,10 +10,6 @@ services:
     image: postgres:16
     env_file:
       - .env.ops
-    environment:
-      POSTGRES_USER: ${POSTGRES_USER:-skerry}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-      POSTGRES_DB: ${POSTGRES_DB:-skerry}
     depends_on:
       init:
         condition: service_completed_successfully
@@ -67,7 +63,6 @@ services:
     networks:
       - default
       - backend
-    environment:
       DATABASE_URL: ${DATABASE_URL}
       SESSION_SECRET: ${SESSION_SECRET}
       SYNAPSE_AS_REGISTRATION_PATH: /app/docker/synapse/skerry-appservice.yaml
@@ -152,11 +147,7 @@ services:
     volumes:
       - ./scripts/backup.sh:/usr/local/bin/backup.sh:ro
       - pg_backups:/backups
-    environment:
       PGHOST: postgres
-      PGUSER: ${POSTGRES_USER:-skerry}
-      PGPASSWORD: ${POSTGRES_PASSWORD}
-      PGDATABASE: ${POSTGRES_DB:-skerry}
     env_file:
       - .env.ops
     entrypoint:


### PR DESCRIPTION
postgres had both `env_file: .env.ops` and an `environment:` block. The `environment:` block takes precedence, and its `${POSTGRES_PASSWORD}` resolved to empty from the shell — overriding the real password from `.env.ops`. Postgres refused to start with an empty password.

Removed the block entirely. `env_file: .env.ops` provides all three values (POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_DB).