### PR TITLE
fix: drop CI override, use docker compose exec for smoke health checks

### DIFF
--- a/.github/release/assemble.sh
+++ b/.github/release/assemble.sh
@@ -17,7 +17,6 @@ done < .github/release/manifest
 cp .github/release/.env "$STAGING/"
 cp .github/release/README.md "$STAGING/"
 cp .github/release/docker-compose.yml "$STAGING/"
-cp .github/release/docker-compose.ci.yml "$STAGING/"
 
 echo "Release tarball assembled in $STAGING/"
 ls -laR "$STAGING/"

--- a/.github/release/docker-compose.ci.yml
+++ b/.github/release/docker-compose.ci.yml
@@ -1,5 +1,0 @@
-# CI override for deploy smoke test — remaps Caddy to port 8080
-services:
-  caddy:
-    ports:
-      - "8080:80"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Wait for services healthy
         run: |
           for i in $(seq 1 60); do
-            if curl -fsS http://localhost:8080/health 2>/dev/null; then
+            if docker compose exec caddy wget -qO- http://localhost/health 2>/dev/null; then
               echo "OK: services healthy"; exit 0
             fi
             sleep 5
@@ -103,7 +103,7 @@ jobs:
 
       - name: Verify web UI
         run: |
-          curl -fsS http://localhost:8080/ | grep -q 'Skerry' || { echo "FAIL"; exit 1; }
+          docker compose exec caddy wget -qO- http://localhost/ | grep -q 'Skerry' || { echo "FAIL"; exit 1; }
           echo "OK: web UI serves Skerry"
 
       - name: Tear down


### PR DESCRIPTION
Replaces `curl localhost:8080/health` with `docker compose exec caddy wget http://localhost/health`. No port mapping needed — uses internal Docker network.

- Deletes `.github/release/docker-compose.ci.yml` (only existed for 8080 mapping)
- Removes CI override references from both workflows