### PR TITLE
fix: room icon leak between edit sessions + sidebar overflow scroll

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -810,6 +810,22 @@ textarea:focus-visible,
   }
 }
 
+.unified-sidebar {
+  overflow-y: auto;
+  min-height: 0;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+}
+
+.unified-sidebar::-webkit-scrollbar {
+  width: 5px;
+}
+
+.unified-sidebar::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 10px;
+}
+
 .unified-sidebar ul {
   list-style: none;
   margin: 0;

--- a/apps/web/components/sidebar.tsx
+++ b/apps/web/components/sidebar.tsx
@@ -523,7 +523,7 @@ export function Sidebar({
                                                                     aria-label="Edit room"
                                                                     onClick={(e) => {
                                                                         e.stopPropagation();
-                                                                        dispatch({ type: "SET_RENAME_ROOM", payload: { id: channel.id, name: channel.name, type: channel.type, categoryId: channel.categoryId, topic: channel.topic, styleContent: channel.styleContent } });
+                                                                        dispatch({ type: "SET_RENAME_ROOM", payload: { id: channel.id, name: channel.name, type: channel.type, categoryId: channel.categoryId, topic: channel.topic, iconUrl: (channel as any).iconUrl, styleContent: channel.styleContent } });
                                                                         dispatch({ type: "SET_ACTIVE_MODAL", payload: "rename-room" });
                                                                     }}
                                                                 >


### PR DESCRIPTION
## fix: room icon leak between edit sessions

The room settings modal's emoji picker was showing the previous room's icon because the sidebar's SET_RENAME_ROOM dispatch didn't include iconUrl. The reducer kept the stale value since `iconUrl !== undefined` was false for the omitted key.

**Fix:** Added `iconUrl: (channel as any).iconUrl` to the SET_RENAME_ROOM dispatch in sidebar.tsx.

## fix: sidebar doesn't scroll when content overflows

The .chat-shell grid uses `overflow: hidden` but the sidebar panel had no overflow-y: auto. Grid children default to `min-height: auto`, so they expand beyond the row and content overflows invisibly.

**Fix:** Added `overflow-y: auto` + `min-height: 0` to `.unified-sidebar` with thin scrollbar styling.