### PR TITLE
fix: include postgres-init in release deploy kit

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -79,6 +79,7 @@ jobs:
 
       - name: Package deploy kit
         run: |
+          cp -r docker/postgres-init deploy/docker/
           tar -czf skerry-deploy-${{ github.event.inputs.version }}.tar.gz deploy/
 
       - name: Create GitHub Release


### PR DESCRIPTION
The release tarball only includes `deploy/` but the compose mounts `./docker/postgres-init` which resolves relative to `deploy/docker-compose.yml`, not the repo root. Copy it into the deploy tree before tarballing.