### PR TITLE
fix: release tarball extracts to skerry/ not deploy/

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Package deploy kit
         run: |
-          tar -chzf skerry-deploy-${{ github.event.inputs.version }}.tar.gz deploy/
+          tar -chzf skerry-deploy-${{ github.event.inputs.version }}.tar.gz --transform 's|^deploy/|skerry/|' deploy/
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
Adds `--transform 's|^deploy/|skerry/|'` to the tar command so `tar xzf` produces `~/skerry/` instead of `~/deploy/`.