### PR TITLE
fix: slim Docker images with multi-stage builds (~200MB → ~60MB)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,50 +1,74 @@
-# Base stage for pnpm and shared dependencies
-FROM node:20-slim AS base
+# ── Builder stage: shared across all targets ──
+FROM node:20-slim AS builder
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 RUN npm install -g pnpm@9.12.2
-COPY . /app
 WORKDIR /app
 
-# --- Build stage ---
-FROM base AS build
+# Copy package manifests first (layer caching for installs)
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json tsconfig.base.json ./
+COPY packages/shared/package.json packages/shared/tsconfig.json packages/shared/
+COPY apps/control-plane/package.json apps/control-plane/tsconfig.json apps/control-plane/
+COPY apps/web/package.json apps/web/tsconfig.json apps/web/next.config.js apps/web/
+COPY apps/sticker-renderer/package.json apps/sticker-renderer/tsconfig.json apps/sticker-renderer/
+
+RUN pnpm install --frozen-lockfile
+
+# Copy source
+COPY packages/shared/src packages/shared/src
+COPY apps/control-plane/src apps/control-plane/src
+COPY apps/web/app apps/web/app
+COPY apps/web/components apps/web/components
+COPY apps/web/context apps/web/context
+COPY apps/web/hooks apps/web/hooks
+COPY apps/web/lib apps/web/lib
+COPY apps/web/public apps/web/public
+COPY apps/web/*.ts apps/web/*.tsx apps/web/next-env.d.ts apps/web/
+COPY apps/sticker-renderer/src apps/sticker-renderer/src
+
+# Build everything
 ARG NEXT_PUBLIC_BASE_DOMAIN
-# Create a .env file for the build to ensure Next.js picks it up.
-RUN echo "NEXT_PUBLIC_BASE_DOMAIN=${NEXT_PUBLIC_BASE_DOMAIN:-localhost}" > .env && \
-    pnpm install --frozen-lockfile && \
-    pnpm run build
+RUN echo "NEXT_PUBLIC_BASE_DOMAIN=${NEXT_PUBLIC_BASE_DOMAIN:-localhost}" > apps/web/.env && \
+    echo "NEXT_PUBLIC_BASE_DOMAIN=${NEXT_PUBLIC_BASE_DOMAIN:-localhost}" > .env && \
+    pnpm --filter @skerry/shared build && \
+    pnpm --filter @skerry/control-plane build && \
+    pnpm --filter @skerry/web build
 
-# --- Control Plane Runtime ---
-FROM base AS control-plane
-COPY --from=build /app /app
-EXPOSE 4000
-CMD [ "pnpm", "--filter", "@skerry/control-plane", "start:prod" ]
 
-# --- Web App Runtime ---
-FROM base AS web
-COPY --from=build /app /app
+# ── Web Runtime (~60-80 MB) ──
+FROM node:20-slim AS web
+WORKDIR /app
+COPY --from=builder /app/apps/web/.next/standalone ./
+COPY --from=builder /app/apps/web/.next/static ./apps/web/.next/static
+COPY --from=builder /app/apps/web/public ./apps/web/public
 EXPOSE 3000
-CMD [ "pnpm", "--filter", "@skerry/web", "start:prod" ]
+CMD ["node", "apps/web/server.js"]
 
-# --- Sticker Renderer Runtime ---
+
+# ── Control Plane Runtime (~80-100 MB) ──
+FROM builder AS cp-deploy
+RUN pnpm --filter @skerry/control-plane --prod deploy /app/out
+
+FROM node:20-slim AS control-plane
+COPY --from=cp-deploy /app/out /app
+EXPOSE 4000
+CMD ["node", "apps/control-plane/dist/index.js"]
+
+
+# ── Sticker Renderer Runtime ──
+FROM builder AS sr-deploy
+RUN pnpm --filter @skerry/sticker-renderer --prod deploy /app/out
+
 FROM node:20-bookworm-slim AS sticker-renderer
 RUN apt-get update && apt-get install -y ffmpeg python3 python3-pip python3-venv build-essential cmake python3-dev && rm -rf /var/lib/apt/lists/*
 
-# Use a virtual environment for python
 RUN python3 -m venv /opt/venv
 ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
-
-# Install rlottie-python
 RUN /opt/venv/bin/pip install --upgrade pip wheel setuptools && \
     /opt/venv/bin/pip install "rlottie-python[full]"
 
-RUN npm install -g pnpm@9.12.2
-ENV PNPM_HOME="/pnpm"
-ENV PATH="$PNPM_HOME:$PATH"
-WORKDIR /app
-COPY --from=build /app /app
-RUN pnpm install --filter @skerry/sticker-renderer
+COPY --from=sr-deploy /app/out /app
 EXPOSE 3000
-CMD [ "pnpm", "--filter", "@skerry/sticker-renderer", "start" ]
+CMD ["node", "apps/sticker-renderer/dist/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN pnpm install --frozen-lockfile
 # Copy source
 COPY packages/shared/src packages/shared/src
 COPY apps/control-plane/src apps/control-plane/src
+COPY apps/control-plane/migrations apps/control-plane/migrations
 COPY apps/web/app apps/web/app
 COPY apps/web/components apps/web/components
 COPY apps/web/context apps/web/context

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ COPY --from=builder /app/apps/web/.next/standalone ./
 COPY --from=builder /app/apps/web/.next/static ./apps/web/.next/static
 COPY --from=builder /app/apps/web/public ./apps/web/public
 EXPOSE 3000
-CMD ["node", "server.js"]
+CMD ["node", "apps/web/server.js"]
 
 
 # ── Control Plane Runtime (~80-100 MB) ──

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ FROM builder AS cp-deploy
 RUN pnpm --filter @skerry/control-plane --prod deploy /app/out
 
 FROM node:20-slim AS control-plane
+WORKDIR /app
 COPY --from=cp-deploy /app/out /app
 EXPOSE 4000
 CMD ["node", "dist/index.js"]
@@ -60,6 +61,7 @@ FROM builder AS sr-deploy
 RUN pnpm --filter @skerry/sticker-renderer --prod deploy /app/out
 
 FROM node:20-bookworm-slim AS sticker-renderer
+WORKDIR /app
 RUN apt-get update && apt-get install -y ffmpeg python3 python3-pip python3-venv build-essential cmake python3-dev && rm -rf /var/lib/apt/lists/*
 
 RUN python3 -m venv /opt/venv

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ COPY --from=builder /app/apps/web/.next/standalone ./
 COPY --from=builder /app/apps/web/.next/static ./apps/web/.next/static
 COPY --from=builder /app/apps/web/public ./apps/web/public
 EXPOSE 3000
-CMD ["node", "apps/web/server.js"]
+CMD ["node", "server.js"]
 
 
 # ── Control Plane Runtime (~80-100 MB) ──
@@ -53,8 +53,7 @@ RUN pnpm --filter @skerry/control-plane --prod deploy /app/out
 FROM node:20-slim AS control-plane
 COPY --from=cp-deploy /app/out /app
 EXPOSE 4000
-CMD ["node", "apps/control-plane/dist/index.js"]
-
+CMD ["node", "dist/index.js"]
 
 # ── Sticker Renderer Runtime ──
 FROM builder AS sr-deploy
@@ -71,4 +70,4 @@ RUN /opt/venv/bin/pip install --upgrade pip wheel setuptools && \
 
 COPY --from=sr-deploy /app/out /app
 EXPOSE 3000
-CMD ["node", "apps/sticker-renderer/dist/index.js"]
+CMD ["node", "dist/index.js"]

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: 'standalone',
+};
+
+module.exports = nextConfig;


### PR DESCRIPTION
Each image was ~200 MB because the base stage copied the entire monorepo (759 MB node_modules, 323 MB .next) and every target inherited it.

**Web (201 → ~60 MB)**: Added Next.js `output: 'standalone'` which auto-traces only the production runtime deps. Runtime image copies only `standalone/` + `static/` + `public/`.

**Control-plane (~200 → ~80 MB)**: Uses `pnpm --prod deploy` to create an isolated output with only production deps (including `@skerry/shared` which has value imports like schemas and constants).

**Sticker-renderer**: Same `pnpm deploy` pattern.

Also added `next.config.js` with the standalone output setting.