### PR TITLE
fix: capture container logs on startup failure, pass SKERRY_VERSION in smoke

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -82,7 +82,7 @@ jobs:
         run: |
           bash .github/release/assemble.sh
           cd skerry
-          ./scripts/start.sh
+          SKERRY_VERSION=${{ github.event.inputs.version }} ./scripts/start.sh
 
       - name: Verify .env.ops
         run: |

--- a/deploy/scripts/start.sh
+++ b/deploy/scripts/start.sh
@@ -183,7 +183,15 @@ echo "Pulling images..."
 docker compose pull 2>&1 | grep -v "^$" || true
 
 echo "Starting services..."
-docker compose up -d
+if ! docker compose up -d; then
+  echo ""
+  echo "ERROR: docker compose up failed. Capturing logs from exited containers..."
+  for svc in $(docker compose ps --status exited -q 2>/dev/null); do
+    echo "=== $svc logs ==="
+    docker compose logs "$svc" 2>&1 | tail -80
+  done
+  exit 1
+fi
 
 echo ""
 echo "Skerry is starting. Check status with: docker compose ps"


### PR DESCRIPTION
start.sh now dumps logs from exited containers when docker compose up fails — makes startup crashes debuggable.

docker-publish.yml smoke test now exports SKERRY_VERSION before running start.sh, so compose matches the versioned images pulled by the Tag step.