### PR TITLE
fix: bridge clientId/clientSecret fall back to general Discord vars

### DIFF
--- a/apps/control-plane/src/config.ts
+++ b/apps/control-plane/src/config.ts
@@ -22,8 +22,8 @@ export const config = {
     keycloakIssuer: process.env.OIDC_KEYCLOAK_ISSUER ?? (baseDomain ? `https://keycloak.${baseDomain}/realms/skerry` : "http://keycloak:8080/realms/skerry"),
     keycloakClientId: process.env.OIDC_KEYCLOAK_CLIENT_ID,
     keycloakClientSecret: process.env.OIDC_KEYCLOAK_CLIENT_SECRET,
-    discordClientId: process.env.OIDC_DISCORD_CLIENT_ID,
-    discordClientSecret: process.env.OIDC_DISCORD_CLIENT_SECRET,
+    discordClientId: process.env.OIDC_DISCORD_CLIENT_ID || process.env.DISCORD_CLIENT_ID,
+    discordClientSecret: process.env.OIDC_DISCORD_CLIENT_SECRET || process.env.DISCORD_CLIENT_SECRET,
     discordAuthorizeUrl: "https://discord.com/api/oauth2/authorize",
     discordTokenUrl: "https://discord.com/api/oauth2/token",
     discordUserInfoUrl: "https://discord.com/api/users/@me",
@@ -40,8 +40,8 @@ export const config = {
   },
   discordBridge: {
     mockMode: process.env.DISCORD_BRIDGE_MOCK === "true",
-    clientId: process.env.DISCORD_BRIDGE_CLIENT_ID,
-    clientSecret: process.env.DISCORD_BRIDGE_CLIENT_SECRET,
+    clientId: process.env.DISCORD_BRIDGE_CLIENT_ID || process.env.DISCORD_CLIENT_ID,
+    clientSecret: process.env.DISCORD_BRIDGE_CLIENT_SECRET || process.env.DISCORD_CLIENT_SECRET,
     callbackUrl:
       process.env.DISCORD_BRIDGE_CALLBACK_URL ??
       `${appBaseUrl}/auth/callback/discord`,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,8 @@ services:
     image: livekit/livekit-server:v1.9.11
     env_file:
       - .env
+    environment:
+      - LIVEKIT_KEYS=${LIVEKIT_KEYS}
     command: [ "--dev", "--bind", "0.0.0.0" ]
     # Signaling port 7880 is now internal only
     ports:
@@ -73,16 +75,14 @@ services:
       - DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
       - NEXT_PUBLIC_BASE_DOMAIN=${BASE_DOMAIN:-localhost}
       - SESSION_SECRET=${SESSION_SECRET}
-      - OIDC_DISCORD_CLIENT_ID=${OIDC_DISCORD_CLIENT_ID}
-      - OIDC_DISCORD_CLIENT_SECRET=${OIDC_DISCORD_CLIENT_SECRET}
       - OIDC_GOOGLE_CLIENT_ID=${OIDC_GOOGLE_CLIENT_ID}
       - OIDC_GOOGLE_CLIENT_SECRET=${OIDC_GOOGLE_CLIENT_SECRET}
       - OIDC_TWITCH_CLIENT_ID=${OIDC_TWITCH_CLIENT_ID}
       - OIDC_TWITCH_CLIENT_SECRET=${OIDC_TWITCH_CLIENT_SECRET}
-      - DISCORD_BRIDGE_CLIENT_ID=${DISCORD_BRIDGE_CLIENT_ID}
-      - DISCORD_BRIDGE_CLIENT_SECRET=${DISCORD_BRIDGE_CLIENT_SECRET}
       - DISCORD_BRIDGE_BOT_TOKEN=${DISCORD_BRIDGE_BOT_TOKEN}
       - SYNAPSE_AS_REGISTRATION_PATH=/app/docker/synapse/skerry-appservice.yaml
+      - LIVEKIT_API_KEY=${LIVEKIT_API_KEY}
+      - LIVEKIT_API_SECRET=${LIVEKIT_API_SECRET}
     depends_on:
       - postgres
       - synapse


### PR DESCRIPTION
## Problem

docker-compose's `environment:` block uses `${VAR}` syntax, which resolves from the shell/compose environment. When variables like `OIDC_DISCORD_CLIENT_ID` and `DISCORD_BRIDGE_CLIENT_ID` aren't set in `.env`, they resolve to empty strings. Because `environment:` overrides `env_file:`, this clobbers the auto-generated values in `.env.ops` — breaking both OIDC Discord login AND the Discord bridge.

The same Discord app (client ID + secret) is used for both OIDC login and bridge operations. There's no reason for separate env vars.

## What was broken

- **OIDC Discord login**: `OIDC_DISCORD_CLIENT_ID` was empty at container runtime despite being populated in `.env.ops` — `${OIDC_DISCORD_CLIENT_ID}` resolved to empty and overrode `env_file`
- **Discord bridge (second server)**: `DISCORD_BRIDGE_CLIENT_ID` same issue — force-overridden to empty, causing Discord API to reject with "Value "" is not snowflake"

## Fix

- `config.ts`: Both `oidc.discordClientId`/`discordClientSecret` and `discordBridge.clientId`/`clientSecret` now fall back to `DISCORD_CLIENT_ID`/`DISCORD_CLIENT_SECRET` — the canonical values that ARE in `.env`
- `docker-compose.yml`: Removed `OIDC_DISCORD_CLIENT_ID`, `OIDC_DISCORD_CLIENT_SECRET`, `DISCORD_BRIDGE_CLIENT_ID`, and `DISCORD_BRIDGE_CLIENT_SECRET` from `environment:` — they're already available via `env_file: .env.ops`