### PR TITLE
fix: add caddy depends_on control-plane to eliminate startup race

### DIFF
--- a/.github/release/docker-compose.yml
+++ b/.github/release/docker-compose.yml
@@ -116,6 +116,9 @@ services:
       - caddy_config:/config
     env_file:
       - .env.ops
+    depends_on:
+      control-plane:
+        condition: service_healthy
     deploy:
       resources:
         limits:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -133,6 +133,9 @@ services:
     environment:
       - NEXT_PUBLIC_BASE_DOMAIN=${BASE_DOMAIN:-localhost}
       - EMAIL=${EMAIL}
+    depends_on:
+      control-plane:
+        condition: service_healthy
     deploy:
       resources:
         limits:


### PR DESCRIPTION
caddy started immediately, but `/health` reverse-proxies to `control-plane:4000` which takes 30–120s to become healthy. The smoke test looped 60×5s but caddy never waited for control-plane.

Adds `depends_on: control-plane (service_healthy)` to caddy in both `docker-compose.yml` and `.github/release/docker-compose.yml`. Test compose already had it — that's why PR smoke passed but release smoke didn't.