### PR TITLE
fix: use docker logs not docker compose logs for exited containers

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -97,10 +97,10 @@ jobs:
           echo "=== docker compose ps ==="
           docker compose ps
           echo ""
-          echo "=== logs (any exited/dead services) ==="
-          for svc in $(docker compose ps --status exited --status dead -q 2>/dev/null); do
-            echo "--- $svc ---"
-            docker compose logs "$svc" 2>&1 | tail -50
+          echo "=== logs (any exited/dead containers) ==="
+          for cid in $(docker compose ps --status exited --status dead -q 2>/dev/null); do
+            echo "--- $cid ---"
+            docker logs "$cid" 2>&1 | tail -50
           done
           echo ""
           echo "=== control-plane logs ==="

--- a/deploy/scripts/start.sh
+++ b/deploy/scripts/start.sh
@@ -186,9 +186,9 @@ echo "Starting services..."
 if ! docker compose up -d; then
   echo ""
   echo "ERROR: docker compose up failed. Capturing logs from exited containers..."
-  for svc in $(docker compose ps --status exited -q 2>/dev/null); do
-    echo "=== $svc logs ==="
-    docker compose logs "$svc" 2>&1 | tail -80
+  for cid in $(docker compose ps --status exited -q 2>/dev/null); do
+    echo "=== $cid logs ==="
+    docker logs "$cid" 2>&1 | tail -80
   done
   exit 1
 fi


### PR DESCRIPTION
docker compose ps -q returns container IDs, not service names. docker compose logs <cid> fails with 'no such service'. Use docker logs <cid> instead.

Fixes both start.sh error handler and CI debug step.