### PR TITLE
fix: add missing cd skerry to Verify web UI smoke step

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -130,6 +130,7 @@ jobs:
 
       - name: Verify web UI
         run: |
+          cd skerry
           docker compose exec caddy wget -qO- http://localhost/ | grep -q 'Skerry' || { echo "FAIL"; exit 1; }
           echo "OK: web UI serves Skerry"
 


### PR DESCRIPTION
The health check + debug steps have `cd skerry` (merged in #193) but the web UI step was still running `docker compose` from the repo root — can't find `.env`, can't reach services.