### PR TITLE
feat: configurable hub name in topbar via Hub Settings

### DIFF
--- a/apps/control-plane/src/routes/hub-routes.ts
+++ b/apps/control-plane/src/routes/hub-routes.ts
@@ -194,6 +194,7 @@ export async function registerHubRoutes(app: FastifyInstance): Promise<void> {
   app.patch("/v1/hubs/:hubId/settings", initializedAuthHandlers, async (request, reply) => {
     const params = z.object({ hubId: z.string().min(1) }).parse(request.params);
     const payload = z.object({
+      name: z.string().min(1).max(100).optional(),
       theme: z.any().optional(),
       spaceCustomizationLimits: z.any().optional(),
       oidcConfig: z.any().optional(),

--- a/apps/control-plane/src/services/settings-service.ts
+++ b/apps/control-plane/src/services/settings-service.ts
@@ -4,7 +4,7 @@ import type { Hub, Server, Channel } from "@skerry/shared";
 export async function getHubSettings(hubId: string): Promise<Partial<Hub>> {
   return withDb(async (db) => {
     const res = await db.query(
-      `select theme, space_customization_limits, oidc_config, allow_space_discord_bridge,
+      `select name, theme, space_customization_limits, oidc_config, allow_space_discord_bridge,
               default_auto_join_hub_members,
               is_suspended, suspended_at, suspension_expires_at, unlock_code_hash
        from hubs where id = $1`,
@@ -13,6 +13,7 @@ export async function getHubSettings(hubId: string): Promise<Partial<Hub>> {
     const row = res.rows[0];
     if (!row) throw new Error("Hub not found");
     return {
+      name: row.name,
       theme: row.theme,
       spaceCustomizationLimits: row.space_customization_limits,
       oidcConfig: row.oidc_config,
@@ -29,6 +30,7 @@ export async function getHubSettings(hubId: string): Promise<Partial<Hub>> {
 }
 
 export async function updateHubSettings(hubId: string, settings: {
+  name?: string;
   theme?: any;
   spaceCustomizationLimits?: any;
   oidcConfig?: any;
@@ -52,7 +54,8 @@ export async function updateHubSettings(hubId: string, settings: {
         is_suspended = coalesce($7, is_suspended),
         suspended_at = case when $8::text is not null or $11::boolean then $8::timestamptz else suspended_at end,
         suspension_expires_at = case when $9::text is not null or $12::boolean then $9::timestamptz else suspension_expires_at end,
-        unlock_code_hash = case when $10::text is not null or $13::boolean then $10::text else unlock_code_hash end
+        unlock_code_hash = case when $10::text is not null or $13::boolean then $10::text else unlock_code_hash end,
+        name = coalesce($14, name)
       where id = $1`,
       [
         hubId,
@@ -67,7 +70,8 @@ export async function updateHubSettings(hubId: string, settings: {
         settings.suspension?.unlockCodeHash,
         settings.suspension?.suspendedAt === null,
         settings.suspension?.expiresAt === null,
-        settings.suspension?.unlockCodeHash === null
+        settings.suspension?.unlockCodeHash === null,
+        settings.name
       ]
     );
   });

--- a/apps/web/app/settings/hub/page.tsx
+++ b/apps/web/app/settings/hub/page.tsx
@@ -55,6 +55,19 @@ export default function HubSettingsPage() {
 
             <div className="settings-grid" style={{ marginTop: '2rem' }}>
                 <section className="settings-row">
+                    <label htmlFor="hub-name">Hub Name</label>
+                    <input
+                        id="hub-name"
+                        className="filter-input"
+                        type="text"
+                        maxLength={100}
+                        defaultValue={settings.name || ''}
+                        onBlur={(e) => setSettings({ ...settings, name: e.target.value })}
+                    />
+                    <p className="settings-description">Displayed in the top bar and login screens.</p>
+                </section>
+
+                <section className="settings-row">
                     <label>Hub Theme (JSON)</label>
                     <textarea
                         className="filter-input"

--- a/apps/web/components/chat-client.tsx
+++ b/apps/web/components/chat-client.tsx
@@ -750,6 +750,7 @@ export function ChatClient() {
         toggleTheme={toggleTheme}
         handleLogout={handleLogout}
         error={error}
+        hubName={hubs[0]?.name}
       />
 
       {error && <p className="error" role="alert">{error}</p>}

--- a/apps/web/components/layout/ClientTopbar.tsx
+++ b/apps/web/components/layout/ClientTopbar.tsx
@@ -13,6 +13,7 @@ interface ClientTopbarProps {
   toggleTheme: () => void;
   handleLogout: () => Promise<void>;
   error: string | null;
+  hubName?: string;
 }
 
 function formatRole(role?: string): string {
@@ -31,7 +32,8 @@ export function ClientTopbar({
   theme,
   toggleTheme,
   handleLogout,
-  error
+  error,
+  hubName
 }: ClientTopbarProps) {
   const isMasquerading = viewer?.isMasquerading;
   const masqRole = formatRole(viewer?.masqueradeRole);
@@ -42,7 +44,7 @@ export function ClientTopbar({
       <header className="topbar">
         <div className="topbar-branding">
           <img src="/logo.png" alt="Skerry Logo" className="topbar-logo" />
-          <h1>Skerry Local Chat</h1>
+          <h1>{hubName || "Skerry Community Chat"}</h1>
         </div>
         <div className="topbar-meta">
           <button


### PR DESCRIPTION
Replaces the hardcoded "Skerry Local Chat" banner with the hub's name, configurable in Hub Settings.

**Backend:**
- `getHubSettings` returns `name` from the hubs table
- `updateHubSettings` accepts `name` param, writes to `hubs.name`
- `PATCH /v1/hubs/:hubId/settings` validates `name` (1-100 chars)

**Frontend:**
- Hub Settings page: new "Hub Name" text input at the top
- `ClientTopbar`: accepts `hubName` prop, falls back to "Skerry Local Chat"
- `chat-client` passes `hubs[0]?.name`