### PR TITLE
fix: make synapse DB init script idempotent

### DIFF
--- a/docker/postgres-init/01-create-synapse-db.sh
+++ b/docker/postgres-init/01-create-synapse-db.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
 # Creates the "synapse" database on the postgres container for Synapse.
 # Mounted at /docker-entrypoint-initdb.d/ — runs only when the data dir is empty.
+# Idempotent: skips if database already exists (handles partial-init recovery).
 set -e
 
-psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-'EOSQL'
-    CREATE DATABASE synapse
-        WITH LC_COLLATE 'C'
-             LC_CTYPE 'C'
-             TEMPLATE template0;
+if psql -tAc "SELECT 1 FROM pg_database WHERE datname = 'synapse'" --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" | grep -q 1; then
+    echo "synapse database already exists, skipping."
+else
+    psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-'EOSQL'
+        CREATE DATABASE synapse
+            WITH LC_COLLATE 'C'
+                 LC_CTYPE 'C'
+                 TEMPLATE template0;
 EOSQL
-
-echo "synapse database created."
+    echo "synapse database created."
+fi


### PR DESCRIPTION
Checks `pg_database` before creating. Handles the case where postgres initialization partially succeeded (e.g. empty POSTGRES_PASSWORD on first boot) — the `skerry` database exists but `synapse` doesn't, and initdb.d won't re-run on an already-initialized data dir.