### PR TITLE
fix: category reordering + image-only message send

### DIFF
--- a/apps/control-plane/src/routes/message-routes.ts
+++ b/apps/control-plane/src/routes/message-routes.ts
@@ -134,7 +134,7 @@ export async function registerMessageRoutes(app: FastifyInstance): Promise<void>
     });
     const payload = z
       .object({
-        content: z.string().trim().min(1).max(2000),
+        content: z.string().trim().max(2000).optional().default(""),
         externalTransactionId: z.string().optional(),
         // Legacy: array of plain URLs (content type is inferred from extension)
         mediaUrls: z.array(z.string().url()).max(8).optional(),
@@ -144,6 +144,10 @@ export async function registerMessageRoutes(app: FastifyInstance): Promise<void>
         parentId: z.string().optional(),
         replyToId: z.string().optional()
       })
+      .refine(
+        (data) => data.content.length > 0 || (data.mediaAttachments?.length ?? 0) > 0 || (data.mediaUrls?.length ?? 0) > 0,
+        { message: "Message must have content or attachments" }
+      )
       .parse(request.body);
 
     const timedOut = await isUserTimedOut(request.auth!.productUserId, { channelId: params.channelId });

--- a/apps/control-plane/src/services/chat/channel-service.ts
+++ b/apps/control-plane/src/services/chat/channel-service.ts
@@ -144,11 +144,17 @@ export async function createCategory(input: {
   name: string;
 }): Promise<Category> {
   return withDb(async (db) => {
+    const maxPos = await db.query<{ max_pos: number }>(
+      "select coalesce(max(position), 0) + 1 as max_pos from categories where server_id = $1",
+      [input.serverId]
+    );
+    const nextPosition = maxPos.rows[0]?.max_pos ?? 1;
+
     const row = await db.query<CategoryRow>(
-      `insert into categories(id, server_id, name, matrix_subspace_id)
-       values($1, $2, $3, null)
+      `insert into categories(id, server_id, name, position, matrix_subspace_id)
+       values($1, $2, $3, $4, null)
        returning *`,
-      [`cat_${crypto.randomUUID().replaceAll("-", "")}`, input.serverId, input.name]
+      [`cat_${crypto.randomUUID().replaceAll("-", "")}`, input.serverId, input.name, nextPosition]
     );
 
     const value = row.rows[0];


### PR DESCRIPTION
## fix: assign sequential positions when creating categories

createCategory never set the position column, so all categories defaulted to position=0. Swapping positions via moveCategoryPosition was a no-op since both categories had the same value — the sort fell back to created_at, making reordering silently fail.

Now queries MAX(position) + 1 for the server and inserts the new category with that position.

## fix: allow image-only messages by relaxing content validation

The message POST endpoint required content to be at least 1 character (z.string().trim().min(1)). When sending an image-only message (no text), the frontend sends content='' which failed validation.

Changed content to optional with a default of '' and added a .refine() to ensure at least one of content, mediaAttachments, or mediaUrls is present — preventing truly empty messages while allowing image-only sends.